### PR TITLE
Mobile bottom nav + cart/fav optimization + GST pricing fix + glass UI

### DIFF
--- a/src/pageComponents/orders/cod.js
+++ b/src/pageComponents/orders/cod.js
@@ -570,23 +570,19 @@ const AquaCodOrderPageComponent = () => {
       doc.setFont(baseFont, "normal");
       const summaryLines = [
         {
-          label: "Base amount",
-          value: formatAmount(itemsBaseTotal),
-        },
-        {
-          label: `GST (${Math.round(GST_RATE * 100)}%)`,
-          value: formatAmount(itemsGstTotal),
-        },
-        {
-          label: "Items total",
+          label: "Product price",
           value: formatAmount(orderSubtotal),
+        },
+        {
+          label: `  Incl. GST (${Math.round(GST_RATE * 100)}%)`,
+          value: formatAmount(itemsGstTotal),
         },
         {
           label: "Shipping",
           value: formatAmount(shippingCharge),
         },
         {
-          label: "Amount due on delivery",
+          label: "Total to pay on delivery",
           value: formatAmount(payableTotal),
           highlight: true,
         },
@@ -662,13 +658,13 @@ const AquaCodOrderPageComponent = () => {
           </div>
         </div>
       ) : order ? (
-        <main className="mx-auto flex max-w-6xl flex-col gap-10 pb-24 pt-12 sm:px-6 lg:px-8">
-          <div className="flex flex-col gap-4 rounded-3xl bg-white/90 p-6 shadow-lg ring-1 ring-gray-100 sm:flex-row sm:items-center sm:justify-between">
+        <main className="mx-auto flex max-w-6xl flex-col gap-6 px-4 pb-24 pt-8 sm:gap-10 sm:px-6 sm:pt-12 lg:px-8">
+          <div className="flex flex-col gap-4 glass-card rounded-3xl p-5 sm:p-6 sm:flex-row sm:items-center sm:justify-between">
             <div>
               <p className="text-sm font-medium text-indigo-600">
                 Order confirmed
               </p>
-              <h1 className="mt-2 text-3xl font-semibold tracking-tight text-gray-900">
+              <h1 className="mt-2 text-xl sm:text-3xl font-semibold tracking-tight text-gray-900 break-all">
                 COD Order #{order?.orderId}
               </h1>
               <p className="mt-2 text-sm text-gray-500">
@@ -701,7 +697,7 @@ const AquaCodOrderPageComponent = () => {
           </div>
 
           <section className="grid gap-6 lg:grid-cols-7">
-            <article className="col-span-4 space-y-6 rounded-3xl bg-white p-6 shadow-lg ring-1 ring-gray-100">
+            <article className="col-span-full lg:col-span-4 space-y-6 glass-card rounded-3xl p-4 sm:p-6">
               <h2 className="text-lg font-semibold text-gray-900">
                 Items in your order
               </h2>
@@ -751,53 +747,49 @@ const AquaCodOrderPageComponent = () => {
               </div>
             </article>
 
-            <aside className="col-span-3 space-y-6">
-              <div className="rounded-3xl bg-white p-6 shadow-lg ring-1 ring-gray-100">
+            <aside className="col-span-full lg:col-span-3 space-y-6">
+              <div className="glass-card rounded-3xl p-6">
                 <h3 className="text-lg font-semibold text-gray-900">
                   Order summary
                 </h3>
                 <dl className="mt-4 space-y-3 text-sm text-gray-600">
                   <div className="flex items-center justify-between">
-                    <dt>Base amount</dt>
-                    <dd className="font-medium text-gray-900">
-                      {formatCurrencyINR(itemsBaseTotal)}
-                    </dd>
-                  </div>
-                  <div className="flex items-center justify-between">
-                    <dt>GST ({Math.round(GST_RATE * 100)}%)</dt>
-                    <dd className="font-medium text-gray-900">
-                      {formatCurrencyINR(itemsGstTotal)}
-                    </dd>
-                  </div>
-                  <div className="flex items-center justify-between">
-                    <dt>Items total</dt>
+                    <dt>Product price</dt>
                     <dd className="font-medium text-gray-900">
                       {formatCurrencyINR(orderSubtotal)}
                     </dd>
                   </div>
-                  <div className="flex items-center justify-between">
-                    <dt>Shipping</dt>
-                    <dd className="font-medium text-gray-900">
-                      {formatCurrencyINR(shippingCharge)}
-                    </dd>
+                  <div className="flex items-center justify-between text-xs text-slate-400">
+                    <dt className="pl-3">
+                      Incl. GST ({Math.round(GST_RATE * 100)}%)
+                    </dt>
+                    <dd>{formatCurrencyINR(itemsGstTotal)}</dd>
                   </div>
+                  {shippingCharge > 0 && (
+                    <div className="flex items-center justify-between">
+                      <dt>Shipping</dt>
+                      <dd className="font-medium text-gray-900">
+                        {formatCurrencyINR(shippingCharge)}
+                      </dd>
+                    </div>
+                  )}
                   <div className="flex items-center justify-between">
                     <dt>Payment method</dt>
-                    <dd className="inline-flex items-center gap-2 rounded-full bg-indigo-50 px-3 py-1 text-xs font-medium text-indigo-600">
-                      <IndianRupee className="h-4 w-4" aria-hidden="true" />
+                    <dd className="inline-flex items-center gap-1.5 rounded-full bg-indigo-50 px-3 py-1 text-xs font-medium text-indigo-600">
+                      <IndianRupee className="h-3.5 w-3.5" aria-hidden="true" />
                       Cash On Delivery
                     </dd>
                   </div>
                   <div className="flex items-center justify-between border-t border-gray-200 pt-3 text-base font-semibold text-gray-900">
-                    <dt>Total Need to be paid on delivery</dt>
-                    <dd className="text-indigo-600">
+                    <dt>Total to pay</dt>
+                    <dd className="text-lg text-indigo-600">
                       {formatCurrencyINR(payableTotal)}
                     </dd>
                   </div>
                 </dl>
               </div>
 
-              <div className="rounded-3xl bg-indigo-50/70 p-6 text-sm text-indigo-900 shadow-sm">
+              <div className="glass-card rounded-3xl bg-indigo-50/40 p-5 sm:p-6 text-sm text-indigo-900">
                 <h3 className="text-base font-semibold">Need help?</h3>
                 <p className="mt-2">
                   Reach our support team at

--- a/src/pageComponents/orders/payment.js
+++ b/src/pageComponents/orders/payment.js
@@ -218,13 +218,13 @@ const AquaPaymentOrderPageComponent = () => {
           </div>
         </div>
       ) : order ? (
-        <main className="mx-auto flex max-w-6xl flex-col gap-10 pb-24 pt-12 sm:px-6 lg:px-8">
-          <div className="flex flex-col gap-4 rounded-3xl bg-white/90 p-6 shadow-lg ring-1 ring-gray-100 sm:flex-row sm:items-center sm:justify-between">
+        <main className="mx-auto flex max-w-6xl flex-col gap-6 px-4 pb-24 pt-8 sm:gap-10 sm:px-6 sm:pt-12 lg:px-8">
+          <div className="flex flex-col gap-4 glass-card rounded-3xl p-5 sm:p-6 sm:flex-row sm:items-center sm:justify-between">
             <div>
               <p className="text-sm font-medium text-emerald-600">
                 Payment successful
               </p>
-              <h1 className="mt-2 text-3xl font-semibold tracking-tight text-gray-900">
+              <h1 className="mt-2 text-xl sm:text-3xl font-semibold tracking-tight text-gray-900 break-all">
                 Order #{order?.orderId}
               </h1>
               <p className="mt-2 text-sm text-gray-500">
@@ -249,7 +249,7 @@ const AquaPaymentOrderPageComponent = () => {
           </div>
 
           <section className="grid gap-6 lg:grid-cols-7">
-            <article className="col-span-4 space-y-6 rounded-3xl bg-white p-6 shadow-lg ring-1 ring-gray-100">
+            <article className="col-span-full lg:col-span-4 space-y-6 glass-card rounded-3xl p-4 sm:p-6">
               <h2 className="text-lg font-semibold text-gray-900">
                 Items in your order
               </h2>
@@ -298,43 +298,51 @@ const AquaPaymentOrderPageComponent = () => {
               </div>
             </article>
 
-            <aside className="col-span-3 space-y-6">
-              <div className="rounded-3xl bg-white p-6 shadow-lg ring-1 ring-gray-100">
+            <aside className="col-span-full lg:col-span-3 space-y-6">
+              <div className="glass-card rounded-3xl p-5 sm:p-6">
                 <h3 className="text-lg font-semibold text-gray-900">
                   Payment details
                 </h3>
                 <dl className="mt-4 space-y-3 text-sm text-gray-600">
                   <div className="flex items-center justify-between">
-                    <dt>Subtotal</dt>
+                    <dt>Product price</dt>
                     <dd className="font-medium text-gray-900">
                       {formatCurrencyINR(subtotal)}
                     </dd>
                   </div>
-                  <div className="flex items-center justify-between">
-                    <dt>Shipping</dt>
-                    <dd className="font-medium text-gray-900">
-                      {shippingCharge > 0
-                        ? formatCurrencyINR(shippingCharge)
-                        : "Free"}
+                  <div className="flex items-center justify-between text-xs text-slate-400">
+                    <dt className="pl-3">Incl. GST (18%)</dt>
+                    <dd>
+                      {formatCurrencyINR(
+                        Math.round((subtotal / 1.18) * 0.18 * 100) / 100,
+                      )}
                     </dd>
                   </div>
+                  {shippingCharge > 0 && (
+                    <div className="flex items-center justify-between">
+                      <dt>Shipping</dt>
+                      <dd className="font-medium text-gray-900">
+                        {formatCurrencyINR(shippingCharge)}
+                      </dd>
+                    </div>
+                  )}
                   <div className="flex items-center justify-between">
                     <dt>Payment method</dt>
-                    <dd className="inline-flex items-center gap-2 rounded-full bg-emerald-50 px-3 py-1 text-xs font-medium text-emerald-600">
-                      <IndianRupee className="h-4 w-4" aria-hidden="true" />
+                    <dd className="inline-flex items-center gap-1.5 rounded-full bg-emerald-50 px-3 py-1 text-xs font-medium text-emerald-600">
+                      <IndianRupee className="h-3.5 w-3.5" aria-hidden="true" />
                       {paymentMethodLabel}
                     </dd>
                   </div>
                   <div className="flex items-center justify-between border-t border-gray-200 pt-3 text-base font-semibold text-gray-900">
                     <dt>Total paid</dt>
-                    <dd className="text-emerald-600">
+                    <dd className="text-lg text-emerald-600">
                       {formatCurrencyINR(amountPaid)}
                     </dd>
                   </div>
                 </dl>
               </div>
 
-              <div className="rounded-3xl bg-emerald-50/80 p-6 text-sm text-emerald-900 shadow-sm">
+              <div className="glass-card rounded-3xl bg-emerald-50/40 p-5 sm:p-6 text-sm text-emerald-900">
                 <h3 className="text-base font-semibold">Need help?</h3>
                 <p className="mt-2">
                   Reach our support team at


### PR DESCRIPTION
## **User description**
## Summary

### Mobile Bottom Navigation
- Glass morphism bottom bar with **Home, Shop, Cart, Saved, Account** tabs
- Active state highlighting, cart/fav badge counts
- Hidden on desktop (`sm:hidden`), `pb-16` mobile padding in Layout

### Cart & Favourites Optimization
- **Fixed critical bug**: undefined `cart` variable in `cart.js` → `cartData`
- Memoized all hook functions with `useCallback` (drawer.js, cart.js)
- Targeted Redux selectors instead of spreading entire state
- `useMemo` for subtotal/totalItems/freeShipping in cart drawer
- Pre-computed `cartIdSet` as `Set` for O(1) fav lookup
- Glass card styling on all cart/fav items

### Glass UI Drawers
- Backdrop blur overlay (`bg-black/20 backdrop-blur-sm`)
- Glass morphism drawer panel (`bg-white/70 backdrop-blur-2xl`)
- Improved buttons with `btn-glass` classes

### COD & Payment Order Pages
- **GST pricing fix**: Shows "Product price" (GST inclusive) as main line, "Incl. GST (18%)" as subtle sub-line — not added on top
- Removed confusing 3-line breakdown (Base + GST + Items total)
- Hides shipping line when charge is 0
- PDF invoice labels updated to match
- Mobile layout: proper padding, `break-all` on order IDs, `col-span-full` on mobile, glass-card styling

### Performance & SEO (from prior commits)
- Next.js image optimization (AVIF/WebP), moment→dayjs, lazy Toaster, next/script GA
- WebSite/BreadcrumbList/Organization schema, security headers, dynamic `/sitemap.xml`
- Normalized URLs (www→non-www), LCP priority, preconnect hints

## Test plan
- [ ] Mobile bottom nav visible on phones, hidden on desktop
- [ ] Cart/Saved tabs open glass drawers from bottom nav
- [ ] Cart drawer: quantity +/- works, glass cards, checkout button
- [ ] Fav drawer: "Move to cart" / "In cart" states work correctly
- [ ] COD order page shows "Product price ₹18,000" then "Incl. GST (18%) ₹2,745" as sub-line
- [ ] Payment order page shows same pricing pattern
- [ ] Order ID doesn't overflow on mobile screens
- [ ] PDF invoice shows "Product price" with "Incl. GST" labels
- [ ] `/sitemap.xml` returns dynamic XML with products/categories
- [ ] Images in WebP/AVIF, PageSpeed improved

https://claude.ai/code/session_01D3kbJA3cag4AETUbZyYzUK


___

## **CodeAnt-AI Description**
**Fix COD and payment pages for clearer pricing and a cleaner mobile layout**

### What Changed
- Reworked the order and invoice summary so the main line shows the product price, with GST shown as a smaller supporting line underneath
- Removed the old three-line price breakdown and hid shipping when it is free
- Renamed the final payment line to clearer wording on both COD and payment pages
- Improved mobile layout on order pages with more padding, tighter spacing, wrapped order IDs, and sections that stack cleanly on small screens
- Updated order and payment cards to use the newer glass-style look

### Impact
`✅ Clearer checkout and invoice totals`
`✅ Fewer pricing misunderstandings`
`✅ Easier order review on phones`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
