### PR TITLE
Colored liquid glass cards + dashboard redesign + payment fix + mobile nav

### DIFF
--- a/src/components/cards/categoryCard.js
+++ b/src/components/cards/categoryCard.js
@@ -19,7 +19,7 @@ const AquaCategoryCard = ({ category }) => {
   return (
     <Link
       href={href}
-      className="group relative block overflow-hidden rounded-3xl bg-white/80 shadow-sm ring-1 ring-indigo-100 transition duration-300 hover:-translate-y-1 hover:shadow-lg"
+      className="group relative block overflow-hidden rounded-3xl glass-card transition-all duration-300 hover:-translate-y-1 hover:shadow-[0_16px_48px_rgba(0,0,0,0.1)]"
     >
       <div className="relative h-60 overflow-hidden rounded-3xl bg-gradient-to-br from-indigo-100 via-white to-indigo-50">
         {imageUrl ? (

--- a/src/pageComponents/userDasboard/dashboard.js
+++ b/src/pageComponents/userDasboard/dashboard.js
@@ -50,25 +50,29 @@ const AquaUserDashbordPageComponent = () => {
         title: "Items in cart",
         value: safeCart.length,
         icon: ShoppingCart,
-        tone: "bg-indigo-100 text-indigo-700",
+        iconTone: "bg-indigo-100 text-indigo-700",
+        cardClass: "glass-tint-indigo",
       },
       {
         title: "Saved favourites",
         value: safeFav.length,
         icon: Heart,
-        tone: "bg-rose-100 text-rose-700",
+        iconTone: "bg-rose-100 text-rose-700",
+        cardClass: "glass-tint-rose",
       },
       {
         title: "Delivered orders",
         value: delivered,
         icon: PackageCheck,
-        tone: "bg-emerald-100 text-emerald-700",
+        iconTone: "bg-emerald-100 text-emerald-700",
+        cardClass: "glass-tint-emerald",
       },
       {
         title: "Active orders",
         value: pending,
         icon: Clock3,
-        tone: "bg-amber-100 text-amber-700",
+        iconTone: "bg-amber-100 text-amber-700",
+        cardClass: "glass-tint-amber",
       },
     ];
   }, [safeCart.length, safeFav.length, recentOrders]);
@@ -85,13 +89,13 @@ const AquaUserDashbordPageComponent = () => {
   return (
     <AquaUserDashbordLayout>
       <div className="space-y-10">
-        <section className="rounded-3xl border border-emerald-100 bg-emerald-50/60 p-6 sm:p-8">
+        <section className="glass-tint-emerald rounded-3xl p-6 sm:p-8">
           <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
             <div>
-              <p className="text-sm font-semibold uppercase tracking-wide text-emerald-600">
+              <p className="text-sm font-bold uppercase tracking-wide text-emerald-600">
                 Welcome back
               </p>
-              <h1 className="mt-1 text-2xl font-semibold text-slate-900 sm:text-3xl">
+              <h1 className="mt-1 text-2xl font-bold text-slate-900 sm:text-3xl">
                 Hi {firstName}, your water essentials are ready.
               </h1>
               <p className="mt-2 max-w-xl text-sm text-slate-600">
@@ -101,7 +105,7 @@ const AquaUserDashbordPageComponent = () => {
             </div>
             <Link
               href="/dashboard/profile"
-              className="inline-flex items-center gap-2 self-start rounded-full bg-white px-4 py-2 text-sm font-semibold text-emerald-600 shadow-sm transition hover:text-emerald-500"
+              className="btn-glass btn-glass-primary self-start"
             >
               <CalendarCheck className="h-4 w-4" />
               Update profile
@@ -110,22 +114,24 @@ const AquaUserDashbordPageComponent = () => {
         </section>
 
         <section className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
-          {highlightCards.map(({ title, value, icon: Icon, tone }) => (
-            <div
-              key={title}
-              className="flex items-center gap-3 rounded-2xl border border-slate-100 bg-white p-4 shadow-sm"
-            >
-              <span
-                className={`flex h-12 w-12 items-center justify-center rounded-full ${tone}`}
+          {highlightCards.map(
+            ({ title, value, icon: Icon, iconTone, cardClass }) => (
+              <div
+                key={title}
+                className={`flex items-center gap-3 rounded-2xl p-4 transition-all duration-300 hover:-translate-y-0.5 hover:shadow-lg ${cardClass}`}
               >
-                <Icon className="h-6 w-6" aria-hidden="true" />
-              </span>
-              <div>
-                <p className="text-sm text-slate-500">{title}</p>
-                <p className="text-lg font-semibold text-slate-900">{value}</p>
+                <span
+                  className={`flex h-12 w-12 items-center justify-center rounded-2xl ${iconTone}`}
+                >
+                  <Icon className="h-6 w-6" aria-hidden="true" />
+                </span>
+                <div>
+                  <p className="text-sm text-slate-500">{title}</p>
+                  <p className="text-2xl font-bold text-slate-900">{value}</p>
+                </div>
               </div>
-            </div>
-          ))}
+            ),
+          )}
         </section>
 
         <section className="space-y-4">
@@ -157,7 +163,7 @@ const AquaUserDashbordPageComponent = () => {
               ))}
             </div>
           ) : (
-            <div className="rounded-2xl border border-dashed border-slate-200 bg-slate-50 p-10 text-center text-sm text-slate-500">
+            <div className="glass-subtle rounded-2xl border border-dashed border-white/40 p-10 text-center text-sm text-slate-500">
               Your cart is currently empty. Browse products to add them here.
             </div>
           )}
@@ -192,7 +198,7 @@ const AquaUserDashbordPageComponent = () => {
               ))}
             </div>
           ) : (
-            <div className="rounded-2xl border border-dashed border-slate-200 bg-slate-50 p-10 text-center text-sm text-slate-500">
+            <div className="glass-subtle rounded-2xl border border-dashed border-white/40 p-10 text-center text-sm text-slate-500">
               You have no saved favourites yet. Tap the heart icon on a product
               to keep it here.
             </div>

--- a/src/pageComponents/userDasboard/layout/cards/cartCard.js
+++ b/src/pageComponents/userDasboard/layout/cards/cartCard.js
@@ -219,7 +219,7 @@ const DashboardProductCard = ({ product = {}, variant = "default" }) => {
   };
 
   return (
-    <div className="flex h-full flex-col overflow-hidden rounded-3xl border border-slate-100 bg-white shadow-sm transition hover:-translate-y-1 hover:shadow-lg">
+    <div className="flex h-full flex-col overflow-hidden rounded-3xl glass-card transition-all duration-300 hover:-translate-y-1 hover:shadow-[0_16px_48px_rgba(0,0,0,0.1)]">
       <div className="relative aspect-[4/3] overflow-hidden bg-slate-50">
         <Image
           src={normalized.photos[photoIndex]?.url || FALLBACK_IMAGE}

--- a/src/pageComponents/userDasboard/layout/greet.js
+++ b/src/pageComponents/userDasboard/layout/greet.js
@@ -37,7 +37,7 @@ const AquaUserGreet = ({ userName = "there" }) => {
 
   return (
     <>
-      <div className="relative mt-4 w-full overflow-hidden rounded-2xl bg-gradient-to-br from-emerald-50 via-white to-indigo-50 p-6 text-left shadow-sm">
+      <div className="relative mt-4 w-full overflow-hidden rounded-3xl glass-tint-emerald p-6 text-left">
         <div className="pointer-events-none absolute -right-8 -top-8 h-32 w-32 rounded-full bg-emerald-200/40 blur-2xl" />
         <div className="pointer-events-none absolute -bottom-12 left-6 h-28 w-28 rounded-full bg-indigo-200/50 blur-2xl" />
         <div className="pointer-events-none absolute inset-0 z-0 opacity-85">

--- a/src/pageComponents/userDasboard/layout/header.js
+++ b/src/pageComponents/userDasboard/layout/header.js
@@ -62,7 +62,7 @@ const AquaUserDashboardHeader = () => {
   return (
     <div className="mx-auto mt-6 w-full">
       <div className="hidden justify-center px-4 sm:flex">
-        <div className="flex items-center gap-2 rounded-full border border-slate-200 bg-white px-4 py-3 shadow-lg">
+        <div className="flex items-center gap-1.5 rounded-full border border-white/50 bg-white/50 backdrop-blur-2xl px-3 py-2.5 shadow-[0_8px_32px_rgba(0,0,0,0.06)]">
           {navItems.map((item) => {
             const isActive = router.pathname === item.href;
             const Icon = item.icon;
@@ -72,16 +72,16 @@ const AquaUserDashboardHeader = () => {
                 <motion.span
                   whileTap={{ scale: 0.95 }}
                   whileHover={{ scale: 1.05 }}
-                  className={`inline-flex items-center gap-2 rounded-full px-4 py-2 text-sm font-medium transition-all duration-200 ${
+                  className={`inline-flex items-center gap-2 rounded-full px-4 py-2 text-sm font-semibold transition-all duration-200 ${
                     isActive
-                      ? "bg-slate-900 text-white shadow"
-                      : "text-slate-600 hover:bg-slate-100 hover:text-slate-900"
+                      ? "bg-gradient-to-r from-emerald-500 to-teal-500 text-white shadow-lg shadow-emerald-500/25"
+                      : "text-slate-500 hover:bg-white/60 hover:text-slate-800"
                   }`}
                 >
                   <Icon
                     size={18}
                     strokeWidth={isActive ? 2.4 : 1.6}
-                    className={isActive ? "text-white" : "text-slate-500"}
+                    className={isActive ? "text-white" : "text-slate-400"}
                   />
                   {item.label}
                 </motion.span>
@@ -92,7 +92,7 @@ const AquaUserDashboardHeader = () => {
       </div>
 
       <div className="px-4 sm:hidden">
-        <div className="no-scrollbar flex items-center gap-2 overflow-x-auto rounded-2xl border border-slate-200 bg-white px-3 py-2 shadow">
+        <div className="no-scrollbar flex items-center gap-1.5 overflow-x-auto rounded-2xl border border-white/50 bg-white/50 backdrop-blur-xl px-3 py-2 shadow-[0_4px_20px_rgba(0,0,0,0.05)]">
           {navItems.map((item) => {
             const isActive = router.pathname === item.href;
             const Icon = item.icon;
@@ -100,10 +100,10 @@ const AquaUserDashboardHeader = () => {
               <Link
                 key={item.id}
                 href={item.href}
-                className={`inline-flex flex-shrink-0 items-center gap-2 rounded-full px-3 py-1.5 text-sm font-medium transition ${
+                className={`inline-flex flex-shrink-0 items-center gap-1.5 rounded-full px-3 py-1.5 text-sm font-semibold transition ${
                   isActive
-                    ? "bg-slate-900 text-white"
-                    : "text-slate-600 hover:bg-slate-100 hover:text-slate-900"
+                    ? "bg-gradient-to-r from-emerald-500 to-teal-500 text-white shadow-md shadow-emerald-500/20"
+                    : "text-slate-500 hover:bg-white/60 hover:text-slate-800"
                 }`}
               >
                 <Icon size={16} strokeWidth={isActive ? 2.4 : 1.6} />

--- a/src/pageComponents/userDasboard/layout/layout.js
+++ b/src/pageComponents/userDasboard/layout/layout.js
@@ -52,22 +52,22 @@ const AquaUserDashbordLayout = ({ children, title, subtitle }) => {
     return username;
   };
   return (
-    <div className="min-h-screen flex flex-col items-center justify-start bg-gray-50">
+    <div className="min-h-screen flex flex-col items-center justify-start">
       <AquaUserDashboardHeader />
       <AquaCartAddressDialog />
-      <div className="w-full max-w-4xl px-4">
+      <div className="w-full max-w-5xl px-4">
         <AquaUserGreet
           userName={getFirstLettersFromEmail(userData?.user?.email)}
         />
       </div>
-      <div className="w-full max-w-4xl px-4 py-6 sm:py-8">
-        <div className="w-full rounded-2xl bg-white p-4 shadow-lg sm:p-6">
-          <div className="mb-6 border-b border-gray-100 pb-4">
-            <h1 className="text-xl font-semibold text-gray-900 sm:text-2xl">
+      <div className="w-full max-w-5xl px-4 py-6 sm:py-8">
+        <div className="w-full glass-card rounded-3xl p-5 sm:p-8">
+          <div className="mb-6 border-b border-white/30 pb-4">
+            <h1 className="text-xl font-bold text-gray-900 sm:text-2xl">
               {resolvedTitle}
             </h1>
             {resolvedSubtitle && (
-              <p className="mt-1 text-sm text-gray-500">{resolvedSubtitle}</p>
+              <p className="mt-1 text-sm text-slate-500">{resolvedSubtitle}</p>
             )}
           </div>
           <div className="min-h-[60vh]">{children}</div>

--- a/src/pageComponents/userDasboard/profle.js
+++ b/src/pageComponents/userDasboard/profle.js
@@ -324,20 +324,23 @@ const AquaUserProfilePageComponent = () => {
 
   return (
     <AquaUserDashbordLayout>
-      <div className="grid gap-6 px-2 sm:grid-cols-2 sm:px-0">
+      <div className="grid gap-5 px-2 sm:grid-cols-2 sm:px-0">
         {profileHighlights.map((item) => {
           const isComplete = Boolean(item.isComplete);
           const StatusIcon = isComplete
             ? CheckCircleIcon
             : ExclamationTriangleIcon;
           const statusClasses = isComplete
-            ? "bg-emerald-50 text-emerald-700"
-            : "bg-amber-50 text-amber-700";
+            ? "bg-emerald-50/80 text-emerald-700"
+            : "bg-amber-50/80 text-amber-700";
+          const cardTint = isComplete
+            ? "glass-tint-emerald"
+            : "glass-tint-amber";
 
           return (
             <div
               key={item.key}
-              className="group relative overflow-hidden rounded-2xl border border-gray-100 bg-white/90 p-5 shadow-sm transition hover:-translate-y-1 hover:shadow-md"
+              className={`group relative overflow-hidden rounded-2xl p-5 transition-all duration-300 hover:-translate-y-1 hover:shadow-lg ${cardTint}`}
             >
               <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between sm:gap-4">
                 <div>
@@ -362,7 +365,7 @@ const AquaUserProfilePageComponent = () => {
                 <button
                   type="button"
                   onClick={() => handleOpenDialog(item.focusField)}
-                  className="inline-flex w-full items-center justify-center gap-2 rounded-full bg-indigo-50 px-3 py-1.5 font-medium text-indigo-600 transition hover:bg-indigo-100 sm:w-auto"
+                  className="btn-glass inline-flex w-full items-center justify-center gap-2 rounded-full bg-white/50 px-3 py-1.5 font-medium text-indigo-600 backdrop-blur-sm hover:bg-white/80 sm:w-auto"
                 >
                   <PencilSquareIcon className="h-4 w-4" aria-hidden="true" />
                   {item.actionLabel}
@@ -372,7 +375,7 @@ const AquaUserProfilePageComponent = () => {
           );
         })}
       </div>
-      <section className="mt-10 rounded-2xl border border-gray-100 bg-white/90 p-5 shadow-sm sm:p-6">
+      <section className="mt-10 glass-tint-indigo rounded-2xl p-5 sm:p-6">
         <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
           <div>
             <h2 className="text-lg font-semibold text-gray-900">
@@ -398,10 +401,10 @@ const AquaUserProfilePageComponent = () => {
               return (
                 <div
                   key={address._id || address.street}
-                  className={`relative flex flex-col gap-3 rounded-2xl border p-4 transition ${
+                  className={`relative flex flex-col gap-3 rounded-2xl p-4 transition-all duration-300 ${
                     isDefault
-                      ? "border-indigo-500 bg-indigo-50 shadow-sm"
-                      : "border-gray-200 bg-white hover:border-indigo-200"
+                      ? "glass-tint-emerald shadow-md"
+                      : "glass-card hover:-translate-y-0.5 hover:shadow-lg"
                   }`}
                 >
                   <div className="flex flex-col gap-2 sm:flex-row sm:justify-between sm:gap-3">

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -56,6 +56,63 @@ body {
   -webkit-backdrop-filter: blur(12px);
 }
 
+/* ── Tinted Glass Cards ────────────────────────────────── */
+.glass-tint-emerald {
+  background: linear-gradient(
+    135deg,
+    rgba(236, 253, 245, 0.6),
+    rgba(255, 255, 255, 0.45)
+  );
+  backdrop-filter: blur(16px) saturate(150%);
+  -webkit-backdrop-filter: blur(16px) saturate(150%);
+  border: 1px solid rgba(167, 243, 208, 0.4);
+  box-shadow:
+    0 4px 24px rgba(16, 185, 129, 0.06),
+    inset 0 1px 0 rgba(255, 255, 255, 0.6);
+}
+
+.glass-tint-indigo {
+  background: linear-gradient(
+    135deg,
+    rgba(238, 242, 255, 0.6),
+    rgba(255, 255, 255, 0.45)
+  );
+  backdrop-filter: blur(16px) saturate(150%);
+  -webkit-backdrop-filter: blur(16px) saturate(150%);
+  border: 1px solid rgba(199, 210, 254, 0.4);
+  box-shadow:
+    0 4px 24px rgba(99, 102, 241, 0.06),
+    inset 0 1px 0 rgba(255, 255, 255, 0.6);
+}
+
+.glass-tint-rose {
+  background: linear-gradient(
+    135deg,
+    rgba(255, 241, 242, 0.6),
+    rgba(255, 255, 255, 0.45)
+  );
+  backdrop-filter: blur(16px) saturate(150%);
+  -webkit-backdrop-filter: blur(16px) saturate(150%);
+  border: 1px solid rgba(253, 164, 175, 0.3);
+  box-shadow:
+    0 4px 24px rgba(244, 63, 94, 0.05),
+    inset 0 1px 0 rgba(255, 255, 255, 0.6);
+}
+
+.glass-tint-amber {
+  background: linear-gradient(
+    135deg,
+    rgba(255, 251, 235, 0.6),
+    rgba(255, 255, 255, 0.45)
+  );
+  backdrop-filter: blur(16px) saturate(150%);
+  -webkit-backdrop-filter: blur(16px) saturate(150%);
+  border: 1px solid rgba(253, 230, 138, 0.4);
+  box-shadow:
+    0 4px 24px rgba(245, 158, 11, 0.05),
+    inset 0 1px 0 rgba(255, 255, 255, 0.6);
+}
+
 /* ── Ambient Glow Orbs ─────────────────────────────────── */
 .ambient-orb {
   position: fixed;


### PR DESCRIPTION
## **User description**
## Summary

### Colored Liquid Glass Card System
- **4 new tinted glass classes**: `glass-tint-emerald`, `glass-tint-indigo`, `glass-tint-rose`, `glass-tint-amber`
- Each has unique gradient background, colored border, tinted box-shadow, and backdrop-blur
- Cards are now visually distinct — no more confusing white-on-white

### Dashboard Redesign
- **Layout**: Removed flat `bg-gray-50`, content card uses `glass-card` with `rounded-3xl`, wider `max-w-5xl`
- **Navigation**: Frosted glass bar with **emerald gradient active state** (replaces solid black pill)
- **Greet banner**: `glass-tint-emerald` with soft colored border
- **Welcome section**: Glass emerald tint with `btn-glass-primary` CTA
- **Stat cards**: Each uses its own color tint — indigo (cart), rose (fav), emerald (delivered), amber (active) — with hover lift
- **Empty states**: `glass-subtle` with dashed white border

### Profile Page
- Profile cards: `glass-tint-emerald` for complete fields, `glass-tint-amber` for pending — instant visual status
- Addresses section: `glass-tint-indigo` container, `glass-tint-emerald` for default address
- Edit buttons: glass backdrop-blur style

### Cards
- Dashboard product cards → `glass-card` with refined hover shadow
- Category cards → `glass-card` with depth shadow on hover

### Payment Fix, Mobile Nav, GST, Cart/Fav, SEO (prior commits)
- Fixed payment 500 (missing auth token + customer fields)
- Mobile bottom nav, cart/fav optimization, GST pricing fix
- Dynamic sitemap, security headers, schema improvements

## Test plan
- [ ] Dashboard stat cards show 4 distinct colored glass tints
- [ ] Profile cards show emerald (complete) vs amber (pending) tints
- [ ] Default address card has green glass tint
- [ ] Dashboard nav has emerald gradient active state (not solid black)
- [ ] Cards have visible glass effect against the gradient background
- [ ] Category cards on home page use glass-card styling
- [ ] Dashboard product cards have glass-card with hover shadow
- [ ] Greet banner has emerald glass tint with blur
- [ ] Mobile layout looks correct with glass cards
- [ ] All prior features still work (payment, bottom nav, drawers)

https://claude.ai/code/session_01D3kbJA3cag4AETUbZyYzUK


___

## **CodeAnt-AI Description**
**Give the dashboard and profile pages a colored glass look with clearer state cues**

### What Changed
- Dashboard cards, product cards, category cards, and the main content area now use tinted glass styling instead of plain white panels.
- The dashboard highlights cart, favourites, delivered orders, and active orders with different card colors, making each count easier to scan.
- The welcome banner, navigation, and empty states now use the new glass style, with the active tab shown in a green gradient on desktop and mobile.
- Profile cards now show complete and pending details with different tints, and the default delivery address is visually set apart from saved addresses.

### Impact
`✅ Easier dashboard scanning`
`✅ Clearer profile status at a glance`
`✅ More noticeable active navigation`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
