### PR TITLE
Fix expired token orders fetch + invoice PDF redesign + glass UI + all features

### DIFF
--- a/src/pageComponents/userDasboard/orders.js
+++ b/src/pageComponents/userDasboard/orders.js
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
-import { useSelector } from "react-redux";
+import { useSelector, useDispatch } from "react-redux";
+import { useRouter } from "next/router";
 import AquaUserDashbordLayout from "./layout/layout";
 import orderServiceOperations from "@/services/order";
 import {
@@ -69,14 +70,22 @@ const toLowerSafe = (value) => `${value || ""}`.toLowerCase();
 
 const AquaOrdersPageComponent = () => {
   const { userData } = useSelector((state) => ({ ...state }));
+  const dispatch = useDispatch();
+  const router = useRouter();
   const [orders, setOrders] = useState([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
+  const [authError, setAuthError] = useState(false);
   const [activeTab, setActiveTab] = useState("cod");
   const [trackingOrder, setTrackingOrder] = useState(null);
 
   const userId = userData?.user?._id;
   const token = userData?.token;
+
+  const handleReLogin = () => {
+    dispatch({ type: "LOGOUT", payload: null });
+    router.push("/");
+  };
 
   useEffect(() => {
     if (!userId || !token) return;
@@ -85,6 +94,7 @@ const AquaOrdersPageComponent = () => {
     const fetchOrders = async () => {
       setLoading(true);
       setError("");
+      setAuthError(false);
       try {
         const response = await orderServiceOperations.getOrdersByUserId(
           userId,
@@ -98,9 +108,18 @@ const AquaOrdersPageComponent = () => {
         setOrders(fetchedOrders);
       } catch (fetchError) {
         if (!isMounted) return;
-        setError(
-          "Unable to load your orders right now. Please try again later.",
-        );
+        if (fetchError?.authError) {
+          setAuthError(true);
+          setError(
+            fetchError.message ||
+              "Your session has expired. Please sign in again.",
+          );
+        } else {
+          setError(
+            fetchError?.message ||
+              "Unable to load your orders right now. Please try again later.",
+          );
+        }
         console.error("Error fetching orders:", fetchError);
       } finally {
         if (isMounted) setLoading(false);
@@ -322,8 +341,25 @@ const AquaOrdersPageComponent = () => {
             ))}
           </div>
         ) : error ? (
-          <div className="rounded-3xl border border-rose-100 bg-rose-50 p-8 text-center text-rose-600">
-            {error}
+          <div className="glass-tint-rose rounded-3xl p-8 text-center">
+            <p className="font-medium text-rose-700">{error}</p>
+            {authError ? (
+              <button
+                type="button"
+                onClick={handleReLogin}
+                className="btn-glass btn-glass-primary mt-4"
+              >
+                Sign in again
+              </button>
+            ) : (
+              <button
+                type="button"
+                onClick={() => window.location.reload()}
+                className="btn-glass btn-glass-secondary mt-4"
+              >
+                Retry
+              </button>
+            )}
           </div>
         ) : resolvedOrders.length === 0 ? (
           <div className="rounded-3xl border border-dashed border-slate-200 bg-slate-50 p-10 text-center text-sm text-slate-500">

--- a/src/services/order.js
+++ b/src/services/order.js
@@ -25,7 +25,21 @@ const getOrdersByUserId = async (id, token) => {
     });
     return response.data;
   } catch (error) {
-    throw new Error(`Error fetching orders by user ID: ${error.message}`);
+    const status = error?.response?.status;
+    const serverMsg =
+      error?.response?.data?.message ||
+      error?.response?.data?.error ||
+      error?.message;
+    if (status === 401 || status === 403) {
+      throw {
+        message: serverMsg || "Session expired. Please sign in again.",
+        authError: true,
+        status,
+      };
+    }
+    throw new Error(
+      serverMsg || `Error fetching orders (${status || "unknown"})`,
+    );
   }
 };
 


### PR DESCRIPTION
## **User description**
## Summary

### Fix: "Token is not valid" for Orders Fetch
- `getOrdersByUserId` now detects **401/403 responses** and throws structured error with `authError: true`
- Dashboard orders page catches auth errors and shows **"Session expired. Please sign in again."** with a **Sign in again** button
- Button dispatches `LOGOUT` and redirects to home for fresh login
- Non-auth errors show a **Retry** button instead
- Error display uses `glass-tint-rose` for visual consistency
- Surfaces actual server error message instead of generic fallback

### Invoice PDF Redesign (prior commit)
- Emerald brand header with white INVOICE badge
- 6-column table: #, ITEM, QTY, RATE, GST, AMOUNT with alternating stripes
- Proper ₹ formatting (fixed `INR ₹` double prefix)
- Per-item GST breakdown, emerald summary section

### All Prior Features
- Glass UI design system with tinted cards
- Mobile bottom nav, cart/fav optimization
- Payment 500 fix, GST pricing, dynamic sitemap, SEO/security headers
- Dashboard redesign, UI component showcase (`/ui`)

## Test plan
- [ ] Navigate to Dashboard → Orders with an expired session
- [ ] Verify "Session expired" message appears with "Sign in again" button
- [ ] Click "Sign in again" — verify logout + redirect to home
- [ ] Sign in with fresh credentials — verify orders load correctly
- [ ] Verify non-auth errors (e.g., network offline) show "Retry" button
- [ ] Invoice PDF downloads with correct ₹ formatting and GST column
- [ ] All prior features still work

https://claude.ai/code/session_01D3kbJA3cag4AETUbZyYzUK


___

## **CodeAnt-AI Description**
Fix expired sessions on the orders page and show the right recovery action

### What Changed
- If orders cannot be loaded because the session expired, the page now shows the server’s message and a clear "Sign in again" button
- Signing in again logs the user out and sends them back to the home page for a fresh login
- Other load failures now keep the existing error message and show a "Retry" button instead of forcing a re-login

### Impact
`✅ Fewer dead-end orders pages`
`✅ Clearer expired-session recovery`
`✅ Faster retry after temporary order load failures`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
