### PR TITLE
Fix retry payment + COD redirect + UI passcode gate + all features

### DIFF
--- a/src/pageComponents/orders/index.js
+++ b/src/pageComponents/orders/index.js
@@ -311,7 +311,7 @@ const AquaOrderPage = () => {
       const nextTransaction =
         response?.data?.transactionId || payload.transactionId;
       if (nextTransaction) {
-        router.push(`/order/${nextTransaction}`);
+        router.push(`/order/cod/${nextTransaction}`);
       }
     } catch (codError) {
       console.error("Switch to COD error:", codError);
@@ -323,8 +323,8 @@ const AquaOrderPage = () => {
 
   return (
     <AquaLayout>
-      <div className="min-h-screen bg-slate-50">
-        <div className="mx-auto flex w-full max-w-5xl flex-col gap-6 px-4 py-10 sm:px-6 lg:px-8">
+      <div className="min-h-screen">
+        <div className="mx-auto flex w-full max-w-5xl flex-col gap-6 px-4 py-8 sm:px-6 sm:py-10 lg:px-8">
           <div className="flex items-center gap-4">
             <Link
               href="/dashboard/orders"
@@ -358,7 +358,7 @@ const AquaOrderPage = () => {
             </div>
           ) : (
             <div className="space-y-8">
-              <section className="rounded-3xl border border-slate-100 bg-white p-6 shadow-sm">
+              <section className="glass-card rounded-3xl p-5 sm:p-6">
                 <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
                   <div className="space-y-1">
                     <div className="flex items-center gap-2 text-sm text-slate-500">
@@ -392,7 +392,7 @@ const AquaOrderPage = () => {
                 </div>
 
                 <div className="mt-6 grid gap-6 lg:grid-cols-3">
-                  <div className="flex h-full flex-col justify-between rounded-2xl border border-slate-200 bg-slate-50/50 p-5 hover:border-slate-300 transition-colors">
+                  <div className="flex h-full flex-col justify-between glass-tint-indigo rounded-2xl p-5 transition-all hover:shadow-lg">
                     <div>
                       <p className="flex items-center gap-2 text-xs font-bold uppercase tracking-wider text-slate-500">
                         <CreditCard className="h-4 w-4" /> Payment Summary
@@ -418,7 +418,7 @@ const AquaOrderPage = () => {
                     </div>
                   </div>
 
-                  <div className="flex h-full flex-col rounded-2xl border border-slate-200 bg-slate-50/50 p-5 hover:border-slate-300 transition-colors">
+                  <div className="flex h-full flex-col glass-tint-indigo rounded-2xl p-5 transition-all hover:shadow-lg">
                     <p className="flex items-center gap-2 text-xs font-bold uppercase tracking-wider text-slate-500">
                       <MapPin className="h-4 w-4" /> Delivery Details
                     </p>
@@ -447,7 +447,7 @@ const AquaOrderPage = () => {
                     </div>
                   </div>
 
-                  <div className="flex h-full flex-col rounded-2xl border border-slate-200 bg-slate-50/50 p-5 hover:border-slate-300 transition-colors">
+                  <div className="flex h-full flex-col glass-tint-indigo rounded-2xl p-5 transition-all hover:shadow-lg">
                     <p className="flex items-center gap-2 text-xs font-bold uppercase tracking-wider text-slate-500">
                       <Receipt className="h-4 w-4" /> Payment Info
                     </p>
@@ -490,25 +490,34 @@ const AquaOrderPage = () => {
               </section>
 
               {paymentFailed || !paymentSettled ? (
-                <section className="rounded-3xl border border-amber-100 bg-amber-50/70 p-6 shadow-sm">
-                  <h2 className="text-lg font-semibold text-amber-900">
-                    Payment pending
-                  </h2>
-                  <p className="mt-1 text-sm text-amber-800">
-                    Your payment hasn’t been completed yet. You can retry the
-                    online payment or switch this purchase to cash on delivery.
-                  </p>
-                  <div className="mt-4 flex flex-col gap-3 sm:flex-row">
+                <section className="glass-tint-amber rounded-3xl p-6">
+                  <div className="flex items-start gap-3">
+                    <div className="flex h-10 w-10 items-center justify-center rounded-2xl bg-amber-100">
+                      <IndianRupee className="h-5 w-5 text-amber-700" />
+                    </div>
+                    <div className="flex-1">
+                      <h2 className="text-lg font-bold text-amber-900">
+                        {paymentFailed ? "Payment failed" : "Payment pending"}
+                      </h2>
+                      <p className="mt-1 text-sm text-amber-800">
+                        {paymentFailed
+                          ? "Your payment could not be processed. Retry or switch to cash on delivery."
+                          : "Your payment hasn’t completed yet. You can retry online or switch to COD."}
+                      </p>
+                    </div>
+                  </div>
+                  <div className="mt-5 flex flex-col gap-3 sm:flex-row">
                     <button
                       type="button"
                       onClick={handleRetryPayment}
                       disabled={retrying || switchingToCod}
-                      className={`inline-flex items-center justify-center gap-2 rounded-full px-4 py-2 text-sm font-semibold shadow transition focus:outline-none focus:ring-2 focus:ring-offset-1 ${
+                      className={`btn-glass inline-flex items-center justify-center gap-2 ${
                         retrying
-                          ? "cursor-not-allowed bg-indigo-300 text-white"
-                          : "bg-indigo-600 text-white hover:bg-indigo-500 focus:ring-indigo-600"
+                          ? "cursor-wait bg-indigo-300 text-white"
+                          : "btn-glass-primary"
                       }`}
                     >
+                      <CreditCard className="h-4 w-4" />
                       {retrying ? "Redirecting…" : "Retry payment"}
                     </button>
                     {allowCod ? (
@@ -516,10 +525,10 @@ const AquaOrderPage = () => {
                         type="button"
                         onClick={handleSwitchToCod}
                         disabled={retrying || switchingToCod}
-                        className={`inline-flex items-center justify-center gap-2 rounded-full px-4 py-2 text-sm font-semibold transition focus:outline-none focus:ring-2 focus:ring-offset-1 ${
+                        className={`btn-glass inline-flex items-center justify-center gap-2 ${
                           switchingToCod
-                            ? "cursor-not-allowed border border-slate-200 bg-white text-slate-400"
-                            : "border border-slate-200 bg-white text-slate-700 hover:border-emerald-200 hover:bg-emerald-50 hover:text-emerald-600 focus:ring-emerald-400"
+                            ? "cursor-wait bg-slate-100 text-slate-400"
+                            : "btn-glass-secondary"
                         }`}
                       >
                         {switchingToCod
@@ -532,8 +541,8 @@ const AquaOrderPage = () => {
               ) : null}
 
               <section className="grid gap-6 lg:grid-cols-[minmax(0,2fr)_minmax(0,1.2fr)]">
-                <div className="rounded-3xl border border-slate-100 bg-white p-6 shadow-sm">
-                  <h2 className="text-lg font-bold text-slate-900 border-b border-slate-100 pb-4 mb-4">
+                <div className="glass-card rounded-3xl p-5 sm:p-6">
+                  <h2 className="text-lg font-bold text-slate-900 border-b border-white/30 pb-4 mb-4">
                     Items Ordered
                   </h2>
                   <div className="space-y-4">
@@ -570,7 +579,7 @@ const AquaOrderPage = () => {
                   </div>
                 </div>
 
-                <div className="rounded-3xl border border-slate-100 bg-white p-6 shadow-sm">
+                <div className="glass-card rounded-3xl p-5 sm:p-6">
                   <h2 className="text-lg font-semibold text-slate-900">
                     Order timeline
                   </h2>
@@ -605,7 +614,7 @@ const AquaOrderPage = () => {
               </section>
 
               {summary?.gatewayMessage ? (
-                <section className="rounded-3xl border border-slate-100 bg-white p-6 shadow-sm">
+                <section className="glass-card rounded-3xl p-5 sm:p-6">
                   <h2 className="text-lg font-semibold text-slate-900">
                     Payment gateway response
                   </h2>

--- a/src/pages/ui.js
+++ b/src/pages/ui.js
@@ -1,10 +1,6 @@
 import Head from "next/head";
-import Link from "next/link";
-import {
-  ShoppingCartIcon,
-  HeartIcon,
-  ArrowRightIcon,
-} from "@heroicons/react/24/outline";
+import { useState } from "react";
+import { ShoppingCartIcon, HeartIcon } from "@heroicons/react/24/outline";
 
 const Section = ({ title, children }) => (
   <section className="space-y-4">
@@ -40,7 +36,79 @@ const PropTable = ({ rows }) => (
   </div>
 );
 
+const ACCESS_CODE = "2607";
+
 const UIShowcasePage = () => {
+  const [code, setCode] = useState("");
+  const [unlocked, setUnlocked] = useState(false);
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    if (code === ACCESS_CODE) {
+      setUnlocked(true);
+    } else {
+      setCode("");
+    }
+  };
+
+  if (!unlocked) {
+    return (
+      <>
+        <Head>
+          <title>Access Required | Aquakart</title>
+          <meta name="robots" content="noindex, nofollow" />
+        </Head>
+        <div className="flex min-h-screen items-center justify-center px-4">
+          <form
+            onSubmit={handleSubmit}
+            className="glass-card w-full max-w-sm rounded-3xl p-8 text-center space-y-6"
+          >
+            <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-2xl bg-emerald-100/80">
+              <svg
+                className="h-8 w-8 text-emerald-600"
+                fill="none"
+                viewBox="0 0 24 24"
+                strokeWidth={1.5}
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M16.5 10.5V6.75a4.5 4.5 0 1 0-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 0 0 2.25-2.25v-6.75a2.25 2.25 0 0 0-2.25-2.25H6.75a2.25 2.25 0 0 0-2.25 2.25v6.75a2.25 2.25 0 0 0 2.25 2.25Z"
+                />
+              </svg>
+            </div>
+            <div>
+              <h1 className="text-xl font-bold text-slate-900">
+                Design System
+              </h1>
+              <p className="mt-1 text-sm text-slate-500">
+                Enter the access code to continue
+              </p>
+            </div>
+            <input
+              type="password"
+              inputMode="numeric"
+              maxLength={4}
+              value={code}
+              onChange={(e) => setCode(e.target.value.replace(/\D/g, ""))}
+              placeholder="Enter code"
+              className="w-full rounded-xl border border-white/50 bg-white/40 px-4 py-3 text-center text-2xl font-bold tracking-[0.5em] text-slate-900 placeholder:text-slate-300 placeholder:tracking-normal placeholder:text-base backdrop-blur-sm focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-400/30"
+              autoFocus
+            />
+            <button
+              type="submit"
+              disabled={code.length < 4}
+              className="btn-glass btn-glass-primary w-full disabled:opacity-40 disabled:cursor-not-allowed"
+            >
+              Unlock
+            </button>
+          </form>
+        </div>
+      </>
+    );
+  }
+
   return (
     <>
       <Head>


### PR DESCRIPTION
## **User description**
## Summary

### Fix: Retry Payment Flow (Post-Payment Page)
- **COD switch redirect bug**: Was redirecting to `/order/{id}` instead of `/order/cod/{id}` — user landed on wrong page after switching to cash on delivery
- Payment pending/failed section upgraded to `glass-tint-amber` with icon and **differentiated messaging** for failed vs pending states
- Retry and COD buttons use `btn-glass-primary`/`btn-glass-secondary`
- All order detail cards upgraded to `glass-card` and `glass-tint-indigo`

### UI Showcase Passcode Gate (`/ui`)
- Page now requires entering code **2607** before revealing components
- Glass card lock screen with numeric-only 4-digit input
- Wrong code silently clears input (no brute force hints)
- Once unlocked, full component showcase is displayed

### All Prior Features
- Dashboard invoice PDF download (shared `@/utils/invoice.js` utility)
- Token expiry handling with "Sign in again" button
- Invoice PDF redesign (emerald header, 6-column table, ₹ formatting)
- Colored liquid glass cards, dashboard redesign
- Payment 500 fix, mobile bottom nav, cart/fav optimization
- GST pricing fix, dynamic sitemap, SEO/security headers

## Test plan
- [ ] On post-payment page with failed/pending payment: "Retry payment" redirects to PhonePe
- [ ] "Switch to cash on delivery" redirects to `/order/cod/{transactionId}` (not `/order/{id}`)
- [ ] Failed payment shows "Payment failed" message; pending shows "Payment pending"
- [ ] Visit `/ui` — see lock screen, enter wrong code → clears, enter 2607 → unlocks
- [ ] All order detail cards have glass styling
- [ ] Dashboard invoice download still works

https://claude.ai/code/session_01D3kbJA3cag4AETUbZyYzUK


___

## **CodeAnt-AI Description**
**Fix payment routing and lock the UI showcase behind an access code**

### What Changed
- Switching an order to cash on delivery now sends users to the correct COD order page instead of the regular order page.
- The order details page now shows a clearer payment state: failed payments are labeled as failed, pending payments stay labeled as pending, and both show direct retry/COD actions.
- Order details and payment sections use the updated glass-style layout, with reduced top spacing on the page.
- The UI showcase page now opens with an access screen and only reveals the component gallery after entering the 4-digit code `2607`.

### Impact
`✅ Fewer wrong-page redirects after switching to cash on delivery`
`✅ Clearer payment status and recovery options`
`✅ Restricted access to the UI showcase page`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
