### PR TITLE
Fix mobile auth dialog + retry payment + UI passcode + all features

### DIFF
--- a/src/components/common/commonDialogs/authDialog.js
+++ b/src/components/common/commonDialogs/authDialog.js
@@ -11,22 +11,20 @@ const AquaUserAuthDialog = () => {
   const [authMethod, setAuthMethod] = useState("email");
   const dispatch = useDispatch();
   const { authDialog, userSignupStatus } = useSelector((state) => ({
-    ...state,
+    authDialog: state.authDialog,
+    userSignupStatus: state.userSignupStatus,
   }));
 
   const closeDialog = () => {
-    dispatch({
-      type: "SET_AUTH_DIALOG_VISIBLE",
-      payload: false,
-    });
+    dispatch({ type: "SET_AUTH_DIALOG_VISIBLE", payload: false });
   };
 
   return (
     <AquaResponsiveDialog open={authDialog} close={closeDialog}>
-      <div className="w-full max-w-sm mx-auto">
-        {/* Minimal Header */}
-        <div className="flex flex-col items-center mb-6">
-          <div className="relative h-10 w-10 mb-2">
+      <div className="w-full">
+        {/* Header */}
+        <div className="flex items-center gap-3 mb-4">
+          <div className="relative h-9 w-9 flex-shrink-0 rounded-xl bg-white/60 p-1.5 shadow-sm">
             <Image
               src={AquaLogo}
               alt="Logo"
@@ -35,75 +33,78 @@ const AquaUserAuthDialog = () => {
               priority
             />
           </div>
-          <h2 className="text-lg font-bold text-slate-900">
-            {userSignupStatus ? "Welcome Back" : "Join Aquakart"}
-          </h2>
-          <p className="text-xs text-slate-500">
-            Secure access to your water solutions
-          </p>
+          <div>
+            <h2 className="text-base font-bold text-slate-900 leading-tight">
+              {userSignupStatus ? "Welcome back" : "Join Aquakart"}
+            </h2>
+            <p className="text-[11px] text-slate-400">
+              Secure access to your water solutions
+            </p>
+          </div>
         </div>
 
-        {/* Sleek Toggle Switch */}
-        <div className="mb-6 rounded-lg bg-slate-100 p-1 flex relative">
+        {/* Toggle */}
+        <div className="mb-4 rounded-xl glass-subtle p-1 flex relative">
           <div
-            className={`absolute top-1 bottom-1 w-[calc(50%-4px)] bg-white rounded-md shadow-sm transition-all duration-300 ease-out left-1 ${authMethod === "phone" ? "translate-x-full" : ""}`}
+            className={`absolute top-1 bottom-1 w-[calc(50%-4px)] rounded-lg shadow-sm transition-all duration-300 ease-out left-1 ${
+              authMethod === "phone" ? "translate-x-full" : ""
+            } bg-gradient-to-r from-emerald-500 to-teal-500`}
           />
           <button
+            type="button"
             onClick={() => setAuthMethod("email")}
-            className={`relative z-10 flex-1 flex items-center justify-center gap-1.5 py-1.5 text-xs font-semibold rounded-md transition-colors ${
-              authMethod === "email"
-                ? "text-slate-900"
-                : "text-slate-500 hover:text-slate-700"
+            className={`relative z-10 flex-1 flex items-center justify-center gap-1.5 py-2 text-xs font-bold rounded-lg transition-colors ${
+              authMethod === "email" ? "text-white" : "text-slate-500"
             }`}
           >
             <Mail size={14} /> Email
           </button>
           <button
+            type="button"
             onClick={() => setAuthMethod("phone")}
-            className={`relative z-10 flex-1 flex items-center justify-center gap-1.5 py-1.5 text-xs font-semibold rounded-md transition-colors ${
-              authMethod === "phone"
-                ? "text-slate-900"
-                : "text-slate-500 hover:text-slate-700"
+            className={`relative z-10 flex-1 flex items-center justify-center gap-1.5 py-2 text-xs font-bold rounded-lg transition-colors ${
+              authMethod === "phone" ? "text-white" : "text-slate-500"
             }`}
           >
             <Smartphone size={14} /> Phone
           </button>
         </div>
 
-        {/* Content Area */}
-        <div className="grid min-h-[280px] relative">
+        {/* Forms */}
+        <div className="relative min-h-[220px]">
           <div
-            className={`row-start-1 col-start-1 transition-all duration-300 ${
+            className={`transition-all duration-300 ${
               authMethod === "email"
-                ? "opacity-100 scale-100 relative z-10"
-                : "opacity-0 scale-95 pointer-events-none absolute inset-0 z-0 invisible"
+                ? "opacity-100 relative z-10"
+                : "opacity-0 pointer-events-none absolute inset-0 z-0 invisible"
             }`}
           >
             <AquaAuthEmailForm signup={userSignupStatus} />
           </div>
           <div
-            className={`row-start-1 col-start-1 transition-all duration-300 ${
+            className={`transition-all duration-300 ${
               authMethod === "phone"
-                ? "opacity-100 scale-100 relative z-10"
-                : "opacity-0 scale-95 pointer-events-none absolute inset-0 z-0 invisible"
+                ? "opacity-100 relative z-10"
+                : "opacity-0 pointer-events-none absolute inset-0 z-0 invisible"
             }`}
           >
             <AquaAuthPhoneForm signup={userSignupStatus} />
           </div>
         </div>
 
-        {/* Footer Toggle */}
-        <div className="mt-6 pt-4 border-t border-slate-100 text-center">
-          <p className="text-xs text-slate-500">
-            {userSignupStatus ? "No account yet?" : "Already have an account?"}{" "}
+        {/* Footer */}
+        <div className="mt-4 pt-3 border-t border-slate-100/60 text-center">
+          <p className="text-xs text-slate-400">
+            {userSignupStatus ? "No account yet?" : "Already have an account?"}
             <button
+              type="button"
               onClick={() =>
                 dispatch({
                   type: "SET_AUTH_STATUS_VISIBLE",
                   payload: !userSignupStatus,
                 })
               }
-              className="font-bold text-indigo-600 hover:text-indigo-700 transition-colors ml-1"
+              className="font-bold text-emerald-600 hover:text-emerald-700 transition-colors ml-1"
             >
               {userSignupStatus ? "Sign up" : "Sign in"}
             </button>

--- a/src/components/common/commonDialogs/commonAuth/authFrom.js
+++ b/src/components/common/commonDialogs/commonAuth/authFrom.js
@@ -4,199 +4,128 @@ import { useState, useCallback, useEffect, useRef } from "react";
 import { useDispatch } from "react-redux";
 import AquaToast from "@/components/reusables/react-toastify";
 import debounce from "lodash.debounce";
-import { showToast } from "@/store/reducers/toastReducer";
 import { Send, Loader2 } from "lucide-react";
-import { motion } from "framer-motion";
 
-const AquaAuthMobileForm = ({ signup }) => {
+const AquaAuthEmailForm = ({ signup }) => {
   const [email, setEmail] = useState("");
   const [otpShow, setOtpShow] = useState(false);
   const [otpDigits, setOtpDigits] = useState(Array(6).fill(""));
-  const [loading, setLoading] = useState(false); // Track loading state
+  const [loading, setLoading] = useState(false);
   const { closeAuthDialog } = useDialog();
   const dispatch = useDispatch();
   const inputRefs = useRef([]);
+  const [verifying, setVerifying] = useState(false);
 
-  const handleKeyDown = (event) => {
-    if (event.key === "Backspace") {
-      // console.log("Backspace pressed");
-    }
-  };
+  const isValidEmail = (val) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(val);
 
-  const isValidEmail = (email) => {
-    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-    return emailRegex.test(email);
-  };
-
-  // Debounced OTP request function
   const requestOtp = useCallback(
     debounce((emailToSend) => {
-      if (isValidEmail(emailToSend)) {
-        setLoading(true);
-
-        dispatch(showToast("First message", "success"));
-        AquaToast({
-          message: "OTP in Air. Please wait...",
-          type: "info",
-        });
-
-        UserServiceOperations.UserEmailOtp({ email: emailToSend })
-          .then((res) => {
-            setOtpDigits(Array(6).fill(""));
-            setOtpShow(true);
-            AquaToast({
-              message: "Successfully sent OTP",
-              type: "success",
-            });
-            dispatch({
-              type: "SET_AUTH_STATUS_VISIBLE",
-              payload: !res.data.userExist,
-            });
-            setTimeout(() => inputRefs.current?.[0]?.focus(), 0);
-          })
-          .catch(() => {
-            setOtpShow(false);
-            AquaToast({
-              message: "Failed to send OTP",
-              type: "error",
-            });
-            dispatch({
-              type: "SET_AUTH_STATUS_VISIBLE",
-              payload: false,
-            });
-          })
-          .finally(() => {
-            setLoading(false);
-          });
-      } else {
-        setOtpShow(false);
-        AquaToast({
-          message: "Invalid email address!",
-          type: "error",
-        });
+      if (!isValidEmail(emailToSend)) {
+        AquaToast({ message: "Invalid email address!", type: "error" });
+        return;
       }
+      setLoading(true);
+      AquaToast({ message: "Sending OTP...", type: "info" });
+
+      UserServiceOperations.UserEmailOtp({ email: emailToSend })
+        .then((res) => {
+          setOtpDigits(Array(6).fill(""));
+          setOtpShow(true);
+          AquaToast({ message: "OTP sent successfully", type: "success" });
+          dispatch({
+            type: "SET_AUTH_STATUS_VISIBLE",
+            payload: !res.data.userExist,
+          });
+          setTimeout(() => inputRefs.current?.[0]?.focus(), 100);
+        })
+        .catch(() => {
+          setOtpShow(false);
+          AquaToast({ message: "Failed to send OTP", type: "error" });
+        })
+        .finally(() => setLoading(false));
     }, 300),
     [dispatch],
   );
 
-  // Function to trigger OTP request only on button click
   const handleSendClick = () => {
-    if (!email || !isValidEmail(email)) {
-      AquaToast({
-        message: "Enter a valid email before sending OTP!",
-        type: "error",
-      });
-      return;
-    }
-    if (loading) {
-      return;
-    }
+    if (!email || !isValidEmail(email) || loading) return;
     setOtpShow(false);
     setOtpDigits(Array(6).fill(""));
     requestOtp(email);
   };
 
   useEffect(() => {
-    if (!email) {
-      requestOtp.cancel();
-    }
+    if (!email) requestOtp.cancel();
   }, [email, requestOtp]);
-
-  const [verifying, setVerifying] = useState(false); // New state
 
   const handleSubmit = (event) => {
     event.preventDefault();
     const otpValue = otpDigits.join("");
-    if (!otpShow || otpValue.length !== 6) {
-      return;
-    }
-    setVerifying(true); // Start loading
+    if (!otpShow || otpValue.length !== 6) return;
+    setVerifying(true);
 
-    const data = { email, otp: Number(otpValue) };
-
-    const otpPromise = UserServiceOperations.UserEmailVerify(data);
+    const otpPromise = UserServiceOperations.UserEmailVerify({
+      email,
+      otp: Number(otpValue),
+    });
     const timeoutPromise = new Promise((_, reject) =>
       setTimeout(() => reject(new Error("Request timed out")), 15000),
     );
 
     Promise.race([otpPromise, timeoutPromise])
       .then((res) => {
-        AquaToast({
-          message: "Verification successful",
-          type: "success",
-        });
-        dispatch({
-          type: "LOGGED_IN_USER",
-          payload: res.data,
-        });
+        AquaToast({ message: "Verification successful", type: "success" });
+        dispatch({ type: "LOGGED_IN_USER", payload: res.data });
         closeAuthDialog();
       })
       .catch((err) => {
-        const isTimeout = err.message === "Request timed out";
         AquaToast({
-          message: isTimeout
-            ? "Server is taking too long. Please try again."
-            : "Verification failed",
+          message:
+            err.message === "Request timed out"
+              ? "Server is taking too long. Please try again."
+              : "Verification failed",
           type: "error",
         });
       })
-      .finally(() => {
-        setVerifying(false); // Stop loading
-      });
+      .finally(() => setVerifying(false));
   };
-
-  // ... (rest of code)
 
   const handleOtpChange = (index, value) => {
     const sanitized = value.replace(/\D/g, "");
-
-    // Handle multi-digit input (mobile auto-fill)
     if (sanitized.length > 1) {
-      const updatedDigits = [...otpDigits];
-      const chars = sanitized.split("");
-
-      let currentIndex = index;
-      chars.forEach((char) => {
-        if (currentIndex < 6) {
-          updatedDigits[currentIndex] = char;
-          currentIndex++;
+      const updated = [...otpDigits];
+      let cur = index;
+      sanitized.split("").forEach((c) => {
+        if (cur < 6) {
+          updated[cur] = c;
+          cur++;
         }
       });
-
-      setOtpDigits(updatedDigits);
-
-      // Focus the next empty input or the last input
-      const nextFocusIndex = Math.min(currentIndex, 5);
-      inputRefs.current[nextFocusIndex]?.focus();
+      setOtpDigits(updated);
+      inputRefs.current[Math.min(cur, 5)]?.focus();
       return;
     }
-
-    const updatedDigits = [...otpDigits];
-
+    const updated = [...otpDigits];
     if (!sanitized) {
-      updatedDigits[index] = "";
-      setOtpDigits(updatedDigits);
+      updated[index] = "";
+      setOtpDigits(updated);
       return;
     }
-
-    updatedDigits[index] = sanitized.charAt(sanitized.length - 1);
-    setOtpDigits(updatedDigits);
-
-    if (index < inputRefs.current.length - 1) {
-      inputRefs.current[index + 1]?.focus();
-    }
+    updated[index] = sanitized.charAt(sanitized.length - 1);
+    setOtpDigits(updated);
+    if (index < 5) inputRefs.current[index + 1]?.focus();
   };
 
   const handleOtpKeyDown = (index, event) => {
     if (event.key === "Backspace") {
       event.preventDefault();
-      const updatedDigits = [...otpDigits];
-      if (updatedDigits[index]) {
-        updatedDigits[index] = "";
-        setOtpDigits(updatedDigits);
+      const updated = [...otpDigits];
+      if (updated[index]) {
+        updated[index] = "";
+        setOtpDigits(updated);
       } else if (index > 0) {
-        updatedDigits[index - 1] = "";
-        setOtpDigits(updatedDigits);
+        updated[index - 1] = "";
+        setOtpDigits(updated);
         inputRefs.current[index - 1]?.focus();
       }
     }
@@ -205,136 +134,124 @@ const AquaAuthMobileForm = ({ signup }) => {
   const handleOtpPaste = (event) => {
     event.preventDefault();
     const pasted = event.clipboardData.getData("text").replace(/\D/g, "");
-    if (!pasted) {
-      return;
-    }
-
-    const updatedDigits = Array(6)
-      .fill("")
-      .map((_, idx) => pasted[idx] || "");
-    setOtpDigits(updatedDigits);
-
-    const nextIndex = Math.min(pasted.length, 5);
-    inputRefs.current[nextIndex]?.focus();
+    if (!pasted) return;
+    setOtpDigits(
+      Array(6)
+        .fill("")
+        .map((_, i) => pasted[i] || ""),
+    );
+    inputRefs.current[Math.min(pasted.length, 5)]?.focus();
   };
 
-  const isOtpComplete = otpDigits.every((digit) => digit !== "");
-  const canSubmit = otpShow && isOtpComplete;
+  const canSubmit = otpShow && otpDigits.every((d) => d !== "");
 
   return (
-    <div className="w-full">
-      <form className="space-y-6" onSubmit={handleSubmit}>
-        <div>
-          <label
-            htmlFor="email-address"
-            className="block text-sm font-semibold text-gray-900 mb-2"
-          >
-            Email Address
-          </label>
-          <div className="relative">
-            <input
-              id="email-address"
-              name="email-address"
-              type="email"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              onKeyDown={handleKeyDown}
-              placeholder="you@example.com"
-              className="block w-full rounded-xl border-0 bg-gray-50 px-4 py-3.5 text-gray-900 ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-blue-600 focus:bg-white transition-all duration-200 sm:text-sm sm:leading-6"
-              disabled={loading}
-            />
-          </div>
-
-          {isValidEmail(email) && !otpShow && (
-            <button
-              type="button"
-              onClick={handleSendClick}
-              className="mt-4 flex w-full items-center justify-center gap-2 rounded-xl bg-blue-600 px-4 py-3 text-sm font-semibold text-white shadow-sm hover:bg-blue-700 active:scale-98 transition-all duration-200 disabled:cursor-not-allowed disabled:bg-blue-300 disabled:scale-100"
-              disabled={loading}
-            >
-              {loading ? (
-                <>
-                  <Loader2 className="h-5 w-5 animate-spin" />
-                  <span>Sending OTP...</span>
-                </>
-              ) : (
-                <>
-                  <Send className="h-5 w-5" />
-                  <span>Send Verification Code</span>
-                </>
-              )}
-            </button>
-          )}
-
-          {otpShow && (
-            <div className="mt-6 space-y-4">
-              <div className="text-center">
-                <p className="text-sm font-medium text-gray-900 mb-1">
-                  Verification Code
-                </p>
-                <p className="text-xs text-gray-600">
-                  Enter the 6-digit code sent to {email}
-                </p>
-              </div>
-              <div className="grid grid-cols-6 gap-1 sm:gap-2">
-                {otpDigits.map((digit, index) => (
-                  <input
-                    key={index}
-                    ref={(el) => {
-                      inputRefs.current[index] = el;
-                    }}
-                    type="text"
-                    inputMode="numeric"
-                    autoComplete="one-time-code"
-                    placeholder="0"
-                    maxLength={1}
-                    value={digit}
-                    onChange={(event) =>
-                      handleOtpChange(index, event.target.value)
-                    }
-                    onKeyDown={(event) => handleOtpKeyDown(index, event)}
-                    onPaste={index === 0 ? handleOtpPaste : undefined}
-                    className="block w-full h-10 sm:h-12 rounded-xl border-2 border-gray-300 bg-white text-center text-base sm:text-lg font-bold text-gray-900 focus:border-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-600 transition-all duration-200 p-0"
-                  />
-                ))}
-              </div>
-              <button
-                type="button"
-                onClick={handleSendClick}
-                className="text-sm text-blue-600 hover:text-blue-700 font-medium transition-colors"
-              >
-                Resend code
-              </button>
-            </div>
-          )}
-        </div>
-
-        <motion.button
-          type="submit"
-          whileHover={{ scale: 1.02 }}
-          whileTap={{ scale: 0.96 }}
-          transition={{ type: "spring", stiffness: 400, damping: 17 }}
-          className={`w-full flex items-center justify-center rounded-xl px-8 py-3.5 text-base font-bold tracking-wide shadow-lg transition-all ${
-            !canSubmit || verifying
-              ? "bg-slate-100 text-slate-400 shadow-none cursor-not-allowed"
-              : "bg-gradient-to-r from-blue-600 to-indigo-600 text-white shadow-blue-200/50 hover:shadow-blue-300/60"
-          }`}
-          disabled={!canSubmit || verifying}
+    <form className="space-y-4" onSubmit={handleSubmit}>
+      {/* Email input */}
+      <div>
+        <label
+          htmlFor="email-address"
+          className="block text-xs font-semibold text-slate-600 mb-1.5"
         >
-          {verifying ? (
-            <div className="flex items-center gap-2">
-              <Loader2 className="h-5 w-5 animate-spin text-white/90" />
-              <span className="text-white/90">Verifying...</span>
-            </div>
-          ) : signup ? (
-            "Create Account"
+          Email Address
+        </label>
+        <input
+          id="email-address"
+          name="email-address"
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          placeholder="you@example.com"
+          className="block w-full rounded-xl border border-white/50 bg-white/40 px-3.5 py-3 text-sm text-slate-900 placeholder:text-slate-400 backdrop-blur-sm focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-400/30 transition-all"
+          disabled={loading}
+          autoComplete="email"
+        />
+      </div>
+
+      {/* Send OTP button */}
+      {isValidEmail(email) && !otpShow && (
+        <button
+          type="button"
+          onClick={handleSendClick}
+          className="btn-glass btn-glass-primary w-full flex items-center justify-center gap-2 py-3"
+          disabled={loading}
+        >
+          {loading ? (
+            <>
+              <Loader2 className="h-4 w-4 animate-spin" /> Sending...
+            </>
           ) : (
-            "Sign In"
+            <>
+              <Send className="h-4 w-4" /> Send Verification Code
+            </>
           )}
-        </motion.button>
-      </form>
-    </div>
+        </button>
+      )}
+
+      {/* OTP section */}
+      {otpShow && (
+        <div className="space-y-3">
+          <div className="text-center">
+            <p className="text-xs font-semibold text-slate-700">
+              Enter 6-digit code
+            </p>
+            <p className="text-[11px] text-slate-400 mt-0.5 truncate">
+              Sent to {email}
+            </p>
+          </div>
+          <div className="flex gap-1.5 justify-center">
+            {otpDigits.map((digit, i) => (
+              <input
+                key={i}
+                ref={(el) => {
+                  inputRefs.current[i] = el;
+                }}
+                type="text"
+                inputMode="numeric"
+                autoComplete="one-time-code"
+                maxLength={1}
+                value={digit}
+                onChange={(e) => handleOtpChange(i, e.target.value)}
+                onKeyDown={(e) => handleOtpKeyDown(i, e)}
+                onPaste={i === 0 ? handleOtpPaste : undefined}
+                placeholder="·"
+                className="w-10 h-11 rounded-lg border border-white/50 bg-white/40 text-center text-lg font-bold text-slate-900 placeholder:text-slate-300 backdrop-blur-sm focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-400/30 transition-all"
+              />
+            ))}
+          </div>
+          <button
+            type="button"
+            onClick={handleSendClick}
+            disabled={loading}
+            className="text-xs text-emerald-600 hover:text-emerald-700 font-semibold transition-colors"
+          >
+            Resend code
+          </button>
+        </div>
+      )}
+
+      {/* Submit */}
+      <button
+        type="submit"
+        disabled={!canSubmit || verifying}
+        className={`w-full flex items-center justify-center rounded-xl py-3 text-sm font-bold transition-all ${
+          canSubmit && !verifying
+            ? "btn-glass-primary shadow-lg"
+            : "bg-slate-100/60 text-slate-400 cursor-not-allowed"
+        }`}
+      >
+        {verifying ? (
+          <span className="flex items-center gap-2">
+            <Loader2 className="h-4 w-4 animate-spin" /> Verifying...
+          </span>
+        ) : signup ? (
+          "Create Account"
+        ) : (
+          "Sign In"
+        )}
+      </button>
+    </form>
   );
 };
 
-export default AquaAuthMobileForm;
+export default AquaAuthEmailForm;

--- a/src/components/common/commonDialogs/commonAuth/mobileOtp.js
+++ b/src/components/common/commonDialogs/commonAuth/mobileOtp.js
@@ -1,9 +1,9 @@
 import UserServiceOperations from "@/services/user";
 import useDialog from "@/utils/dialog";
 import { useRef, useState } from "react";
-import { motion } from "framer-motion";
 import { useDispatch } from "react-redux";
 import AquaToast from "@/components/reusables/react-toastify";
+import { Loader2 } from "lucide-react";
 
 const AquaAuthMobileForm = ({ signup }) => {
   const [phone, setPhone] = useState("");
@@ -13,57 +13,9 @@ const AquaAuthMobileForm = ({ signup }) => {
   const dispatch = useDispatch();
   const inputRefs = useRef([]);
   const [isSendingOtp, setIsSendingOtp] = useState(false);
-
   const [verifying, setVerifying] = useState(false);
 
-  const handleSubmit = (event) => {
-    event.preventDefault();
-    const phoneFormat = Number(phone);
-    const otpValue = otpDigits.join("");
-    if (otpValue.length !== 6) {
-      return;
-    }
-    setVerifying(true);
-    const otpFormat = Number(otpValue);
-    const data = { phone: phoneFormat, otp: otpFormat };
-
-    const otpPromise = UserServiceOperations.UserMobileVerify(data);
-    const timeoutPromise = new Promise((_, reject) =>
-      setTimeout(() => reject(new Error("Request timed out")), 15000),
-    );
-
-    Promise.race([otpPromise, timeoutPromise])
-      .then((res) => {
-        AquaToast({
-          message: "Verification successful",
-          type: "success",
-        });
-        dispatch({
-          type: "LOGGED_IN_USER",
-          payload: res.data,
-        });
-        closeAuthDialog();
-      })
-      .catch((err) => {
-        const isTimeout = err.message === "Request timed out";
-        AquaToast({
-          message: isTimeout
-            ? "Server is taking too long. Please try again."
-            : "Verification failed",
-          type: "error",
-        });
-      })
-      .finally(() => {
-        setVerifying(false);
-      });
-  };
-
-  // ... rest of code
-
-  const isValidPhone = (phone) => {
-    const phoneRegex = /^\d{10}$/;
-    return phoneRegex.test(phone);
-  };
+  const isValidPhone = (val) => /^\d{10}$/.test(val);
 
   const handlePhoneChange = (e) => {
     const newPhone = e.target.value.replace(/\D/g, "");
@@ -75,95 +27,96 @@ const AquaAuthMobileForm = ({ signup }) => {
   };
 
   const handleSendOtp = () => {
-    if (!isValidPhone(phone) || isSendingOtp) {
-      return;
-    }
-
+    if (!isValidPhone(phone) || isSendingOtp) return;
     setIsSendingOtp(true);
-    AquaToast({
-      message: "Sending WhatsApp OTP...",
-      type: "info",
-    });
+    AquaToast({ message: "Sending WhatsApp OTP...", type: "info" });
 
     UserServiceOperations.UserMobileOtp({ phone })
       .then((res) => {
         setOtpShow(true);
-        setIsSendingOtp(false);
-        AquaToast({
-          message: "OTP sent successfully",
-          type: "success",
-        });
+        AquaToast({ message: "OTP sent successfully", type: "success" });
         dispatch({
           type: "SET_AUTH_STATUS_VISIBLE",
           payload: !res.data.userExist,
         });
-        setTimeout(() => inputRefs.current?.[0]?.focus(), 0);
+        setTimeout(() => inputRefs.current?.[0]?.focus(), 100);
       })
       .catch(() => {
         setOtpShow(false);
-        setIsSendingOtp(false);
+        AquaToast({ message: "Failed to send OTP", type: "error" });
+        dispatch({ type: "SET_AUTH_STATUS_VISIBLE", payload: false });
+      })
+      .finally(() => setIsSendingOtp(false));
+  };
+
+  const handleSubmit = (event) => {
+    event.preventDefault();
+    const otpValue = otpDigits.join("");
+    if (otpValue.length !== 6) return;
+    setVerifying(true);
+
+    const otpPromise = UserServiceOperations.UserMobileVerify({
+      phone: Number(phone),
+      otp: Number(otpValue),
+    });
+    const timeoutPromise = new Promise((_, reject) =>
+      setTimeout(() => reject(new Error("Request timed out")), 15000),
+    );
+
+    Promise.race([otpPromise, timeoutPromise])
+      .then((res) => {
+        AquaToast({ message: "Verification successful", type: "success" });
+        dispatch({ type: "LOGGED_IN_USER", payload: res.data });
+        closeAuthDialog();
+      })
+      .catch((err) => {
         AquaToast({
-          message: "Failed to send OTP",
+          message:
+            err.message === "Request timed out"
+              ? "Server is taking too long. Please try again."
+              : "Verification failed",
           type: "error",
         });
-
-        dispatch({
-          type: "SET_AUTH_STATUS_VISIBLE",
-          payload: false,
-        });
-      });
+      })
+      .finally(() => setVerifying(false));
   };
 
   const handleOtpChange = (index, value) => {
     const sanitized = value.replace(/\D/g, "");
-
-    // Handle multi-digit input (mobile auto-fill)
     if (sanitized.length > 1) {
-      const updatedDigits = [...otpDigits];
-      const chars = sanitized.split("");
-
-      let currentIndex = index;
-      chars.forEach((char) => {
-        if (currentIndex < 6) {
-          updatedDigits[currentIndex] = char;
-          currentIndex++;
+      const updated = [...otpDigits];
+      let cur = index;
+      sanitized.split("").forEach((c) => {
+        if (cur < 6) {
+          updated[cur] = c;
+          cur++;
         }
       });
-
-      setOtpDigits(updatedDigits);
-
-      // Focus the next empty input or the last input
-      const nextFocusIndex = Math.min(currentIndex, 5);
-      inputRefs.current[nextFocusIndex]?.focus();
+      setOtpDigits(updated);
+      inputRefs.current[Math.min(cur, 5)]?.focus();
       return;
     }
-
-    const updatedDigits = [...otpDigits];
-
+    const updated = [...otpDigits];
     if (!sanitized) {
-      updatedDigits[index] = "";
-      setOtpDigits(updatedDigits);
+      updated[index] = "";
+      setOtpDigits(updated);
       return;
     }
-
-    updatedDigits[index] = sanitized.charAt(sanitized.length - 1);
-    setOtpDigits(updatedDigits);
-
-    if (index < inputRefs.current.length - 1) {
-      inputRefs.current[index + 1]?.focus();
-    }
+    updated[index] = sanitized.charAt(sanitized.length - 1);
+    setOtpDigits(updated);
+    if (index < 5) inputRefs.current[index + 1]?.focus();
   };
 
   const handleOtpKeyDown = (index, event) => {
     if (event.key === "Backspace") {
       event.preventDefault();
-      const updatedDigits = [...otpDigits];
-      if (updatedDigits[index]) {
-        updatedDigits[index] = "";
-        setOtpDigits(updatedDigits);
+      const updated = [...otpDigits];
+      if (updated[index]) {
+        updated[index] = "";
+        setOtpDigits(updated);
       } else if (index > 0) {
-        updatedDigits[index - 1] = "";
-        setOtpDigits(updatedDigits);
+        updated[index - 1] = "";
+        setOtpDigits(updated);
         inputRefs.current[index - 1]?.focus();
       }
     }
@@ -172,156 +125,145 @@ const AquaAuthMobileForm = ({ signup }) => {
   const handleOtpPaste = (event) => {
     event.preventDefault();
     const pasted = event.clipboardData.getData("text").replace(/\D/g, "");
-    if (!pasted) {
-      return;
-    }
-
-    const updatedDigits = Array(6)
-      .fill("")
-      .map((_, idx) => pasted[idx] || "");
-    setOtpDigits(updatedDigits);
-
-    const nextIndex = Math.min(pasted.length, 5);
-    inputRefs.current[nextIndex]?.focus();
+    if (!pasted) return;
+    setOtpDigits(
+      Array(6)
+        .fill("")
+        .map((_, i) => pasted[i] || ""),
+    );
+    inputRefs.current[Math.min(pasted.length, 5)]?.focus();
   };
 
-  const isOtpComplete = otpDigits.every((digit) => digit !== "");
-  const canSubmit = otpShow && isOtpComplete;
+  const canSubmit = otpShow && otpDigits.every((d) => d !== "");
 
   return (
-    <div className="w-full">
-      <form onSubmit={handleSubmit} className="space-y-6">
-        <div>
-          <label
-            htmlFor="phone-number"
-            className="block text-sm font-semibold text-gray-900 mb-2"
-          >
-            Phone Number
-          </label>
-          <div className="relative">
-            <div className="absolute inset-y-0 left-0 flex items-center pl-4 pointer-events-none">
-              <span className="text-gray-500 text-sm">+91</span>
-            </div>
-            <input
-              id="phone-number"
-              name="phone-number"
-              maxLength="10"
-              type="text"
-              inputMode="numeric"
-              value={phone}
-              onChange={handlePhoneChange}
-              placeholder="9876543210"
-              className="block w-full rounded-xl border-0 bg-gray-50 pl-12 pr-4 py-3.5 text-gray-900 ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-blue-600 focus:bg-white transition-all duration-200 sm:text-sm sm:leading-6"
-            />
+    <form onSubmit={handleSubmit} className="space-y-4">
+      {/* Phone input */}
+      <div>
+        <label
+          htmlFor="phone-number"
+          className="block text-xs font-semibold text-slate-600 mb-1.5"
+        >
+          Phone Number
+        </label>
+        <div className="relative">
+          <div className="absolute inset-y-0 left-0 flex items-center pl-3.5 pointer-events-none">
+            <span className="text-xs font-semibold text-slate-500">+91</span>
           </div>
-          <div className="mt-3 flex items-center gap-2">
-            <div className="flex-shrink-0">
-              <svg
-                className="w-4 h-4 text-green-600"
-                fill="currentColor"
-                viewBox="0 0 24 24"
-              >
+          <input
+            id="phone-number"
+            name="phone-number"
+            maxLength="10"
+            type="text"
+            inputMode="numeric"
+            value={phone}
+            onChange={handlePhoneChange}
+            placeholder="9876543210"
+            className="block w-full rounded-xl border border-white/50 bg-white/40 pl-11 pr-3.5 py-3 text-sm text-slate-900 placeholder:text-slate-400 backdrop-blur-sm focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-400/30 transition-all"
+            autoComplete="tel"
+          />
+        </div>
+        <div className="mt-1.5 flex items-center gap-1.5">
+          <svg
+            className="w-3.5 h-3.5 text-green-600 flex-shrink-0"
+            fill="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 01-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 01-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 012.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0012.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 005.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 00-3.48-8.413Z" />
+          </svg>
+          <p className="text-[11px] text-slate-400">
+            WhatsApp OTP verification
+          </p>
+        </div>
+      </div>
+
+      {/* Send OTP button */}
+      {isValidPhone(phone) && !otpShow && (
+        <button
+          type="button"
+          onClick={handleSendOtp}
+          className="w-full flex items-center justify-center gap-2 rounded-xl bg-green-600 px-4 py-3 text-sm font-bold text-white shadow-md shadow-green-600/20 transition-all hover:bg-green-500 active:scale-[0.97] disabled:opacity-50"
+          disabled={isSendingOtp}
+        >
+          {isSendingOtp ? (
+            <>
+              <Loader2 className="h-4 w-4 animate-spin" /> Sending...
+            </>
+          ) : (
+            <>
+              <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
                 <path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 01-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 01-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 012.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0012.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 005.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 00-3.48-8.413Z" />
               </svg>
-            </div>
-            <p className="text-xs text-gray-600">WhatsApp OTP verification</p>
+              Send OTP via WhatsApp
+            </>
+          )}
+        </button>
+      )}
+
+      {/* OTP section */}
+      {otpShow && (
+        <div className="space-y-3">
+          <div className="text-center">
+            <p className="text-xs font-semibold text-slate-700">
+              Enter 6-digit code
+            </p>
+            <p className="text-[11px] text-slate-400 mt-0.5">
+              Sent to +91 {phone}
+            </p>
           </div>
-
-          {isValidPhone(phone) && !otpShow && (
-            <button
-              type="button"
-              onClick={handleSendOtp}
-              className="mt-4 flex w-full items-center justify-center gap-2 rounded-xl bg-green-600 px-4 py-3 text-sm font-semibold text-white shadow-sm hover:bg-green-700 active:scale-98 transition-all duration-200 disabled:cursor-not-allowed disabled:bg-green-300 disabled:scale-100"
-              disabled={isSendingOtp}
-            >
-              {isSendingOtp ? (
-                <>
-                  <div className="h-5 w-5 border-2 border-white border-t-transparent rounded-full animate-spin" />
-                  <span>Sending OTP...</span>
-                </>
-              ) : (
-                <>
-                  <svg
-                    className="w-5 h-5"
-                    fill="currentColor"
-                    viewBox="0 0 24 24"
-                  >
-                    <path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 01-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 01-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 012.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0012.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 005.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 00-3.48-8.413Z" />
-                  </svg>
-                  <span>Send OTP via WhatsApp</span>
-                </>
-              )}
-            </button>
-          )}
-
-          {otpShow && (
-            <div className="mt-6 space-y-4">
-              <div className="text-center">
-                <p className="text-sm font-medium text-gray-900 mb-1">
-                  Verification Code
-                </p>
-                <p className="text-xs text-gray-600">
-                  Enter the 6-digit code sent to +91 {phone}
-                </p>
-              </div>
-              <div className="grid grid-cols-6 gap-1 sm:gap-2">
-                {otpDigits.map((digit, index) => (
-                  <input
-                    key={index}
-                    ref={(el) => {
-                      inputRefs.current[index] = el;
-                    }}
-                    type="text"
-                    inputMode="numeric"
-                    pattern="[0-9]*"
-                    autoComplete="one-time-code"
-                    maxLength="1"
-                    placeholder="0"
-                    value={digit}
-                    onChange={(e) => handleOtpChange(index, e.target.value)}
-                    onKeyDown={(event) => handleOtpKeyDown(index, event)}
-                    onPaste={index === 0 ? handleOtpPaste : undefined}
-                    className="block w-full h-10 sm:h-12 rounded-xl border-2 border-gray-300 bg-white text-center text-base sm:text-lg font-bold text-gray-900 focus:border-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-600 transition-all duration-200 p-0"
-                  />
-                ))}
-              </div>
-              <button
-                type="button"
-                onClick={handleSendOtp}
-                className="text-sm text-blue-600 hover:text-blue-700 font-medium transition-colors"
-                disabled={isSendingOtp}
-              >
-                Resend code
-              </button>
-            </div>
-          )}
+          <div className="flex gap-1.5 justify-center">
+            {otpDigits.map((digit, i) => (
+              <input
+                key={i}
+                ref={(el) => {
+                  inputRefs.current[i] = el;
+                }}
+                type="text"
+                inputMode="numeric"
+                pattern="[0-9]*"
+                autoComplete="one-time-code"
+                maxLength="1"
+                value={digit}
+                onChange={(e) => handleOtpChange(i, e.target.value)}
+                onKeyDown={(e) => handleOtpKeyDown(i, e)}
+                onPaste={i === 0 ? handleOtpPaste : undefined}
+                placeholder="·"
+                className="w-10 h-11 rounded-lg border border-white/50 bg-white/40 text-center text-lg font-bold text-slate-900 placeholder:text-slate-300 backdrop-blur-sm focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-400/30 transition-all"
+              />
+            ))}
+          </div>
+          <button
+            type="button"
+            onClick={handleSendOtp}
+            disabled={isSendingOtp}
+            className="text-xs text-emerald-600 hover:text-emerald-700 font-semibold transition-colors"
+          >
+            Resend code
+          </button>
         </div>
+      )}
 
-        <motion.button
-          type="submit"
-          whileHover={{ scale: 1.02 }}
-          whileTap={{ scale: 0.96 }}
-          transition={{ type: "spring", stiffness: 400, damping: 17 }}
-          className={`w-full flex items-center justify-center rounded-xl px-8 py-3.5 text-base font-bold tracking-wide shadow-lg transition-all ${
-            canSubmit && !verifying
-              ? "bg-gradient-to-r from-blue-600 to-indigo-600 text-white shadow-blue-200/50 hover:shadow-blue-300/60"
-              : "bg-slate-100 text-slate-400 shadow-none cursor-not-allowed"
-          }`}
-          disabled={!canSubmit || verifying}
-        >
-          {verifying ? (
-            <div className="flex items-center gap-2">
-              <div className="h-5 w-5 border-2 border-white/30 border-t-white rounded-full animate-spin" />
-              <span className="text-white/90">Verifying...</span>
-            </div>
-          ) : signup ? (
-            "Create Account"
-          ) : (
-            "Sign In"
-          )}
-        </motion.button>
-      </form>
-    </div>
+      {/* Submit */}
+      <button
+        type="submit"
+        disabled={!canSubmit || verifying}
+        className={`w-full flex items-center justify-center rounded-xl py-3 text-sm font-bold transition-all ${
+          canSubmit && !verifying
+            ? "btn-glass-primary shadow-lg"
+            : "bg-slate-100/60 text-slate-400 cursor-not-allowed"
+        }`}
+      >
+        {verifying ? (
+          <span className="flex items-center gap-2">
+            <Loader2 className="h-4 w-4 animate-spin" /> Verifying...
+          </span>
+        ) : signup ? (
+          "Create Account"
+        ) : (
+          "Sign In"
+        )}
+      </button>
+    </form>
   );
 };
 

--- a/src/components/reusables/dialog.js
+++ b/src/components/reusables/dialog.js
@@ -1,6 +1,6 @@
-import { useState, Fragment } from "react";
+import { Fragment } from "react";
 import { Dialog, Transition } from "@headlessui/react";
-import { CheckCircleIcon, XMarkIcon } from "@heroicons/react/24/outline";
+import { XMarkIcon } from "@heroicons/react/24/outline";
 
 const AquaResponsiveDialog = ({
   open,
@@ -12,7 +12,7 @@ const AquaResponsiveDialog = ({
 }) => {
   return (
     <Transition show={open} as={Fragment}>
-      <Dialog as="div" className="relative z-10" onClose={close}>
+      <Dialog as="div" className="relative z-50" onClose={close}>
         <Transition.Child
           as={Fragment}
           enter="ease-out duration-300"
@@ -22,32 +22,35 @@ const AquaResponsiveDialog = ({
           leaveFrom="opacity-100"
           leaveTo="opacity-0"
         >
-          <div className="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" />
+          <div className="fixed inset-0 bg-black/25 backdrop-blur-sm transition-opacity" />
         </Transition.Child>
 
-        <div className="fixed inset-0 z-10 overflow-y-auto">
-          <div className="flex min-h-full items-center justify-center p-4 text-center sm:items-center sm:p-0">
+        <div className="fixed inset-0 z-50 overflow-y-auto">
+          <div className="flex min-h-full items-end justify-center sm:items-center sm:p-4">
             <Transition.Child
               as={Fragment}
               enter="ease-out duration-300"
-              enterFrom="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
+              enterFrom="opacity-0 translate-y-8 sm:translate-y-0 sm:scale-95"
               enterTo="opacity-100 translate-y-0 sm:scale-100"
               leave="ease-in duration-200"
               leaveFrom="opacity-100 translate-y-0 sm:scale-100"
-              leaveTo="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
+              leaveTo="opacity-0 translate-y-8 sm:translate-y-0 sm:scale-95"
             >
-              <Dialog.Panel className="relative mx-4 w-full max-w-lg transform overflow-hidden rounded-3xl bg-white px-5 pb-6 pt-6 text-left shadow-xl transition-all sm:mx-0 sm:my-8 sm:w-full sm:max-w-xl sm:px-8 sm:pb-8 sm:pt-8">
-                <div className="absolute right-4 top-4">
+              <Dialog.Panel className="relative w-full max-w-md transform overflow-hidden rounded-t-3xl sm:rounded-3xl border-t border-white/50 sm:border border-white/50 bg-white/80 backdrop-blur-2xl px-5 pb-6 pt-5 text-left shadow-[0_-10px_40px_rgba(0,0,0,0.08)] sm:shadow-[0_8px_40px_rgba(0,0,0,0.1)] transition-all sm:mx-auto sm:my-8">
+                {/* Drag handle on mobile */}
+                <div className="mx-auto mb-3 h-1 w-10 rounded-full bg-slate-300/60 sm:hidden" />
+
+                <div className="absolute right-3 top-3 sm:right-4 sm:top-4">
                   <button
                     type="button"
-                    className="inline-flex h-9 w-9 items-center justify-center rounded-full bg-white/90 text-gray-400 shadow-sm ring-1 ring-gray-200 hover:text-gray-600 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+                    className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-white/60 text-slate-400 backdrop-blur-sm transition hover:bg-white hover:text-slate-600 active:scale-90"
                     onClick={close}
                   >
                     <span className="sr-only">Close</span>
-                    <XMarkIcon className="h-6 w-6" aria-hidden="true" />
+                    <XMarkIcon className="h-5 w-5" aria-hidden="true" />
                   </button>
                 </div>
-                <div className="mt-6 sm:mt-4">{children}</div>
+                <div className="mt-1 sm:mt-2">{children}</div>
               </Dialog.Panel>
             </Transition.Child>
           </div>

--- a/src/pageComponents/orders/index.js
+++ b/src/pageComponents/orders/index.js
@@ -1,7 +1,7 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState, useCallback, useRef } from "react";
 import { useRouter } from "next/router";
 import Link from "next/link";
-import { useSelector } from "react-redux";
+import { useSelector, useDispatch } from "react-redux";
 import dayjs from "dayjs";
 import { nanoid } from "nanoid";
 import {
@@ -104,49 +104,100 @@ const deriveTimeline = (orderStatus = "") => {
 
 const AquaOrderPage = () => {
   const router = useRouter();
+  const dispatch = useDispatch();
   const { id } = router.query;
-  const { userData } = useSelector((state) => ({ ...state }));
+  const userData = useSelector((state) => state.userData);
 
   const [order, setOrder] = useState(null);
-  const [loading, setLoading] = useState(false);
+  const [loading, setLoading] = useState(true); // Start true to avoid flash
   const [error, setError] = useState("");
+  const [authError, setAuthError] = useState(false);
   const [retrying, setRetrying] = useState(false);
   const [switchingToCod, setSwitchingToCod] = useState(false);
+  const pollCountRef = useRef(0);
 
   const token = userData?.token;
   const userId = userData?.user?._id;
 
-  const fetchOrder = async (signal) => {
-    if (!id || !token) return;
-    setLoading(true);
-    setError("");
-
-    try {
-      const response = await orderServiceOperations.getOrdersByTransactionId(
-        id,
-        token,
-        { signal },
-      );
-      const orderData = response?.data;
-      setOrder(orderData || null);
-    } catch (fetchError) {
-      if (signal?.aborted) return;
-      console.error("Order fetch error:", fetchError);
-      setError("We couldn’t load this order. Please try again later.");
-      AquaToast({ message: "Unable to load order details", type: "error" });
-      setOrder(null);
-    } finally {
-      if (!signal?.aborted) setLoading(false);
-    }
+  const handleReLogin = () => {
+    dispatch({ type: "LOGOUT", payload: null });
+    router.push("/");
   };
 
+  const fetchOrder = useCallback(
+    async (signal) => {
+      if (!id || !token) {
+        setLoading(false);
+        return;
+      }
+      setError("");
+      setAuthError(false);
+
+      try {
+        const response = await orderServiceOperations.getOrdersByTransactionId(
+          id,
+          token,
+          { signal },
+        );
+        // API may return { data: order } or order directly
+        const orderData = response?.data || response;
+        setOrder(orderData || null);
+        return orderData;
+      } catch (fetchError) {
+        if (signal?.aborted) return null;
+        console.error("Order fetch error:", fetchError);
+        if (fetchError?.authError) {
+          setAuthError(true);
+          setError(
+            fetchError.message || "Session expired. Please sign in again.",
+          );
+        } else {
+          setError(
+            fetchError?.message ||
+              "We couldn’t load this order. Please try again.",
+          );
+        }
+        setOrder(null);
+        return null;
+      } finally {
+        if (!signal?.aborted) setLoading(false);
+      }
+    },
+    [id, token],
+  );
+
+  // Initial fetch + polling for payment verification (max 3 retries over 15s)
   useEffect(() => {
-    if (!router.isReady || !token) return;
+    if (!router.isReady || !token || !id) {
+      setLoading(false);
+      return;
+    }
+
+    setLoading(true);
+    pollCountRef.current = 0;
     const controller = new AbortController();
-    fetchOrder(controller.signal);
+
+    const poll = async () => {
+      const result = await fetchOrder(controller.signal);
+      if (controller.signal.aborted) return;
+
+      // If order not found yet (payment gateway may not have notified backend),
+      // retry a few times with delay
+      if (!result && pollCountRef.current < 3) {
+        pollCountRef.current += 1;
+        setTimeout(() => {
+          if (!controller.signal.aborted) {
+            setLoading(true);
+            setError("");
+            poll();
+          }
+        }, pollCountRef.current * 3000); // 3s, 6s, 9s
+      }
+    };
+
+    poll();
     return () => controller.abort();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [router.isReady, id, token]);
+  }, [router.isReady, id, token, fetchOrder]);
 
   const summary = useMemo(() => {
     if (!order) return null;
@@ -335,22 +386,44 @@ const AquaOrderPage = () => {
           </div>
 
           {loading ? (
-            <div className="flex min-h-[50vh] flex-col items-center justify-center gap-4 rounded-3xl border border-slate-100 bg-white p-10">
-              <AquaSpinner color="blue" size="lg" />
-              <p className="text-sm text-slate-500">
-                Loading your order details…
-              </p>
+            <div className="flex min-h-[50vh] flex-col items-center justify-center gap-5 glass-card rounded-3xl p-10">
+              <AquaSpinner color="emerald" size="lg" />
+              <div className="text-center">
+                <p className="text-sm font-semibold text-slate-700">
+                  {pollCountRef.current > 0
+                    ? "Confirming your payment..."
+                    : "Loading your order details..."}
+                </p>
+                <p className="text-xs text-slate-400 mt-1">
+                  {pollCountRef.current > 0
+                    ? "This may take a few seconds while we verify with the payment gateway."
+                    : "Please wait while we fetch your order."}
+                </p>
+              </div>
             </div>
           ) : error ? (
-            <div className="flex min-h-[50vh] flex-col items-center justify-center gap-4 rounded-3xl border border-rose-100 bg-rose-50 p-10 text-center">
+            <div className="flex min-h-[50vh] flex-col items-center justify-center gap-4 glass-tint-rose rounded-3xl p-10 text-center">
               <p className="text-lg font-semibold text-rose-700">{error}</p>
-              <button
-                type="button"
-                onClick={() => fetchOrder()}
-                className="inline-flex items-center gap-2 rounded-full bg-rose-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-rose-700"
-              >
-                Try again
-              </button>
+              {authError ? (
+                <button
+                  type="button"
+                  onClick={handleReLogin}
+                  className="btn-glass btn-glass-primary"
+                >
+                  Sign in again
+                </button>
+              ) : (
+                <button
+                  type="button"
+                  onClick={() => {
+                    setLoading(true);
+                    fetchOrder();
+                  }}
+                  className="btn-glass btn-glass-secondary"
+                >
+                  Try again
+                </button>
+              )}
             </div>
           ) : !order ? (
             <div className="rounded-3xl border border-dashed border-slate-200 bg-white p-12 text-center text-sm text-slate-500">

--- a/src/services/order.js
+++ b/src/services/order.js
@@ -53,8 +53,21 @@ const getOrdersByTransactionId = async (id, token, config = {}) => {
     });
     return response.data;
   } catch (error) {
+    if (config?.signal?.aborted) throw error;
+    const status = error?.response?.status;
+    const serverMsg =
+      error?.response?.data?.message ||
+      error?.response?.data?.error ||
+      error?.message;
+    if (status === 401 || status === 403) {
+      throw {
+        message: serverMsg || "Session expired. Please sign in again.",
+        authError: true,
+        status,
+      };
+    }
     throw new Error(
-      `Error fetching orders by transaction ID: ${error.message}`,
+      serverMsg || `Error fetching order (${status || "unknown"})`,
     );
   }
 };


### PR DESCRIPTION
## **User description**
## Summary

### Fix: Auth Dialog Mobile + Small Screen UI
- **Bottom sheet on mobile**: Dialog slides up from bottom (`items-end`, `rounded-t-3xl`) instead of floating centered — no more cutoff on small phones or 11" laptops
- **Drag handle** on mobile for visual affordance
- **Glass backdrop** (`bg-black/25 backdrop-blur-sm`) replaces opaque gray
- **Glass panel** (`bg-white/80 backdrop-blur-2xl border-white/50`)
- **Compact header**: Logo + text horizontal (saves vertical space)
- **Emerald gradient toggle** for Email/Phone switch (replaces white pill)
- **Glass inputs**: `bg-white/40 backdrop-blur-sm border-white/50` with emerald focus ring
- **Fixed OTP boxes**: `w-10 h-11` — fits all screens without overflow
- **Removed framer-motion** from email form (was only used for button scale)
- **btn-glass-primary** on submit buttons, clear disabled state (`bg-slate-100/60`)
- **z-50** so dialog sits above bottom nav and header
- Reduced `min-height` from 280px to 220px

### Fix: Retry Payment Flow (prior commit)
- COD switch redirect: `/order/{id}` → `/order/cod/{id}`
- Glass-tinted payment pending/failed section

### UI Showcase Passcode Gate (prior commit)
- `/ui` requires code 2607

### All Prior Features
- Invoice PDF download, token fix, glass cards, dashboard redesign
- Payment 500 fix, mobile bottom nav, cart/fav optimization
- GST pricing, dynamic sitemap, SEO/security headers

## Test plan
- [ ] Open auth dialog on mobile phone — slides up as bottom sheet
- [ ] Toggle between Email and Phone — emerald gradient moves
- [ ] Enter email → Send OTP → 6-digit OTP boxes fit screen without scrolling
- [ ] Enter phone → WhatsApp OTP → same compact layout
- [ ] Submit with valid OTP — login works
- [ ] Dialog on 11" laptop — centered with glass panel, no cutoff
- [ ] Close button works, clicking backdrop closes dialog
- [ ] Bottom nav visible behind dialog backdrop

https://claude.ai/code/session_01D3kbJA3cag4AETUbZyYzUK


___

## **CodeAnt-AI Description**
**Make the sign-in dialog fit small screens and keep OTP steps clearer**

### What Changed
- The sign-in dialog now opens as a bottom sheet on mobile with a visible drag handle, softer backdrop, and a closer button that stays easy to reach.
- The email and phone sign-in forms use a tighter layout with smaller spacing, clearer buttons, and OTP boxes that fit without overflowing on small screens.
- Switching between email and phone sign-in now uses a more distinct highlighted tab, and the sign-up/sign-in switch in the footer is easier to see.
- Sending and verifying OTPs now shows clearer loading and timeout messages, and successful verification closes the dialog as before.

### Impact
`✅ Fewer sign-in dialog cutoffs on small phones`
`✅ Clearer OTP entry on mobile`
`✅ Fewer failed sign-in attempts from cramped layouts`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
