### PR TITLE
Improve DatePicker accessibility, refresh products on mount, use SSR for home page, and make invoice amount calculation robust

### DIFF
--- a/src/components/reusables/datePicker.js
+++ b/src/components/reusables/datePicker.js
@@ -10,6 +10,7 @@ import {
 import { createPortal } from "react-dom";
 import {
   CalendarDaysIcon,
+  ChevronDownIcon,
   ChevronLeftIcon,
   ChevronRightIcon,
   XMarkIcon,
@@ -86,6 +87,7 @@ const AquaDatePicker = forwardRef(function AquaDatePicker(
   const selected = useMemo(() => parseValue(value), [value]);
   const today = dayjs();
   const [viewDate, setViewDate] = useState(selected || today);
+  const [focusDate, setFocusDate] = useState(selected || today);
   const [open, setOpen] = useState(false);
   const [coords, setCoords] = useState(null);
   const [mounted, setMounted] = useState(false);
@@ -105,8 +107,16 @@ const AquaDatePicker = forwardRef(function AquaDatePicker(
   useEffect(() => setMounted(true), []);
 
   useEffect(() => {
-    if (selected) setViewDate(selected);
+    if (selected) {
+      setViewDate(selected);
+      setFocusDate(selected);
+    }
   }, [selected]);
+
+  useEffect(() => {
+    if (!open) return;
+    setFocusDate(selected || viewDate);
+  }, [open, selected, viewDate]);
 
   const updatePosition = useCallback(() => {
     if (!buttonRef.current) return;
@@ -179,6 +189,42 @@ const AquaDatePicker = forwardRef(function AquaDatePicker(
     setOpen(false);
   };
 
+  const moveFocusByDays = (daysToMove) => {
+    const nextDay = focusDate.add(daysToMove, "day");
+    if (minDate && nextDay.isBefore(minDate, "day")) return;
+    if (maxDate && nextDay.isAfter(maxDate, "day")) return;
+    setFocusDate(nextDay);
+    setViewDate(nextDay);
+  };
+
+  const handleGridKeyDown = (event) => {
+    switch (event.key) {
+      case "ArrowLeft":
+        event.preventDefault();
+        moveFocusByDays(-1);
+        break;
+      case "ArrowRight":
+        event.preventDefault();
+        moveFocusByDays(1);
+        break;
+      case "ArrowUp":
+        event.preventDefault();
+        moveFocusByDays(-7);
+        break;
+      case "ArrowDown":
+        event.preventDefault();
+        moveFocusByDays(7);
+        break;
+      case "Enter":
+      case " ":
+        event.preventDefault();
+        handleSelect(focusDate);
+        break;
+      default:
+        break;
+    }
+  };
+
   const handleClear = (event) => {
     event?.stopPropagation();
     emitChange("");
@@ -202,6 +248,8 @@ const AquaDatePicker = forwardRef(function AquaDatePicker(
         type="button"
         disabled={disabled}
         onClick={() => setOpen((prev) => !prev)}
+        aria-haspopup="dialog"
+        aria-expanded={open}
         className={`mt-1 flex w-full items-center justify-between rounded-lg border bg-white p-3 text-left text-sm shadow-sm transition focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 disabled:cursor-not-allowed disabled:bg-gray-50 ${
           open ? "border-indigo-500 ring-2 ring-indigo-500" : "border-gray-300"
         } ${selected ? "text-gray-900" : "text-gray-400"}`}
@@ -229,6 +277,10 @@ const AquaDatePicker = forwardRef(function AquaDatePicker(
             className="h-5 w-5 text-indigo-500"
             aria-hidden="true"
           />
+          <ChevronDownIcon
+            className={`h-4 w-4 text-gray-400 transition ${open ? "rotate-180" : ""}`}
+            aria-hidden="true"
+          />
         </span>
       </button>
 
@@ -243,7 +295,7 @@ const AquaDatePicker = forwardRef(function AquaDatePicker(
                 width: coords.width,
                 zIndex: 9999,
               }}
-              className="rounded-2xl border border-white/60 bg-white/95 p-4 shadow-[0_12px_40px_rgba(0,0,0,0.18)] backdrop-blur-xl animate-in fade-in"
+              className="rounded-2xl border border-gray-200 bg-white p-4 shadow-xl animate-in fade-in"
             >
               <div className="flex items-center justify-between gap-2">
                 <button
@@ -302,12 +354,19 @@ const AquaDatePicker = forwardRef(function AquaDatePicker(
                 ))}
               </div>
 
-              <div className="mt-1 grid grid-cols-7 gap-1">
+              <div
+                className="mt-1 grid grid-cols-7 gap-1"
+                role="grid"
+                tabIndex={0}
+                onKeyDown={handleGridKeyDown}
+                aria-label="Calendar dates"
+              >
                 {days.map((day) => {
                   const inMonth = day.month() === viewDate.month();
                   const isSelected = selected && day.isSame(selected, "day");
                   const isTodayCell = day.isSame(today, "day");
                   const disabledDay = isDisabled(day);
+                  const isFocused = day.isSame(focusDate, "day");
 
                   let classes =
                     "h-9 w-full rounded-full text-sm font-medium transition focus:outline-none focus:ring-2 focus:ring-indigo-400";
@@ -325,13 +384,19 @@ const AquaDatePicker = forwardRef(function AquaDatePicker(
                     classes += " text-gray-300 hover:bg-gray-50";
                   }
 
+                  if (isFocused && !disabledDay && !isSelected) {
+                    classes += " ring-2 ring-indigo-200";
+                  }
+
                   return (
                     <button
                       key={day.format("YYYY-MM-DD")}
                       type="button"
                       disabled={disabledDay}
                       onClick={() => handleSelect(day)}
+                      onFocus={() => setFocusDate(day)}
                       className={classes}
+                      aria-pressed={Boolean(isSelected)}
                     >
                       {day.date()}
                     </button>

--- a/src/pageComponents/home/products.js
+++ b/src/pageComponents/home/products.js
@@ -10,35 +10,54 @@ const AquaProducts = ({ initialProducts = [] }) => {
   const [loading, setLoading] = useState(false);
   const [selectedFilter, setSelectedFilter] = useState("All");
 
-  // Fallback fetch if no initial products (e.g., client navigation fallback)
+  // Always refresh product data once on mount so prices stay in sync with shop.
   useEffect(() => {
-    if (initialProducts.length === 0) {
-      let isMounted = true;
-      const fetchProducts = async () => {
+    let isMounted = true;
+    const shouldShowLoader = initialProducts.length === 0;
+
+    const fetchProducts = async () => {
+      if (shouldShowLoader) {
         setLoading(true);
-        try {
-          const response = await ProductServiceOperations.AllProducts();
-          if (isMounted) {
-            setProducts(response.data?.data || []);
-          }
-        } catch (error) {
-          console.error("Failed to load products", error);
-        } finally {
-          if (isMounted) {
-            setLoading(false);
-          }
+      }
+
+      try {
+        const response = await ProductServiceOperations.AllProducts();
+        if (isMounted) {
+          const latestProducts = Array.isArray(response?.data?.data)
+            ? response.data.data
+            : [];
+          setProducts(latestProducts);
         }
-      };
+      } catch (error) {
+        console.error("Failed to load products", error);
+        if (isMounted && initialProducts.length === 0) {
+          setProducts([]);
+        }
+      } finally {
+        if (isMounted && shouldShowLoader) {
+          setLoading(false);
+        }
+      }
+    };
 
-      fetchProducts();
-
-      return () => {
-        isMounted = false;
-      };
-    } else {
+    if (initialProducts.length > 0) {
       setProducts(initialProducts);
     }
+
+    fetchProducts();
+
+    return () => {
+      isMounted = false;
+    };
   }, [initialProducts]);
+
+  useEffect(() => {
+    if (products.length > 0 || initialProducts.length === 0) {
+      return;
+    }
+
+    setProducts(initialProducts);
+  }, [initialProducts, products.length]);
 
   useEffect(() => {
     setSelectedFilter("All");

--- a/src/pages/admin/crm/invoice/invoiceComponent.js
+++ b/src/pages/admin/crm/invoice/invoiceComponent.js
@@ -69,10 +69,17 @@ const AquaInvoiceClient = ({ data }) => {
     },
   ];
 
-  const total = data?.products.reduce(
+  const totalProductPrice = data?.products.reduce(
     (acc, product) => acc + product?.productPrice,
     0,
   );
+  const amountPaid =
+    data?.amountPaid ??
+    data?.paidAmount ??
+    data?.totalPaid ??
+    data?.finalAmount ??
+    data?.totalAmount ??
+    totalProductPrice;
 
   return (
     <div className="flex flex-col items-center justify-center min-h-screen bg-gray-700">
@@ -210,7 +217,7 @@ const AquaInvoiceClient = ({ data }) => {
 
               <div className="flex justify-end mt-4">
                 <h4 className="text-xl font-bold text-green-600">
-                  Grand Total: {IndianCurrencySumbol(total)}
+                  Amount Paid: {IndianCurrencySumbol(amountPaid)}
                 </h4>
               </div>
             </div>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -11,7 +11,12 @@ const AquaHomePage = (props) => {
   );
 };
 
-export async function getStaticProps() {
+export async function getServerSideProps({ res }) {
+  res.setHeader(
+    "Cache-Control",
+    "private, no-cache, no-store, must-revalidate, max-age=0",
+  );
+
   try {
     const [categoriesRes, subCategoriesRes, productsRes] = await Promise.all([
       CategoryServiceOperations.Allcategories(),
@@ -25,8 +30,6 @@ export async function getStaticProps() {
         initialSubCategories: subCategoriesRes.data?.data || [],
         initialProducts: productsRes.data?.data || [],
       },
-      // Revalidate every hour
-      revalidate: 3600,
     };
   } catch (error) {
     console.error("Failed to fetch home page data:", error);
@@ -36,7 +39,6 @@ export async function getStaticProps() {
         initialSubCategories: [],
         initialProducts: [],
       },
-      revalidate: 60,
     };
   }
 }

--- a/src/utils/invoice.js
+++ b/src/utils/invoice.js
@@ -10,6 +10,25 @@ const toNumber = (value, fallback = 0) => {
   return Number.isFinite(parsed) ? parsed : fallback;
 };
 
+const resolveAmountPaid = (order, fallbackAmount) => {
+  const directCandidates = [
+    order?.amountPaid,
+    order?.paidAmount,
+    order?.totalPaid,
+    order?.finalAmount,
+    order?.totalAmount,
+  ];
+
+  for (const candidate of directCandidates) {
+    const parsed = Number(candidate);
+    if (Number.isFinite(parsed) && parsed >= 0) {
+      return roundToTwo(parsed);
+    }
+  }
+
+  return roundToTwo(toNumber(fallbackAmount, 0));
+};
+
 const fmt = (v) =>
   new Intl.NumberFormat("en-IN", {
     style: "currency",
@@ -106,7 +125,8 @@ export const generateInvoicePDF = async (order) => {
     ),
   );
 
-  const payableTotal = roundToTwo(orderSubtotal + shippingCharge);
+  const amountPaid = resolveAmountPaid(order, orderSubtotal + shippingCharge);
+  const payableTotal = amountPaid;
   const isCOD = `${order.orderType || order.paymentMethod || ""}`
     .toLowerCase()
     .includes("cash");
@@ -351,8 +371,20 @@ export const generateInvoicePDF = async (order) => {
   doc.setTextColor(...SLATE_900);
   doc.text("INVOICE SUMMARY", rBoxX + 16, Y + 22);
 
+  const payableBeforeShipping = Math.max(
+    roundToTwo(toNumber(order?.totalAmount, orderSubtotal)),
+    0,
+  );
+  const discountAmount = Math.max(
+    roundToTwo(orderSubtotal - payableBeforeShipping),
+    0,
+  );
+
   const summaryData = [
-    { label: "Product price", value: fmt(orderSubtotal) },
+    {
+      label: "Product price",
+      value: fmt(payableBeforeShipping || orderSubtotal),
+    },
     {
       label: `Incl. GST (${Math.round(GST_RATE * 100)}%)`,
       value: fmt(itemsGstTotal),
@@ -363,6 +395,13 @@ export const generateInvoicePDF = async (order) => {
       value: shippingCharge > 0 ? fmt(shippingCharge) : "FREE",
     },
   ];
+
+  if (discountAmount > 0) {
+    summaryData.splice(1, 0, {
+      label: "Discount applied",
+      value: `- ${fmt(discountAmount)}`,
+    });
+  }
 
   let sLineY = Y + 42;
   summaryData.forEach((row) => {
@@ -384,7 +423,7 @@ export const generateInvoicePDF = async (order) => {
   doc.setFont(F, "bold");
   doc.setFontSize(12);
   doc.setTextColor(...BRAND_DARK);
-  doc.text("TOTAL TO PAY", rBoxX + 16, sLineY);
+  doc.text("AMOUNT PAID", rBoxX + 16, sLineY);
   doc.text(fmt(payableTotal), rBoxX + boxW - 16, sLineY, { align: "right" });
 
   // Footer


### PR DESCRIPTION
## **User description**
### Motivation
- Enable keyboard navigation and better focus handling for the date picker to improve accessibility and UX.
- Ensure product prices are refreshed on client mount so storefront prices remain in sync with the shop.
- Serve the home page via server-side rendering and disable stale caching to always fetch current catalog data.
- Make invoice amount/total resolution resilient to various payload shapes and show applied discounts when present.

### Description
- DatePicker (`src/components/reusables/datePicker.js`): added focus state management (`focusDate`), keyboard handlers (`onKeyDown` grid navigation and Enter/Space select), ARIA attributes, visual focus ring for focused cell, a chevron icon, and simplified panel styling; also update position handling and focus sync when opened.
- Products list (`src/pageComponents/home/products.js`): always refresh products on mount with a single `useEffect`, show loader only when there were no initial products, handle API response shape defensively, and add cleanup/guarding with `isMounted` to avoid state updates after unmount.
- Home page entry (`src/pages/index.js`): switched from `getStaticProps` to `getServerSideProps`, added `Cache-Control` headers to prevent stale caching, and removed `revalidate` usage so the page always requests fresh data on each request.
- Invoice rendering (`src/pages/admin/crm/invoice/invoiceComponent.js` and `src/utils/invoice.js`): introduced `resolveAmountPaid` to pick the correct paid/total field from multiple possible keys, use that value for summary and displayed amount, compute and insert a "Discount applied" row when appropriate, renamed displayed labels to "Amount Paid", and ensured numeric rounding/formatting consistency.

### Testing
- No automated tests were executed as part of this rollout (no unit/integration test runs were performed).

[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb65cdf63c832db754d2c426757d2b)


___

## **CodeAnt-AI Description**
**Keep home content and invoices in sync with the latest data**

### What Changed
- Home products now refresh when the page opens, so shoppers see the latest prices instead of stale product data.
- The home page now loads on each request and stops using cached catalog data, which keeps categories, subcategories, and products current.
- Invoices now show a clearer paid amount, accept several order amount field names, and include a discount line when the order total is lower than the product total.
- The date picker now supports keyboard navigation, shows a clearer focused day, and has improved open/close behavior for accessibility.

### Impact
`✅ Fewer stale product prices`
`✅ Current catalog data on page load`
`✅ Clearer invoice totals`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=2R9aZSuMerwCOiNSckVWuBANyUbYGNuj6LupOrVsMw4&org=SVSKHD)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
