### PR TITLE
Fix canonical URL generation for SEO metadata

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,3 @@
+import nextVitals from "eslint-config-next/core-web-vitals";
+
+export default [...nextVitals];

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev --webpack",
     "build": "next build --turbopack",
     "start": "next start",
-    "lint": "next lint",
+    "lint": "eslint .",
     "pretty": "npx prettier . --write",
     "update:packages": "npx npm-check-updates -u && npm install",
     "prepare": "husky"

--- a/src/components/Layout/seo/RefactoredSeo.js
+++ b/src/components/Layout/seo/RefactoredSeo.js
@@ -89,17 +89,44 @@ const AquaSeoRevamp = ({
     };
   }
 
+  const inferredPath = (() => {
+    if (blogPage) {
+      const slug = blogPage?.slug || blogPage?._id;
+      return slug ? `/blog/${slug}` : "/blogs";
+    }
+    if (product) {
+      const slug =
+        productData?.slug || productData?._id || product?._id || product;
+      return slug ? `/product/${slug}` : "/shop";
+    }
+    if (subcategory) {
+      const slug = subcategoryData?.slug || subcategoryData?._id || subcategory;
+      return slug ? `/subcategory/${slug}` : "/shop";
+    }
+    if (category) {
+      const slug = categoryData?.slug || categoryData?._id || category;
+      return slug ? `/category/${slug}` : "/shop";
+    }
+    if (path && path !== "home") {
+      return `/${String(path).replace(/^\/+/, "")}`;
+    }
+    return "/";
+  })();
+
   const {
     title = "Aquakart",
     keywords = "",
     keyphrases = "",
-    url: rawUrl = baseUrl,
+    url: rawUrl,
     description = "",
     follow = true,
     photos,
   } = metaData || {};
 
-  const canonicalUrl = toAbsoluteUrl(baseUrl, rawUrl || baseUrl);
+  const canonicalUrl = toAbsoluteUrl(
+    baseUrl,
+    rawUrl || inferredPath || baseUrl,
+  );
   const photoCandidates = collectImages(photos);
   const primaryImage = photoCandidates[0] || DEFAULT_LOGO;
 


### PR DESCRIPTION
## **User description**
## Summary
- Fixed canonical URL generation in `AquaSeoRevamp` so dynamic pages no longer default to the site root when `metaData.url` is missing.
- Added deterministic fallback path inference for blog, product, subcategory, category, and routed static pages.
- Canonical now resolves from explicit `metaData.url` first, then inferred route path, ensuring page-specific canonical tags and OG/Twitter URLs.

## Why this fixes the SEO issue
Previously, when dynamic page data (like product/category/blog) omitted a `url` field, canonical fell back to the base domain. That caused duplicate-canonical behavior across multiple pages. The new fallback builds route-aware URLs so each page self-canonicalizes correctly.

## Validation
- Static inspection of `src/components/Layout/seo/RefactoredSeo.js` confirms canonical URL fallback now uses context-derived paths for dynamic page types.
- Prettier formatting applied to the updated file.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02e196a52c832da8df3b0ed2034292)


___

## **CodeAnt-AI Description**
**Fix canonical URLs for pages without an explicit page URL**

### What Changed
- Pages now use a page-specific fallback URL when no canonical URL is provided, instead of pointing to the site root
- Blog, product, category, subcategory, and routed static pages now resolve to their own paths for canonical, Open Graph, and social preview URLs
- The project lint command now runs through the standard ESLint setup

### Impact
`✅ Fewer duplicate canonical URLs`
`✅ More accurate SEO tags on product and content pages`
`✅ Clearer lint checks during development`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
