### PR TITLE
Add ESLint config; improve SEO canonical inference; add sign-in prompt in reviews; render footer in user dashboard

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,3 @@
+import nextVitals from "eslint-config-next/core-web-vitals";
+
+export default [...nextVitals];

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev --webpack",
     "build": "next build --turbopack",
     "start": "next start",
-    "lint": "next lint",
+    "lint": "eslint .",
     "pretty": "npx prettier . --write",
     "update:packages": "npx npm-check-updates -u && npm install",
     "prepare": "husky"

--- a/src/components/Layout/seo/RefactoredSeo.js
+++ b/src/components/Layout/seo/RefactoredSeo.js
@@ -89,17 +89,44 @@ const AquaSeoRevamp = ({
     };
   }
 
+  const inferredPath = (() => {
+    if (blogPage) {
+      const slug = blogPage?.slug || blogPage?._id;
+      return slug ? `/blog/${slug}` : "/blogs";
+    }
+    if (product) {
+      const slug =
+        productData?.slug || productData?._id || product?._id || product;
+      return slug ? `/product/${slug}` : "/shop";
+    }
+    if (subcategory) {
+      const slug = subcategoryData?.slug || subcategoryData?._id || subcategory;
+      return slug ? `/subcategory/${slug}` : "/shop";
+    }
+    if (category) {
+      const slug = categoryData?.slug || categoryData?._id || category;
+      return slug ? `/category/${slug}` : "/shop";
+    }
+    if (path && path !== "home") {
+      return `/${String(path).replace(/^\/+/, "")}`;
+    }
+    return "/";
+  })();
+
   const {
     title = "Aquakart",
     keywords = "",
     keyphrases = "",
-    url: rawUrl = baseUrl,
+    url: rawUrl,
     description = "",
     follow = true,
     photos,
   } = metaData || {};
 
-  const canonicalUrl = toAbsoluteUrl(baseUrl, rawUrl || baseUrl);
+  const canonicalUrl = toAbsoluteUrl(
+    baseUrl,
+    rawUrl || inferredPath || baseUrl,
+  );
   const photoCandidates = collectImages(photos);
   const primaryImage = photoCandidates[0] || DEFAULT_LOGO;
 

--- a/src/components/reviews/ProductReviews.js
+++ b/src/components/reviews/ProductReviews.js
@@ -16,6 +16,7 @@ import {
 } from "@headlessui/react";
 import ProductServiceOperations from "@/services/products";
 import AquaToast from "@/components/reusables/react-toastify";
+import useDialog from "@/utils/dialog";
 
 const STARS = [1, 2, 3, 4, 5];
 
@@ -284,6 +285,8 @@ const ProductReviews = ({
   const userName =
     userData?.user?.name || userData?.user?.email?.split("@")[0] || "";
 
+  const { openAuthDialog } = useDialog();
+
   const isControlled = Array.isArray(externalReviews);
 
   const [internalReviews, setInternalReviews] = useState([]);
@@ -449,7 +452,16 @@ const ProductReviews = ({
             {existingReview ? "Update your review" : "Write a review"}
           </button>
         ) : (
-          <p className="text-xs text-slate-400">Sign in to leave a review</p>
+          <div className="flex items-center gap-3">
+            <p className="text-xs text-slate-400">Sign in to leave a review</p>
+            <button
+              type="button"
+              onClick={openAuthDialog}
+              className="btn-glass btn-glass-primary !px-4 !py-2 text-xs"
+            >
+              Sign in
+            </button>
+          </div>
         )}
 
         {/* Reviews list + form */}

--- a/src/pageComponents/userDasboard/layout/layout.js
+++ b/src/pageComponents/userDasboard/layout/layout.js
@@ -2,6 +2,7 @@ import AquaUserGreet from "./greet";
 import AquaUserDashboardHeader from "./header";
 import AquaCartAddressDialog from "@/components/common/commonDialogs/cartAddress";
 import { useSelector } from "react-redux";
+import AquaFooter from "@/components/Layout/Footer";
 import { useRouter } from "next/router";
 
 const ROUTE_COPY = {
@@ -32,7 +33,9 @@ const ROUTE_COPY = {
 };
 
 const AquaUserDashbordLayout = ({ children, title, subtitle }) => {
-  const { userData } = useSelector((state) => ({ ...state }));
+  const { userData, dynamicData } = useSelector((state) => ({ ...state }));
+  const categories = dynamicData?.categories || [];
+  const subcategories = dynamicData?.subcategories || [];
   const router = useRouter();
 
   const routeMeta = ROUTE_COPY[router.pathname] || ROUTE_COPY["/dashboard"];
@@ -52,7 +55,7 @@ const AquaUserDashbordLayout = ({ children, title, subtitle }) => {
     return username;
   };
   return (
-    <div className="min-h-screen flex flex-col items-center justify-start">
+    <div className="relative min-h-screen flex flex-col items-center justify-start bg-slate-50">
       <AquaUserDashboardHeader />
       <AquaCartAddressDialog />
       <div className="w-full max-w-5xl px-4">
@@ -72,6 +75,9 @@ const AquaUserDashbordLayout = ({ children, title, subtitle }) => {
           </div>
           <div className="min-h-[60vh]">{children}</div>
         </div>
+      </div>
+      <div className="w-full mt-auto">
+        <AquaFooter categories={categories} subcategories={subcategories} />
       </div>
     </div>
   );


### PR DESCRIPTION
## **User description**
### Motivation

- Add a base ESLint configuration for Next.js Core Web Vitals and switch the project lint script to run `eslint .` to enforce consistent linting. 
- Improve canonical URL generation for pages that may not provide an explicit URL by inferring paths from known page props. 
- Improve UX in the reviews area by offering an explicit sign-in action for unauthenticated users and include the site footer in the user dashboard layout.

### Description

- Added `eslint.config.mjs` that exports `nextVitals` from `eslint-config-next/core-web-vitals` and updated `package.json` to change the `lint` script to `eslint .`.
- In `src/components/Layout/seo/RefactoredSeo.js` added an `inferredPath` computation to derive a sensible path for blogs, products, categories, subcategories, or custom `path`, and updated `canonicalUrl` to use `rawUrl || inferredPath || baseUrl`.
- In `src/components/reviews/ProductReviews.js` imported `useDialog`, extracted `openAuthDialog`, and replaced the static sign-in message with a `Sign in` button that triggers `openAuthDialog` when the user is unauthenticated.
- In `src/pageComponents/userDasboard/layout/layout.js` added `AquaFooter` import, read `dynamicData` from Redux to obtain `categories` and `subcategories`, adjusted container styling, and rendered `AquaFooter` with those props at the bottom of the dashboard layout.

### Testing

- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02e196a52c832da8df3b0ed2034292)


___

## **CodeAnt-AI Description**
**Improve dashboard layout, review sign-in access, and page canonical links**

### What Changed
- The user dashboard now uses a light background and includes the site footer at the bottom of the page.
- Product reviews now show a clickable **Sign in** button for logged-out users instead of only a text prompt.
- Canonical links are now generated from the page’s content when no page URL is provided, covering blogs, products, categories, subcategories, and custom paths.
- Project linting now runs through the standard ESLint command used across the app.

### Impact
`✅ Clearer dashboard pages`
`✅ Easier sign-in from reviews`
`✅ Fewer missing canonical links`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
