### PR TITLE
Redesign user orders and clean invoice PDF

### DIFF
--- a/src/pageComponents/userDasboard/orders.js
+++ b/src/pageComponents/userDasboard/orders.js
@@ -16,26 +16,67 @@ import {
   X,
   Download,
   Loader2,
+  Share2,
+  ExternalLink,
+  Copy,
+  PackageCheck,
+  ReceiptText,
+  Truck,
+  ShoppingBag,
 } from "lucide-react";
 
 const STATUS_TONES = {
-  delivered: "bg-emerald-100 text-emerald-700",
-  processing: "bg-indigo-100 text-indigo-700",
-  pending: "bg-amber-100 text-amber-700",
-  cancelled: "bg-rose-100 text-rose-700",
-  refunded: "bg-sky-100 text-sky-700",
+  delivered: "bg-emerald-100 text-emerald-700 ring-emerald-200",
+  completed: "bg-emerald-100 text-emerald-700 ring-emerald-200",
+  processing: "bg-indigo-100 text-indigo-700 ring-indigo-200",
+  packed: "bg-indigo-100 text-indigo-700 ring-indigo-200",
+  shipped: "bg-sky-100 text-sky-700 ring-sky-200",
+  dispatched: "bg-sky-100 text-sky-700 ring-sky-200",
+  pending: "bg-amber-100 text-amber-700 ring-amber-200",
+  cancelled: "bg-rose-100 text-rose-700 ring-rose-200",
+  refunded: "bg-slate-100 text-slate-700 ring-slate-200",
 };
 
 const PAYMENT_TONES = {
-  cod: "bg-slate-900 text-white",
-  online: "bg-emerald-500 text-white",
+  cod: "bg-slate-950 text-white ring-slate-900",
+  online: "bg-emerald-500 text-white ring-emerald-500",
 };
 
 const PAYMENT_STATUS_TONES = {
-  pending: "bg-amber-100 text-amber-700",
-  completed: "bg-emerald-100 text-emerald-700",
-  failed: "bg-rose-100 text-rose-700",
+  pending: "bg-amber-100 text-amber-700 ring-amber-200",
+  completed: "bg-emerald-100 text-emerald-700 ring-emerald-200",
+  paid: "bg-emerald-100 text-emerald-700 ring-emerald-200",
+  success: "bg-emerald-100 text-emerald-700 ring-emerald-200",
+  failed: "bg-rose-100 text-rose-700 ring-rose-200",
 };
+
+const TIMELINE_STEPS = [
+  {
+    key: "placed",
+    label: "Order placed",
+    description: "We have received your order details",
+  },
+  {
+    key: "processing",
+    label: "Processing",
+    description: "Order is being confirmed and packed",
+  },
+  {
+    key: "shipped",
+    label: "Shipped",
+    description: "Package handed over to delivery partner",
+  },
+  {
+    key: "out_for_delivery",
+    label: "Out for delivery",
+    description: "Courier is on the way to you",
+  },
+  {
+    key: "delivered",
+    label: "Delivered",
+    description: "Order delivered successfully",
+  },
+];
 
 const formatDateLabel = (value) => {
   if (!value) return "—";
@@ -62,14 +103,93 @@ const formatCurrency = (value) => {
 };
 
 const composeAddress = (address = {}) => {
-  if (!address || typeof address !== "object") return "—";
-  return [address.street, address.city, address.state, address.postalCode]
+  if (!address || typeof address !== "object") return "";
+  return [
+    address.street,
+    address.landmark,
+    address.city,
+    address.state,
+    address.postalCode,
+  ]
     .filter(Boolean)
     .map((part) => `${part}`.trim())
     .join(", ");
 };
 
 const toLowerSafe = (value) => `${value || ""}`.toLowerCase();
+
+const getOrderKey = (order) => order?._id || order?.orderId || order?.transactionId;
+
+const getTrackingIdentifier = (order) =>
+  order?.transactionId || order?.orderId || order?._id;
+
+const isCashOrder = (order) =>
+  [order?.orderType, order?.paymentMethod, order?.paymentChipLabel].some(
+    (value) => toLowerSafe(value).includes("cash"),
+  );
+
+const buildTrackingPath = (order) => {
+  const identifier = getTrackingIdentifier(order);
+  if (!identifier) return "/dashboard/orders";
+  const safeId = encodeURIComponent(identifier);
+  return isCashOrder(order) ? `/order/cod/${safeId}` : `/order/${safeId}`;
+};
+
+const buildTrackingLink = (order) => {
+  const baseUrl =
+    typeof window !== "undefined"
+      ? window.location.origin
+      : process.env.NEXT_PUBLIC_URL || "https://aquakart.co.in";
+  return `${baseUrl}${buildTrackingPath(order)}`;
+};
+
+const getOrderItemCount = (order) =>
+  (order?.items || []).reduce(
+    (sum, item) => sum + Number(item?.quantity || 0),
+    0,
+  );
+
+const getTimelineStatusKey = (orderStatus) => {
+  const rawStatus = toLowerSafe(orderStatus);
+
+  if (rawStatus.includes("deliver") || rawStatus.includes("complete")) {
+    return "delivered";
+  }
+  if (rawStatus.includes("out")) {
+    return "out_for_delivery";
+  }
+  if (rawStatus.includes("ship") || rawStatus.includes("dispatch")) {
+    return "shipped";
+  }
+  if (rawStatus.includes("process") || rawStatus.includes("pack")) {
+    return "processing";
+  }
+  return "placed";
+};
+
+const getTimelineSteps = (orderStatus) => {
+  const statusRank = {
+    placed: 0,
+    processing: 1,
+    packed: 1,
+    shipped: 2,
+    dispatched: 2,
+    "out for delivery": 3,
+    out_for_delivery: 3,
+    delivered: 4,
+    completed: 4,
+    cancelled: 0,
+  };
+
+  const currentKey = getTimelineStatusKey(orderStatus);
+  const currentIndex = statusRank[currentKey] ?? 1;
+
+  return TIMELINE_STEPS.map((step, index) => ({
+    ...step,
+    completed: index <= currentIndex,
+    current: index === currentIndex,
+  }));
+};
 
 const AquaOrdersPageComponent = () => {
   const { userData } = useSelector((state) => ({ ...state }));
@@ -81,6 +201,8 @@ const AquaOrdersPageComponent = () => {
   const [authError, setAuthError] = useState(false);
   const [activeTab, setActiveTab] = useState("cod");
   const [trackingOrder, setTrackingOrder] = useState(null);
+  const [copiedTrackingFor, setCopiedTrackingFor] = useState(null);
+  const [sharingFor, setSharingFor] = useState(null);
 
   const userId = userData?.user?._id;
   const token = userData?.token;
@@ -88,7 +210,6 @@ const AquaOrdersPageComponent = () => {
   const [pdfReady, setPdfReady] = useState(false);
   const [generatingFor, setGeneratingFor] = useState(null);
 
-  // Load jsPDF once on mount
   useEffect(() => {
     loadJsPDF().then(setPdfReady);
   }, []);
@@ -96,7 +217,7 @@ const AquaOrdersPageComponent = () => {
   const handleDownloadInvoice = useCallback(
     async (order) => {
       if (!order) return;
-      const orderId = order?._id || order?.orderId;
+      const orderId = getOrderKey(order);
       setGeneratingFor(orderId);
       try {
         if (!pdfReady) {
@@ -118,6 +239,51 @@ const AquaOrdersPageComponent = () => {
     [pdfReady],
   );
 
+  const handleShareTracking = useCallback(async (order) => {
+    if (!order) return;
+
+    const orderKey = getOrderKey(order);
+    const trackingLink = buildTrackingLink(order);
+    const sharePayload = {
+      title: "Aquakart order tracking",
+      text: `Track Aquakart order #${
+        order?.orderId || order?.transactionId || "order"
+      }`,
+      url: trackingLink,
+    };
+
+    setSharingFor(orderKey);
+
+    try {
+      if (navigator?.share) {
+        await navigator.share(sharePayload);
+      } else if (navigator?.clipboard?.writeText) {
+        await navigator.clipboard.writeText(trackingLink);
+      } else {
+        window.prompt("Copy your tracking link", trackingLink);
+      }
+
+      setCopiedTrackingFor(orderKey);
+      window.setTimeout(() => {
+        setCopiedTrackingFor((current) =>
+          current === orderKey ? null : current,
+        );
+      }, 2500);
+    } catch (shareError) {
+      if (shareError?.name !== "AbortError") {
+        try {
+          await navigator?.clipboard?.writeText?.(trackingLink);
+          setCopiedTrackingFor(orderKey);
+        } catch (clipboardError) {
+          console.error("Tracking link share failed:", clipboardError);
+          window.prompt("Copy your tracking link", trackingLink);
+        }
+      }
+    } finally {
+      setSharingFor(null);
+    }
+  }, []);
+
   const handleReLogin = () => {
     dispatch({ type: "LOGOUT", payload: null });
     router.push("/");
@@ -138,9 +304,7 @@ const AquaOrdersPageComponent = () => {
         );
 
         if (!isMounted) return;
-        const fetchedOrders = Array.isArray(response?.data)
-          ? response.data
-          : [];
+        const fetchedOrders = Array.isArray(response?.data) ? response.data : [];
         setOrders(fetchedOrders);
       } catch (fetchError) {
         if (!isMounted) return;
@@ -171,32 +335,44 @@ const AquaOrdersPageComponent = () => {
 
   const resolvedOrders = useMemo(
     () =>
-      orders.map((order) => ({
-        ...order,
-        paymentChipTone: toLowerSafe(order?.orderType).includes(
-          "cash on delivery",
-        )
-          ? PAYMENT_TONES.cod
-          : PAYMENT_TONES.online,
-        paymentChipLabel: toLowerSafe(order?.orderType).includes(
-          "cash on delivery",
-        )
-          ? "Cash on delivery"
-          : "Prepaid",
-        paymentStatusTone:
-          PAYMENT_STATUS_TONES[toLowerSafe(order?.paymentStatus)] ||
-          PAYMENT_STATUS_TONES.pending,
-        orderStatusTone:
-          STATUS_TONES[toLowerSafe(order?.orderStatus)] ||
-          STATUS_TONES.processing,
-        addressLabel:
-          composeAddress(order?.shippingAddress) ||
-          composeAddress(order?.billingAddress),
-        orderedOn: formatDateLabel(order?.createdAt),
-        deliveryEta: formatDateLabel(order?.estimatedDelivery),
-        totalLabel: formatCurrency(order?.totalAmount),
-        items: Array.isArray(order?.items) ? order.items : [],
-      })),
+      orders
+        .map((order) => {
+          const paymentLabel = isCashOrder(order)
+            ? "Cash on delivery"
+            : "Prepaid";
+          const lowerPaymentStatus = toLowerSafe(order?.paymentStatus);
+          const lowerOrderStatus = toLowerSafe(order?.orderStatus);
+          const addressLabel =
+            composeAddress(order?.shippingAddress) ||
+            composeAddress(order?.billingAddress);
+
+          return {
+            ...order,
+            paymentChipTone: isCashOrder(order)
+              ? PAYMENT_TONES.cod
+              : PAYMENT_TONES.online,
+            paymentChipLabel: paymentLabel,
+            paymentStatusTone:
+              PAYMENT_STATUS_TONES[lowerPaymentStatus] ||
+              PAYMENT_STATUS_TONES.pending,
+            orderStatusTone:
+              STATUS_TONES[lowerOrderStatus] || STATUS_TONES.processing,
+            addressLabel,
+            orderedOn: formatDateLabel(order?.createdAt),
+            deliveryEta: formatDateLabel(order?.estimatedDelivery),
+            totalLabel: formatCurrency(order?.totalAmount),
+            items: Array.isArray(order?.items) ? order.items : [],
+            itemCount: getOrderItemCount(order),
+            trackingPath: buildTrackingPath({
+              ...order,
+              paymentChipLabel: paymentLabel,
+            }),
+          };
+        })
+        .sort(
+          (a, b) =>
+            new Date(b?.createdAt || 0) - new Date(a?.createdAt || 0),
+        ),
     [orders],
   );
 
@@ -241,7 +417,7 @@ const AquaOrdersPageComponent = () => {
       label: "Total orders",
       value: resolvedOrders.length,
       icon: ClipboardList,
-      tone: "bg-slate-100 text-slate-700",
+      tone: "bg-slate-950 text-white",
     },
     {
       label: "Cash on delivery",
@@ -266,113 +442,58 @@ const AquaOrdersPageComponent = () => {
   const activeOrders =
     activeTab === "online" ? resolvedOnlineOrders : resolvedCodOrders;
 
-  const timelineSteps = useMemo(() => {
-    if (!trackingOrder) return [];
-
-    const TIMELINE_STEPS = [
-      {
-        key: "placed",
-        label: "Order placed",
-        description: "We have received your order details",
-      },
-      {
-        key: "processing",
-        label: "Processing",
-        description: "Order is being confirmed and packed",
-      },
-      {
-        key: "shipped",
-        label: "Shipped",
-        description: "Package handed over to delivery partner",
-      },
-      {
-        key: "out_for_delivery",
-        label: "Out for delivery",
-        description: "Courier is on the way to you",
-      },
-      {
-        key: "delivered",
-        label: "Delivered",
-        description: "Order delivered successfully",
-      },
-    ];
-
-    const statusRank = {
-      placed: 0,
-      processing: 1,
-      packed: 1,
-      shipped: 2,
-      dispatched: 2,
-      "out for delivery": 3,
-      out_for_delivery: 3,
-      delivered: 4,
-      cancelled: 4,
-    };
-
-    const rawStatus = toLowerSafe(trackingOrder?.orderStatus);
-    let statusKey = "placed";
-
-    if (rawStatus.includes("deliver")) {
-      statusKey = "delivered";
-    } else if (rawStatus.includes("out")) {
-      statusKey = "out_for_delivery";
-    } else if (rawStatus.includes("ship") || rawStatus.includes("dispatch")) {
-      statusKey = "shipped";
-    } else if (rawStatus.includes("process") || rawStatus.includes("pack")) {
-      statusKey = "processing";
-    }
-
-    const currentIndex = statusRank[statusKey] ?? 1;
-
-    return TIMELINE_STEPS.map((step, index) => ({
-      ...step,
-      completed: index <= currentIndex,
-      current: index === currentIndex,
-    }));
-  }, [trackingOrder]);
+  const timelineSteps = useMemo(
+    () => (trackingOrder ? getTimelineSteps(trackingOrder?.orderStatus) : []),
+    [trackingOrder],
+  );
 
   return (
     <AquaUserDashbordLayout>
       <div className="space-y-8">
-        <section className="rounded-3xl border border-slate-100 bg-white p-6 shadow-sm">
-          <div className="flex flex-col gap-2">
-            <h1 className="text-xl font-semibold text-slate-900">
-              Your orders
-            </h1>
-            <p className="text-sm text-slate-500">
-              Track payments, delivery progress, and keep an eye on pending
-              actions.
-            </p>
-          </div>
+        <section className="relative overflow-hidden rounded-[2rem] border border-white/70 bg-gradient-to-br from-white via-emerald-50/80 to-white p-5 shadow-sm sm:p-6">
+          <div className="absolute -right-12 -top-14 h-40 w-40 rounded-full bg-emerald-200/30 blur-3xl" />
+          <div className="relative flex flex-col gap-5 lg:flex-row lg:items-end lg:justify-between">
+            <div className="max-w-xl">
+              <span className="inline-flex items-center gap-2 rounded-full bg-emerald-100 px-3 py-1 text-xs font-bold uppercase tracking-[0.22em] text-emerald-700">
+                <PackageCheck className="h-3.5 w-3.5" />
+                Order centre
+              </span>
+              <h1 className="mt-4 text-2xl font-bold text-slate-950 sm:text-3xl">
+                Your orders, invoices & tracking
+              </h1>
+              <p className="mt-2 text-sm leading-6 text-slate-500">
+                Share tracking links, download clean GST invoices, and view every
+                order with less clutter.
+              </p>
+            </div>
 
-          <div className="mt-6 grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
-            {paymentSummaryCards.map(({ label, value, icon: Icon, tone }) => (
-              <div
-                key={label}
-                className="flex items-center gap-3 rounded-2xl border border-slate-100 bg-slate-50/60 p-4"
-              >
-                <span
-                  className={`flex h-12 w-12 items-center justify-center rounded-full ${tone}`}
+            <div className="grid grid-cols-2 gap-3 sm:grid-cols-4 lg:min-w-[520px]">
+              {paymentSummaryCards.map(({ label, value, icon: Icon, tone }) => (
+                <div
+                  key={label}
+                  className="rounded-2xl border border-white/70 bg-white/80 p-4 shadow-sm"
                 >
-                  <Icon className="h-6 w-6" aria-hidden="true" />
-                </span>
-                <div>
-                  <p className="text-sm text-slate-500">{label}</p>
-                  <p className="text-lg font-semibold text-slate-900">
-                    {value}
+                  <span
+                    className={`flex h-10 w-10 items-center justify-center rounded-2xl ${tone}`}
+                  >
+                    <Icon className="h-5 w-5" aria-hidden="true" />
+                  </span>
+                  <p className="mt-3 text-xs font-medium text-slate-500">
+                    {label}
                   </p>
+                  <p className="text-xl font-bold text-slate-950">{value}</p>
                 </div>
-              </div>
-            ))}
+              ))}
+            </div>
           </div>
         </section>
 
         {loading ? (
-          <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
-            {Array.from({ length: 3 }).map((_, index) => (
+          <div className="grid gap-4 lg:grid-cols-2">
+            {Array.from({ length: 4 }).map((_, index) => (
               <div
                 key={index}
-                className="h-64 animate-pulse rounded-3xl border border-slate-100 bg-white/60"
+                className="h-72 animate-pulse rounded-[1.75rem] border border-slate-100 bg-white/60"
               />
             ))}
           </div>
@@ -404,29 +525,41 @@ const AquaOrdersPageComponent = () => {
           </div>
         ) : (
           <>
-            <div className="flex flex-wrap items-center gap-3">
-              <button
-                type="button"
-                onClick={() => setActiveTab("cod")}
-                className={`inline-flex items-center gap-2 rounded-full px-4 py-2 text-sm font-semibold transition focus:outline-none focus:ring-2 focus:ring-offset-1 ${
-                  activeTab === "cod"
-                    ? "bg-emerald-500 text-white focus:ring-emerald-500"
-                    : "bg-slate-100 text-slate-600 hover:bg-slate-200 focus:ring-slate-300"
-                }`}
-              >
-                Cash on delivery ({resolvedCodOrders.length})
-              </button>
-              <button
-                type="button"
-                onClick={() => setActiveTab("online")}
-                className={`inline-flex items-center gap-2 rounded-full px-4 py-2 text-sm font-semibold transition focus:outline-none focus:ring-2 focus:ring-offset-1 ${
-                  activeTab === "online"
-                    ? "bg-indigo-500 text-white focus:ring-indigo-500"
-                    : "bg-slate-100 text-slate-600 hover:bg-slate-200 focus:ring-slate-300"
-                }`}
-              >
-                Prepaid / gateway ({resolvedOnlineOrders.length})
-              </button>
+            <div className="flex flex-col gap-3 rounded-3xl border border-slate-100 bg-white p-3 shadow-sm sm:flex-row sm:items-center sm:justify-between">
+              <div className="px-2">
+                <p className="text-sm font-semibold text-slate-900">
+                  Filter orders
+                </p>
+                <p className="text-xs text-slate-500">
+                  Separate COD and prepaid orders for quick scanning.
+                </p>
+              </div>
+              <div className="grid grid-cols-2 gap-2 rounded-2xl bg-slate-100 p-1">
+                <button
+                  type="button"
+                  onClick={() => setActiveTab("cod")}
+                  className={`inline-flex items-center justify-center gap-2 rounded-xl px-4 py-2 text-sm font-semibold transition ${
+                    activeTab === "cod"
+                      ? "bg-white text-slate-950 shadow-sm"
+                      : "text-slate-500 hover:text-slate-800"
+                  }`}
+                >
+                  <Banknote className="h-4 w-4" />
+                  COD ({resolvedCodOrders.length})
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setActiveTab("online")}
+                  className={`inline-flex items-center justify-center gap-2 rounded-xl px-4 py-2 text-sm font-semibold transition ${
+                    activeTab === "online"
+                      ? "bg-white text-slate-950 shadow-sm"
+                      : "text-slate-500 hover:text-slate-800"
+                  }`}
+                >
+                  <Wallet className="h-4 w-4" />
+                  Prepaid ({resolvedOnlineOrders.length})
+                </button>
+              </div>
             </div>
 
             {activeOrders.length === 0 ? (
@@ -434,140 +567,197 @@ const AquaOrdersPageComponent = () => {
                 No orders found under this category yet.
               </div>
             ) : (
-              <div className="grid gap-6 lg:grid-cols-2 2xl:grid-cols-3">
-                {activeOrders.map((order) => (
-                  <article
-                    key={order?._id || order?.orderId}
-                    className="flex h-full flex-col gap-5 rounded-3xl border border-slate-100 bg-white p-6 shadow-sm"
-                  >
-                    <header className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-                      <div>
-                        <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">
-                          Order ID
-                        </p>
-                        <h2 className="text-lg font-semibold text-slate-900">
-                          #{order?.orderId || "—"}
-                        </h2>
-                      </div>
-                      <div className="flex flex-wrap gap-2">
-                        <span
-                          className={`inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-semibold capitalize ${order.paymentChipTone}`}
-                        >
-                          {order.paymentChipLabel}
-                        </span>
-                        <span
-                          className={`inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-semibold capitalize ${order.paymentStatusTone}`}
-                        >
-                          {order?.paymentStatus || "Pending"}
-                        </span>
-                        <span
-                          className={`inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-semibold capitalize ${order.orderStatusTone}`}
-                        >
-                          {order?.orderStatus || "Processing"}
-                        </span>
-                      </div>
-                    </header>
+              <div className="grid gap-5 lg:grid-cols-2">
+                {activeOrders.map((order) => {
+                  const orderKey = getOrderKey(order);
+                  const isGenerating = generatingFor === orderKey;
+                  const isSharing = sharingFor === orderKey;
+                  const isCopied = copiedTrackingFor === orderKey;
+                  const cardTimeline = getTimelineSteps(order?.orderStatus);
 
-                    <div className="space-y-3 rounded-2xl border border-slate-100 bg-slate-50/70 p-4">
-                      <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">
-                        Items (
-                        {order.items.reduce(
-                          (sum, item) => sum + (item?.quantity || 0),
-                          0,
-                        )}
-                        )
-                      </p>
-                      <ul className="space-y-2">
-                        {order.items.slice(0, 3).map((item) => (
-                          <li
-                            key={item?._id || item?.productId}
-                            className="flex items-center justify-between text-sm text-slate-600"
+                  return (
+                    <article
+                      key={orderKey}
+                      className="group flex h-full flex-col overflow-hidden rounded-[1.75rem] border border-slate-100 bg-white shadow-sm ring-1 ring-white/80 transition duration-200 hover:-translate-y-0.5 hover:shadow-xl"
+                    >
+                      <header className="bg-gradient-to-br from-slate-950 via-slate-900 to-emerald-950 p-5 text-white">
+                        <div className="flex items-start justify-between gap-4">
+                          <div className="min-w-0">
+                            <p className="text-xs font-semibold uppercase tracking-[0.2em] text-emerald-200">
+                              Order ID
+                            </p>
+                            <h2 className="mt-1 truncate text-xl font-bold">
+                              #{order?.orderId || "—"}
+                            </h2>
+                            <p className="mt-2 flex items-center gap-2 text-xs text-slate-300">
+                              <CalendarClock className="h-3.5 w-3.5" />
+                              {order.orderedOn}
+                            </p>
+                          </div>
+
+                          <div className="rounded-2xl bg-white/10 px-4 py-3 text-right backdrop-blur">
+                            <p className="text-xs text-emerald-100">
+                              Paid / Payable
+                            </p>
+                            <p className="text-lg font-bold">{order.totalLabel}</p>
+                          </div>
+                        </div>
+
+                        <div className="mt-5 grid grid-cols-5 gap-2">
+                          {cardTimeline.map((step) => (
+                            <div
+                              key={step.key}
+                              className={`h-1.5 rounded-full ${
+                                step.completed ? "bg-emerald-300" : "bg-white/20"
+                              }`}
+                              title={step.label}
+                            />
+                          ))}
+                        </div>
+                      </header>
+
+                      <div className="flex flex-1 flex-col gap-4 p-5">
+                        <div className="flex flex-wrap gap-2">
+                          <span
+                            className={`inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-bold capitalize ring-1 ${order.paymentChipTone}`}
                           >
-                            <span className="line-clamp-1 pr-3 font-medium text-slate-700">
-                              {item?.name || "Product"}
-                            </span>
-                            <span className="whitespace-nowrap text-slate-500">
-                              ×{item?.quantity || 1}
-                            </span>
-                          </li>
-                        ))}
-                      </ul>
-                      {order.items.length > 3 ? (
-                        <p className="text-xs text-slate-500">
-                          + {order.items.length - 3} more item(s)
-                        </p>
-                      ) : null}
-                    </div>
+                            {order.paymentChipLabel}
+                          </span>
+                          <span
+                            className={`inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-bold capitalize ring-1 ${order.paymentStatusTone}`}
+                          >
+                            {order?.paymentStatus || "Pending"}
+                          </span>
+                          <span
+                            className={`inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-bold capitalize ring-1 ${order.orderStatusTone}`}
+                          >
+                            {order?.orderStatus || "Processing"}
+                          </span>
+                        </div>
 
-                    <div className="grid gap-4 sm:grid-cols-2">
-                      <div className="flex flex-col gap-1">
-                        <span className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-slate-500">
-                          <ClipboardList className="h-3.5 w-3.5" /> Ordered on
-                        </span>
-                        <span className="text-sm font-medium text-slate-700">
-                          {order.orderedOn}
-                        </span>
-                      </div>
-                      <div className="flex flex-col gap-1">
-                        <span className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-slate-500">
-                          <CalendarClock className="h-3.5 w-3.5" /> ETA
-                        </span>
-                        <span className="text-sm font-medium text-slate-700">
-                          {order.deliveryEta}
-                        </span>
-                      </div>
-                    </div>
+                        <div className="grid gap-3 sm:grid-cols-3">
+                          <div className="rounded-2xl bg-slate-50 p-3">
+                            <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">
+                              Items
+                            </p>
+                            <p className="mt-1 text-sm font-bold text-slate-900">
+                              {order.itemCount || order.items.length} item(s)
+                            </p>
+                          </div>
+                          <div className="rounded-2xl bg-slate-50 p-3">
+                            <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">
+                              ETA
+                            </p>
+                            <p className="mt-1 text-sm font-bold text-slate-900">
+                              {order.deliveryEta}
+                            </p>
+                          </div>
+                          <div className="rounded-2xl bg-slate-50 p-3">
+                            <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">
+                              Link
+                            </p>
+                            <button
+                              type="button"
+                              onClick={() => handleShareTracking(order)}
+                              className="mt-1 inline-flex items-center gap-1 text-sm font-bold text-emerald-700 hover:text-emerald-800"
+                            >
+                              <Share2 className="h-3.5 w-3.5" />
+                              {isCopied ? "Copied" : "Share"}
+                            </button>
+                          </div>
+                        </div>
 
-                    <div className="flex flex-col gap-1">
-                      <span className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-slate-500">
-                        <MapPin className="h-3.5 w-3.5" /> Deliver to
-                      </span>
-                      <span className="text-sm text-slate-600">
-                        {order.addressLabel}
-                      </span>
-                    </div>
+                        <div className="rounded-2xl border border-slate-100 bg-slate-50/70 p-4">
+                          <div className="mb-3 flex items-center justify-between gap-3">
+                            <p className="flex items-center gap-2 text-xs font-bold uppercase tracking-wide text-slate-500">
+                              <ShoppingBag className="h-4 w-4" />
+                              Items ordered
+                            </p>
+                            {order.items.length > 2 ? (
+                              <span className="rounded-full bg-white px-2.5 py-1 text-xs font-semibold text-slate-500">
+                                +{order.items.length - 2} more
+                              </span>
+                            ) : null}
+                          </div>
+                          <ul className="space-y-2">
+                            {order.items.slice(0, 2).map((item) => (
+                              <li
+                                key={item?._id || item?.productId || item?.name}
+                                className="flex items-center justify-between gap-3 text-sm"
+                              >
+                                <span className="line-clamp-1 font-semibold text-slate-800">
+                                  {item?.name || "Product"}
+                                </span>
+                                <span className="whitespace-nowrap rounded-full bg-white px-2.5 py-1 text-xs font-bold text-slate-600">
+                                  ×{item?.quantity || 1}
+                                </span>
+                              </li>
+                            ))}
+                          </ul>
+                        </div>
 
-                    <footer className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                      <div className="text-sm font-semibold text-slate-900">
-                        Total payable:{" "}
-                        <span className="text-lg">{order.totalLabel}</span>
+                        <div className="flex gap-3 rounded-2xl border border-emerald-100 bg-emerald-50/60 p-4">
+                          <MapPin className="mt-0.5 h-4 w-4 shrink-0 text-emerald-700" />
+                          <div>
+                            <p className="text-xs font-bold uppercase tracking-wide text-emerald-700">
+                              Deliver to
+                            </p>
+                            <p className="mt-1 line-clamp-2 text-sm leading-6 text-slate-600">
+                              {order.addressLabel || "Address not available"}
+                            </p>
+                          </div>
+                        </div>
+
+                        <footer className="mt-auto grid gap-2 sm:grid-cols-3">
+                          <button
+                            type="button"
+                            onClick={() => setTrackingOrder(order)}
+                            className="inline-flex items-center justify-center gap-2 rounded-2xl border border-slate-200 px-4 py-2.5 text-sm font-bold text-slate-700 transition hover:border-emerald-200 hover:bg-emerald-50 hover:text-emerald-700"
+                          >
+                            <Truck className="h-4 w-4" />
+                            Track
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => router.push(order.trackingPath)}
+                            className="inline-flex items-center justify-center gap-2 rounded-2xl border border-slate-200 px-4 py-2.5 text-sm font-bold text-slate-700 transition hover:border-emerald-200 hover:bg-emerald-50 hover:text-emerald-700"
+                          >
+                            <ExternalLink className="h-4 w-4" />
+                            Open
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => handleDownloadInvoice(order)}
+                            disabled={isGenerating}
+                            className={`inline-flex items-center justify-center gap-2 rounded-2xl px-4 py-2.5 text-sm font-bold transition ${
+                              isGenerating
+                                ? "cursor-wait bg-slate-100 text-slate-400"
+                                : "bg-slate-950 text-white hover:bg-slate-800"
+                            }`}
+                          >
+                            {isGenerating ? (
+                              <>
+                                <Loader2 className="h-4 w-4 animate-spin" />
+                                PDF
+                              </>
+                            ) : (
+                              <>
+                                <Download className="h-4 w-4" />
+                                Invoice
+                              </>
+                            )}
+                          </button>
+                        </footer>
+
+                        {isSharing ? (
+                          <p className="text-center text-xs font-medium text-slate-400">
+                            Preparing share link...
+                          </p>
+                        ) : null}
                       </div>
-                      <div className="flex flex-wrap gap-2">
-                        <button
-                          type="button"
-                          onClick={() => setTrackingOrder(order)}
-                          className="inline-flex items-center gap-2 rounded-full border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-600 transition hover:border-emerald-200 hover:bg-emerald-50 hover:text-emerald-600"
-                        >
-                          Track order
-                        </button>
-                        <button
-                          type="button"
-                          onClick={() => handleDownloadInvoice(order)}
-                          disabled={
-                            generatingFor === (order?._id || order?.orderId)
-                          }
-                          className={`inline-flex items-center gap-2 rounded-full border px-4 py-2 text-sm font-semibold transition ${
-                            generatingFor === (order?._id || order?.orderId)
-                              ? "cursor-wait border-slate-100 bg-slate-50 text-slate-400"
-                              : "border-slate-200 text-slate-600 hover:border-emerald-200 hover:bg-emerald-50 hover:text-emerald-600"
-                          }`}
-                        >
-                          {generatingFor === (order?._id || order?.orderId) ? (
-                            <>
-                              <Loader2 className="h-4 w-4 animate-spin" />
-                              Preparing...
-                            </>
-                          ) : (
-                            <>
-                              <Download className="h-4 w-4" />
-                              Download invoice
-                            </>
-                          )}
-                        </button>
-                      </div>
-                    </footer>
-                  </article>
-                ))}
+                    </article>
+                  );
+                })}
               </div>
             )}
           </>
@@ -575,49 +765,91 @@ const AquaOrdersPageComponent = () => {
       </div>
 
       {trackingOrder ? (
-        <div className="fixed inset-0 z-50 flex items-end justify-center bg-slate-900/40 px-4 pb-6 pt-10 sm:items-center">
-          <div className="relative w-full max-w-2xl rounded-3xl bg-white shadow-2xl">
+        <div className="fixed inset-0 z-50 flex items-end justify-center bg-slate-950/50 px-4 pb-6 pt-10 backdrop-blur-sm sm:items-center">
+          <div className="relative max-h-[92vh] w-full max-w-3xl overflow-y-auto rounded-[2rem] bg-white shadow-2xl">
             <button
               type="button"
               onClick={() => setTrackingOrder(null)}
-              className="absolute right-4 top-4 rounded-full bg-slate-100 p-2 text-slate-500 transition hover:bg-slate-200 hover:text-slate-700"
+              className="absolute right-4 top-4 z-10 rounded-full bg-white/90 p-2 text-slate-500 shadow-sm transition hover:bg-white hover:text-slate-700"
               aria-label="Close tracking dialog"
             >
               <X className="h-4 w-4" />
             </button>
 
-            <div className="flex flex-col gap-6 p-6 md:p-8">
-              <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+            <div className="bg-gradient-to-br from-slate-950 via-slate-900 to-emerald-950 p-6 text-white md:p-8">
+              <p className="text-xs font-semibold uppercase tracking-[0.24em] text-emerald-200">
+                Tracking order
+              </p>
+              <div className="mt-3 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
                 <div>
-                  <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">
-                    Tracking order
-                  </p>
-                  <h2 className="text-lg font-semibold text-slate-900">
+                  <h2 className="text-2xl font-bold">
                     #{trackingOrder?.orderId || "—"}
                   </h2>
+                  <p className="mt-1 text-sm text-slate-300">
+                    {trackingOrder?.itemCount ||
+                      trackingOrder?.items?.length ||
+                      0}{" "}
+                    item(s) • {trackingOrder?.totalLabel}
+                  </p>
                 </div>
                 <div className="flex flex-wrap gap-2">
-                  <span className="inline-flex items-center gap-2 rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-700">
+                  <span className="inline-flex items-center gap-2 rounded-full bg-white/10 px-3 py-1 text-xs font-bold text-white ring-1 ring-white/15">
                     Payment: {trackingOrder?.paymentStatus || "Pending"}
                   </span>
-                  <span className="inline-flex items-center gap-2 rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-700">
+                  <span className="inline-flex items-center gap-2 rounded-full bg-white/10 px-3 py-1 text-xs font-bold text-white ring-1 ring-white/15">
                     Method:{" "}
                     {trackingOrder?.orderType ||
                       trackingOrder?.paymentMethod ||
+                      trackingOrder?.paymentChipLabel ||
                       "—"}
                   </span>
                 </div>
               </div>
+            </div>
 
-              <div className="rounded-2xl border border-slate-100 bg-slate-50/70 p-4">
-                <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+            <div className="flex flex-col gap-6 p-6 md:p-8">
+              <div className="rounded-2xl border border-emerald-100 bg-emerald-50/60 p-4">
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                  <div className="min-w-0">
+                    <p className="text-xs font-bold uppercase tracking-wide text-emerald-700">
+                      Shareable tracking link
+                    </p>
+                    <p className="mt-1 truncate text-sm text-slate-600">
+                      {buildTrackingLink(trackingOrder)}
+                    </p>
+                  </div>
+                  <div className="flex gap-2">
+                    <button
+                      type="button"
+                      onClick={() => handleShareTracking(trackingOrder)}
+                      className="inline-flex items-center justify-center gap-2 rounded-full bg-emerald-600 px-4 py-2 text-sm font-bold text-white transition hover:bg-emerald-700"
+                    >
+                      <Share2 className="h-4 w-4" />
+                      {copiedTrackingFor === getOrderKey(trackingOrder)
+                        ? "Copied"
+                        : "Share"}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => router.push(buildTrackingPath(trackingOrder))}
+                      className="inline-flex items-center justify-center gap-2 rounded-full border border-emerald-200 bg-white px-4 py-2 text-sm font-bold text-emerald-700 transition hover:bg-emerald-50"
+                    >
+                      <ExternalLink className="h-4 w-4" />
+                      Open
+                    </button>
+                  </div>
+                </div>
+              </div>
+
+              <div className="rounded-2xl border border-slate-100 bg-slate-50/80 p-4">
+                <p className="text-xs font-bold uppercase tracking-wide text-slate-500">
                   Delivery timeline
                 </p>
                 <ol className="mt-4 space-y-4">
                   {timelineSteps.map((step) => (
                     <li key={step.key} className="flex items-start gap-4">
                       <span
-                        className={`mt-0.5 flex h-6 w-6 items-center justify-center rounded-full ${
+                        className={`mt-0.5 flex h-7 w-7 items-center justify-center rounded-full ${
                           step.completed
                             ? "bg-emerald-500 text-white"
                             : "bg-slate-200 text-slate-500"
@@ -630,10 +862,10 @@ const AquaOrdersPageComponent = () => {
                         )}
                       </span>
                       <div>
-                        <p className="text-sm font-semibold text-slate-900">
+                        <p className="text-sm font-bold text-slate-900">
                           {step.label}
                         </p>
-                        <p className="text-xs text-slate-500">
+                        <p className="text-xs leading-5 text-slate-500">
                           {step.description}
                         </p>
                       </div>
@@ -644,10 +876,11 @@ const AquaOrdersPageComponent = () => {
 
               <div className="grid gap-4 sm:grid-cols-2">
                 <div className="rounded-2xl border border-slate-100 bg-white p-4">
-                  <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                  <p className="flex items-center gap-2 text-xs font-bold uppercase tracking-wide text-slate-500">
+                    <CalendarClock className="h-4 w-4" />
                     Estimated delivery
                   </p>
-                  <p className="mt-1 text-sm font-semibold text-slate-800">
+                  <p className="mt-2 text-sm font-bold text-slate-800">
                     {formatDateLabel(trackingOrder?.estimatedDelivery)}
                   </p>
                   <p className="text-xs text-slate-500">
@@ -655,27 +888,44 @@ const AquaOrdersPageComponent = () => {
                   </p>
                 </div>
                 <div className="rounded-2xl border border-slate-100 bg-white p-4">
-                  <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                  <p className="flex items-center gap-2 text-xs font-bold uppercase tracking-wide text-slate-500">
+                    <MapPin className="h-4 w-4" />
                     Delivering to
                   </p>
-                  <p className="mt-1 text-sm text-slate-700">
+                  <p className="mt-2 text-sm leading-6 text-slate-700">
                     {composeAddress(trackingOrder?.shippingAddress) ||
-                      composeAddress(trackingOrder?.billingAddress)}
+                      composeAddress(trackingOrder?.billingAddress) ||
+                      "Address not available"}
                   </p>
                 </div>
               </div>
 
-              <div className="flex flex-wrap gap-2">
+              <div className="flex flex-wrap justify-end gap-2">
                 <button
                   type="button"
-                  className="inline-flex items-center gap-2 rounded-full border border-slate-300 px-4 py-2 text-sm font-semibold text-slate-600 transition hover:border-slate-400 hover:bg-slate-50"
+                  onClick={() => {
+                    navigator?.clipboard?.writeText?.(
+                      buildTrackingLink(trackingOrder),
+                    );
+                    setCopiedTrackingFor(getOrderKey(trackingOrder));
+                  }}
+                  className="inline-flex items-center gap-2 rounded-full border border-slate-300 px-4 py-2 text-sm font-bold text-slate-600 transition hover:border-slate-400 hover:bg-slate-50"
                 >
-                  Share tracking link
+                  <Copy className="h-4 w-4" />
+                  Copy link
+                </button>
+                <button
+                  type="button"
+                  onClick={() => handleDownloadInvoice(trackingOrder)}
+                  className="inline-flex items-center gap-2 rounded-full border border-slate-300 px-4 py-2 text-sm font-bold text-slate-600 transition hover:border-slate-400 hover:bg-slate-50"
+                >
+                  <ReceiptText className="h-4 w-4" />
+                  Invoice PDF
                 </button>
                 <button
                   type="button"
                   onClick={() => setTrackingOrder(null)}
-                  className="inline-flex items-center gap-2 rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white transition hover:bg-slate-800"
+                  className="inline-flex items-center gap-2 rounded-full bg-slate-950 px-4 py-2 text-sm font-bold text-white transition hover:bg-slate-800"
                 >
                   Close
                 </button>

--- a/src/utils/invoice.js
+++ b/src/utils/invoice.js
@@ -1,4 +1,4 @@
-const INVOICE_WATERMARK_URL =
+const AQUAKART_LOGO_URL =
   "https://res.cloudinary.com/aquakartproducts/image/upload/v1695408027/android-chrome-384x384_ijvo24.png";
 const GST_RATE = 0.18;
 
@@ -8,6 +8,14 @@ const roundToTwo = (value) =>
 const toNumber = (value, fallback = 0) => {
   const parsed = Number(value);
   return Number.isFinite(parsed) ? parsed : fallback;
+};
+
+const firstFiniteNumber = (values) => {
+  for (const value of values) {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return null;
 };
 
 const resolveAmountPaid = (order, fallbackAmount) => {
@@ -29,12 +37,13 @@ const resolveAmountPaid = (order, fallbackAmount) => {
   return roundToTwo(toNumber(fallbackAmount, 0));
 };
 
-const fmt = (v) =>
-  new Intl.NumberFormat("en-IN", {
-    style: "currency",
-    currency: "INR",
+const fmt = (value) => {
+  const amount = roundToTwo(toNumber(value, 0)).toLocaleString("en-IN", {
     minimumFractionDigits: 2,
-  }).format(roundToTwo(toNumber(v, 0)));
+    maximumFractionDigits: 2,
+  });
+  return `INR ${amount}`;
+};
 
 const loadImageAsDataURL = (url) =>
   new Promise((resolve) => {
@@ -67,7 +76,29 @@ const composeAddressLines = (address) => {
     [city, state].filter(Boolean).join(", "),
     postalCode,
     country,
-  ].filter(Boolean);
+  ]
+    .map((line) => (line ? `${line}`.trim() : ""))
+    .filter(Boolean);
+};
+
+const writeWrappedLines = (doc, lines, x, y, width, lineGap = 12) => {
+  let cursorY = y;
+  lines.forEach((line) => {
+    const wrapped = doc.splitTextToSize(String(line), width);
+    doc.text(wrapped, x, cursorY, { lineHeightFactor: 1.25 });
+    cursorY += wrapped.length * lineGap;
+  });
+  return cursorY;
+};
+
+const drawRoundedCard = (doc, x, y, w, h, fill, stroke) => {
+  doc.setFillColor(...fill);
+  doc.roundedRect(x, y, w, h, 10, 10, "F");
+  if (stroke) {
+    doc.setDrawColor(...stroke);
+    doc.setLineWidth(0.8);
+    doc.roundedRect(x, y, w, h, 10, 10, "S");
+  }
 };
 
 /**
@@ -86,28 +117,34 @@ export const generateInvoicePDF = async (order) => {
   const doc = new jsPDFConstructor({ unit: "pt", format: "a4" });
   const W = doc.internal.pageSize.getWidth();
   const H = doc.internal.pageSize.getHeight();
-  const M = 44;
+  const M = 42;
   const TW = W - M * 2;
   const F = "helvetica";
 
-  // Colours
   const BRAND = [16, 185, 129];
   const BRAND_DARK = [6, 95, 70];
+  const BRAND_DEEP = [4, 120, 87];
+  const SLATE_950 = [2, 6, 23];
   const SLATE_900 = [15, 23, 42];
+  const SLATE_700 = [51, 65, 85];
   const SLATE_600 = [71, 85, 105];
+  const SLATE_500 = [100, 116, 139];
   const SLATE_400 = [148, 163, 184];
+  const SLATE_200 = [226, 232, 240];
+  const SLATE_100 = [241, 245, 249];
   const STRIPE_BG = [248, 250, 252];
   const WHITE = [255, 255, 255];
 
-  // Compute totals
+  const items = Array.isArray(order?.items) ? order.items : [];
+
   const orderSubtotal = roundToTwo(
-    (order.items || []).reduce((sum, item) => {
+    items.reduce((sum, item) => {
       return sum + toNumber(item?.price) * toNumber(item?.quantity, 1);
     }, 0),
   );
 
   const itemsGstTotal = roundToTwo(
-    (order.items || []).reduce((sum, item) => {
+    items.reduce((sum, item) => {
       const gross = roundToTwo(
         toNumber(item?.price) * toNumber(item?.quantity, 1),
       );
@@ -126,150 +163,167 @@ export const generateInvoicePDF = async (order) => {
   );
 
   const amountPaid = resolveAmountPaid(order, orderSubtotal + shippingCharge);
-  const payableTotal = amountPaid;
+  const orderTotal = toNumber(order?.totalAmount, amountPaid);
+  const explicitDiscount = firstFiniteNumber([
+    order?.discountAmount,
+    order?.discount,
+    order?.couponDiscount,
+    order?.offerDiscount,
+  ]);
+  const discountAmount =
+    explicitDiscount !== null && explicitDiscount >= 0
+      ? roundToTwo(explicitDiscount)
+      : Math.max(roundToTwo(orderSubtotal - orderTotal), 0);
+
   const isCOD = `${order.orderType || order.paymentMethod || ""}`
     .toLowerCase()
     .includes("cash");
 
-  // Watermark
-  const watermark = await loadImageAsDataURL(INVOICE_WATERMARK_URL);
-  if (watermark) {
+  const logo = await loadImageAsDataURL(AQUAKART_LOGO_URL);
+
+  if (logo) {
     try {
       if (doc.GState) {
-        doc.setGState(new doc.GState({ opacity: 0.04 }));
-        doc.addImage(watermark, "PNG", W / 2 - 150, H / 2 - 150, 300, 300);
+        doc.setGState(new doc.GState({ opacity: 0.035 }));
+        doc.addImage(logo, "PNG", W / 2 - 145, H / 2 - 145, 290, 290);
         doc.setGState(new doc.GState({ opacity: 1 }));
       }
     } catch (_) {}
   }
 
-  // Header band
   doc.setFillColor(...BRAND);
-  doc.rect(0, 0, W, 88, "F");
+  doc.rect(0, 0, W, 96, "F");
   doc.setFillColor(...BRAND_DARK);
-  doc.rect(0, 88, W, 4, "F");
+  doc.rect(0, 96, W, 5, "F");
+
+  let brandTextX = M;
+  if (logo) {
+    try {
+      doc.setFillColor(...WHITE);
+      doc.roundedRect(M, 22, 50, 50, 14, 14, "F");
+      doc.addImage(logo, "PNG", M + 8, 30, 34, 34);
+      brandTextX = M + 64;
+    } catch (_) {
+      brandTextX = M;
+    }
+  }
 
   doc.setTextColor(...WHITE);
   doc.setFont(F, "bold");
-  doc.setFontSize(28);
-  doc.text("Aquakart", M, 42);
+  doc.setFontSize(27);
+  doc.text("Aquakart", brandTextX, 43);
   doc.setFont(F, "normal");
   doc.setFontSize(10);
-  doc.text("Premium Water Solutions", M, 58);
+  doc.text("Premium Water Solutions", brandTextX, 60);
   doc.setFontSize(9);
-  doc.text("GSTIN: 36AJOPH6387A1Z2  |  aquakart.co.in", M, 74);
+  doc.text("GSTIN: 36AJOPH6387A1Z2  |  aquakart.co.in", brandTextX, 76);
 
-  // INVOICE badge
   doc.setFont(F, "bold");
   doc.setFontSize(11);
   doc.setFillColor(...WHITE);
-  const badgeW = 80;
-  doc.roundedRect(W - M - badgeW, 30, badgeW, 28, 14, 14, "F");
+  const badgeW = 86;
+  doc.roundedRect(W - M - badgeW, 32, badgeW, 30, 15, 15, "F");
   doc.setTextColor(...BRAND_DARK);
-  doc.text("INVOICE", W - M - badgeW / 2, 49, { align: "center" });
+  doc.text("INVOICE", W - M - badgeW / 2, 51, { align: "center" });
 
-  // Invoice meta grid
-  let Y = 112;
-  const metaLeft = [
-    ["Invoice #", order?.orderId || "-"],
-    [
-      "Date",
-      order?.createdAt
-        ? new Date(order.createdAt).toLocaleDateString("en-IN", {
-            day: "2-digit",
-            month: "short",
-            year: "numeric",
-          })
-        : "-",
-    ],
+  let Y = 122;
+  const invoiceNumber = order?.invoiceId || order?.orderId || "-";
+  const createdDate = order?.createdAt
+    ? new Date(order.createdAt).toLocaleDateString("en-IN", {
+        day: "2-digit",
+        month: "short",
+        year: "numeric",
+      })
+    : "-";
+
+  const metaData = [
+    ["Invoice #", invoiceNumber],
+    ["Date", createdDate],
     ["Transaction", order?.transactionId || "-"],
-  ];
-  const metaRight = [
     ["Payment", isCOD ? "Cash on Delivery" : "Online / Gateway"],
     ["Status", order?.orderStatus || "Processing"],
-    ["Currency", "INR (₹)"],
+    ["Currency", "INR"],
   ];
 
-  const drawMeta = (items, startX, startY) => {
-    let y = startY;
-    items.forEach(([label, value]) => {
-      doc.setFont(F, "normal");
-      doc.setFontSize(8);
-      doc.setTextColor(...SLATE_400);
-      doc.text(label.toUpperCase(), startX, y);
-      doc.setFont(F, "bold");
-      doc.setFontSize(10);
-      doc.setTextColor(...SLATE_900);
-      doc.text(String(value), startX, y + 13);
-      y += 30;
-    });
-    return y;
-  };
+  const metaCardW = (TW - 14) / 2;
+  const metaCardH = 36;
+  metaData.forEach(([label, value], index) => {
+    const col = index % 2;
+    const row = Math.floor(index / 2);
+    const x = M + col * (metaCardW + 14);
+    const y = Y + row * (metaCardH + 10);
 
-  drawMeta(metaLeft, M, Y);
-  drawMeta(metaRight, W / 2 + 20, Y);
-  Y += 30 * metaLeft.length + 8;
-
-  // Divider
-  doc.setDrawColor(...SLATE_400);
-  doc.setLineWidth(0.5);
-  doc.line(M, Y, W - M, Y);
-  Y += 16;
-
-  // Billing / Shipping
-  const drawAddressBlock = (title, lines, x, y) => {
+    drawRoundedCard(doc, x, y, metaCardW, metaCardH, STRIPE_BG, SLATE_200);
+    doc.setFont(F, "normal");
+    doc.setFontSize(7.5);
+    doc.setTextColor(...SLATE_400);
+    doc.text(label.toUpperCase(), x + 12, y + 13);
     doc.setFont(F, "bold");
     doc.setFontSize(9);
-    doc.setTextColor(...BRAND);
-    doc.text(title.toUpperCase(), x, y);
-    doc.setFont(F, "normal");
-    doc.setFontSize(10);
     doc.setTextColor(...SLATE_900);
-    let offsetY = y + 16;
-    lines.forEach((line) => {
-      doc.text(String(line), x, offsetY);
-      offsetY += 14;
-    });
-    return offsetY;
-  };
+    const valueLines = doc.splitTextToSize(String(value), metaCardW - 24);
+    doc.text(valueLines.slice(0, 1), x + 12, y + 27);
+  });
+
+  Y += 3 * (metaCardH + 10) + 12;
 
   const billingLines = [
     order?.customerName || order?.user?.name || "Customer",
     order?.email,
     order?.phone,
   ].filter(Boolean);
+
   const shippingLines = composeAddressLines(order?.shippingAddress);
-  if (order?.phone) shippingLines.push(`Ph: ${order.phone}`);
+  if (order?.phone) shippingLines.push(`Phone: ${order.phone}`);
 
-  const bY = drawAddressBlock("Bill To", billingLines, M, Y);
-  const sY = drawAddressBlock("Ship To", shippingLines, W / 2 + 20, Y);
-  Y = Math.max(bY, sY) + 16;
+  const addressBoxW = (TW - 16) / 2;
+  const addressBoxH = 94;
 
-  // Table
-  const colX = {
-    idx: M + 12,
-    item: M + 40,
-    qty: M + TW - 180,
-    rate: M + TW - 120,
-    gst: M + TW - 60,
-    total: M + TW - 4,
+  const drawAddressBlock = (title, lines, x, y) => {
+    drawRoundedCard(doc, x, y, addressBoxW, addressBoxH, WHITE, SLATE_200);
+    doc.setFont(F, "bold");
+    doc.setFontSize(9);
+    doc.setTextColor(...BRAND_DEEP);
+    doc.text(title.toUpperCase(), x + 14, y + 20);
+    doc.setFont(F, "normal");
+    doc.setFontSize(9);
+    doc.setTextColor(...SLATE_700);
+    writeWrappedLines(
+      doc,
+      lines.length ? lines : ["N/A"],
+      x + 14,
+      y + 38,
+      addressBoxW - 28,
+      12,
+    );
   };
-  const itemDescW = colX.qty - colX.item - 16;
+
+  drawAddressBlock("Bill To", billingLines, M, Y);
+  drawAddressBlock("Ship To", shippingLines, M + addressBoxW + 16, Y);
+  Y += addressBoxH + 22;
+
+  const colX = {
+    idx: M + 14,
+    item: M + 42,
+    qty: M + TW - 206,
+    rate: M + TW - 128,
+    total: M + TW - 14,
+  };
+  const itemDescW = colX.qty - colX.item - 18;
 
   const drawTableHead = (y) => {
     doc.setFillColor(...BRAND);
-    doc.roundedRect(M, y, TW, 28, 6, 6, "F");
+    doc.roundedRect(M, y, TW, 30, 8, 8, "F");
     doc.setTextColor(...WHITE);
     doc.setFont(F, "bold");
-    doc.setFontSize(9);
-    doc.text("#", colX.idx, y + 18);
-    doc.text("ITEM", colX.item, y + 18);
-    doc.text("QTY", colX.qty, y + 18, { align: "right" });
-    doc.text("RATE", colX.rate, y + 18, { align: "right" });
-    doc.text("GST", colX.gst, y + 18, { align: "right" });
-    doc.text("AMOUNT", colX.total, y + 18, { align: "right" });
+    doc.setFontSize(8.5);
+    doc.text("#", colX.idx, y + 19);
+    doc.text("ITEM", colX.item, y + 19);
+    doc.text("QTY", colX.qty, y + 19, { align: "right" });
+    doc.text("RATE", colX.rate, y + 19, { align: "right" });
+    doc.text("AMOUNT", colX.total, y + 19, { align: "right" });
     doc.setTextColor(...SLATE_900);
-    return y + 34;
+    return y + 38;
   };
 
   Y = drawTableHead(Y);
@@ -278,115 +332,111 @@ export const generateInvoicePDF = async (order) => {
     if (Y + need > H - 100) {
       doc.addPage();
       doc.setFillColor(...BRAND);
-      doc.rect(0, 0, W, 36, "F");
+      doc.rect(0, 0, W, 38, "F");
       doc.setTextColor(...WHITE);
       doc.setFont(F, "bold");
       doc.setFontSize(10);
-      doc.text("Aquakart Invoice (continued)", M, 24);
+      doc.text("Aquakart Invoice - continued", M, 24);
       doc.setTextColor(...SLATE_900);
-      Y = 56;
+      Y = 58;
       Y = drawTableHead(Y);
     }
   };
 
-  (order?.items || []).forEach((product, i) => {
+  items.forEach((product, i) => {
     const name = product?.name || product?.productName || `Item ${i + 1}`;
     const qty = toNumber(product?.quantity, 1);
     const unitPrice = toNumber(product?.price, 0);
     const lineTotal = roundToTwo(qty * unitPrice);
-    const gstAmt = roundToTwo(
-      lineTotal - roundToTwo(lineTotal / (1 + GST_RATE)),
-    );
-    const nameLines = doc.splitTextToSize(name, Math.max(itemDescW, 100));
-    const rowH = Math.max(nameLines.length * 14 + 18, 40);
+    const nameLines = doc.splitTextToSize(name, Math.max(itemDescW, 110));
+    const rowH = Math.max(nameLines.length * 13 + 18, 42);
 
-    ensurePage(rowH + 6);
+    ensurePage(rowH + 8);
 
     if (i % 2 === 1) {
       doc.setFillColor(...STRIPE_BG);
-      doc.roundedRect(M, Y, TW, rowH, 4, 4, "F");
+      doc.roundedRect(M, Y, TW, rowH, 6, 6, "F");
     }
 
     const textY = Y + 18;
     doc.setFont(F, "normal");
-    doc.setFontSize(10);
-    doc.setTextColor(...SLATE_600);
+    doc.setFontSize(9.5);
+    doc.setTextColor(...SLATE_500);
     doc.text(String(i + 1).padStart(2, "0"), colX.idx, textY);
     doc.setTextColor(...SLATE_900);
-    doc.text(nameLines, colX.item, textY, { lineHeightFactor: 1.3 });
+    doc.text(nameLines, colX.item, textY, { lineHeightFactor: 1.25 });
+    doc.setFont(F, "bold");
     doc.text(String(qty), colX.qty, textY, { align: "right" });
+    doc.setFont(F, "normal");
     doc.setTextColor(...SLATE_600);
     doc.text(fmt(unitPrice), colX.rate, textY, { align: "right" });
-    doc.setFontSize(9);
-    doc.text(fmt(gstAmt), colX.gst, textY, { align: "right" });
-    doc.setFontSize(10);
     doc.setFont(F, "bold");
-    doc.setTextColor(...SLATE_900);
+    doc.setTextColor(...SLATE_950);
     doc.text(fmt(lineTotal), colX.total, textY, { align: "right" });
 
-    Y += rowH + 2;
+    Y += rowH + 4;
   });
 
-  // Summary section
-  ensurePage(200);
-  Y += 12;
+  if (!items.length) {
+    ensurePage(48);
+    doc.setFont(F, "normal");
+    doc.setFontSize(10);
+    doc.setTextColor(...SLATE_500);
+    doc.text("No line items available for this invoice.", M + 14, Y + 20);
+    Y += 48;
+  }
+
+  ensurePage(210);
+  Y += 14;
 
   const boxW = TW / 2 - 10;
-  const boxH = 140;
+  const boxH = 154;
 
-  // Delivery details box
-  doc.setFillColor(240, 253, 244);
-  doc.roundedRect(M, Y, boxW, boxH, 10, 10, "F");
-  doc.setDrawColor(167, 243, 208);
-  doc.setLineWidth(0.8);
-  doc.roundedRect(M, Y, boxW, boxH, 10, 10, "S");
-
+  drawRoundedCard(doc, M, Y, boxW, boxH, [240, 253, 244], [167, 243, 208]);
   doc.setFont(F, "bold");
   doc.setFontSize(10);
   doc.setTextColor(...BRAND_DARK);
-  doc.text("DELIVERY DETAILS", M + 16, Y + 22);
+  doc.text("DELIVERY DETAILS", M + 16, Y + 23);
   doc.setFont(F, "normal");
-  doc.setFontSize(9);
+  doc.setFontSize(8.6);
   doc.setTextColor(...SLATE_600);
-  const deliveryLines = [
-    ...(shippingLines.length ? shippingLines : ["N/A"]),
-    order?.email ? `Email: ${order.email}` : null,
-  ].filter(Boolean);
-  let dY = Y + 40;
-  deliveryLines.forEach((line) => {
-    doc.text(String(line), M + 16, dY);
-    dY += 14;
-  });
+  writeWrappedLines(
+    doc,
+    [
+      ...(shippingLines.length ? shippingLines : ["N/A"]),
+      order?.email ? `Email: ${order.email}` : null,
+    ].filter(Boolean),
+    M + 16,
+    Y + 42,
+    boxW - 32,
+    12,
+  );
 
-  // Invoice summary box
   const rBoxX = M + boxW + 20;
-  doc.setFillColor(...STRIPE_BG);
-  doc.roundedRect(rBoxX, Y, boxW, boxH, 10, 10, "F");
-  doc.setDrawColor(226, 232, 240);
-  doc.setLineWidth(0.8);
-  doc.roundedRect(rBoxX, Y, boxW, boxH, 10, 10, "S");
+  drawRoundedCard(doc, rBoxX, Y, boxW, boxH, STRIPE_BG, SLATE_200);
 
   doc.setFont(F, "bold");
   doc.setFontSize(10);
   doc.setTextColor(...SLATE_900);
-  doc.text("INVOICE SUMMARY", rBoxX + 16, Y + 22);
-
-  const payableBeforeShipping = Math.max(
-    roundToTwo(toNumber(order?.totalAmount, orderSubtotal)),
-    0,
-  );
-  const discountAmount = Math.max(
-    roundToTwo(orderSubtotal - payableBeforeShipping),
-    0,
-  );
+  doc.text("INVOICE SUMMARY", rBoxX + 16, Y + 23);
 
   const summaryData = [
     {
-      label: "Product price",
-      value: fmt(payableBeforeShipping || orderSubtotal),
+      label: "Items subtotal",
+      value: fmt(orderSubtotal),
     },
+  ];
+
+  if (discountAmount > 0) {
+    summaryData.push({
+      label: "Discount applied",
+      value: `- ${fmt(discountAmount)}`,
+    });
+  }
+
+  summaryData.push(
     {
-      label: `Incl. GST (${Math.round(GST_RATE * 100)}%)`,
+      label: `GST included (${Math.round(GST_RATE * 100)}%)`,
       value: fmt(itemsGstTotal),
       muted: true,
     },
@@ -394,40 +444,31 @@ export const generateInvoicePDF = async (order) => {
       label: "Shipping",
       value: shippingCharge > 0 ? fmt(shippingCharge) : "FREE",
     },
-  ];
+  );
 
-  if (discountAmount > 0) {
-    summaryData.splice(1, 0, {
-      label: "Discount applied",
-      value: `- ${fmt(discountAmount)}`,
-    });
-  }
-
-  let sLineY = Y + 42;
+  let sLineY = Y + 44;
   summaryData.forEach((row) => {
     doc.setFont(F, "normal");
-    doc.setFontSize(row.muted ? 8 : 9);
-    const tc = row.muted ? SLATE_400 : SLATE_600;
-    doc.setTextColor(tc[0], tc[1], tc[2]);
-    doc.text(row.muted ? `    ${row.label}` : row.label, rBoxX + 16, sLineY);
+    doc.setFontSize(row.muted ? 8 : 8.8);
+    const textColor = row.muted ? SLATE_400 : SLATE_600;
+    doc.setTextColor(...textColor);
+    doc.text(row.label, rBoxX + 16, sLineY);
     doc.text(row.value, rBoxX + boxW - 16, sLineY, { align: "right" });
-    sLineY += row.muted ? 14 : 16;
+    sLineY += row.muted ? 13 : 16;
   });
 
-  // Divider + total
   doc.setDrawColor(...BRAND);
   doc.setLineWidth(1);
   doc.line(rBoxX + 16, sLineY + 2, rBoxX + boxW - 16, sLineY + 2);
-  sLineY += 16;
+  sLineY += 18;
 
   doc.setFont(F, "bold");
-  doc.setFontSize(12);
+  doc.setFontSize(11.5);
   doc.setTextColor(...BRAND_DARK);
   doc.text("AMOUNT PAID", rBoxX + 16, sLineY);
-  doc.text(fmt(payableTotal), rBoxX + boxW - 16, sLineY, { align: "right" });
+  doc.text(fmt(amountPaid), rBoxX + boxW - 16, sLineY, { align: "right" });
 
-  // Footer
-  doc.setDrawColor(226, 232, 240);
+  doc.setDrawColor(...SLATE_200);
   doc.setLineWidth(0.5);
   doc.line(M, H - 68, W - M, H - 68);
 
@@ -450,7 +491,6 @@ export const generateInvoicePDF = async (order) => {
   doc.setTextColor(...BRAND);
   doc.text("Thank you for your order!", W - M, H - 42, { align: "right" });
 
-  // Save
   doc.save(
     `Aquakart-Invoice-${order?.orderId || order?.transactionId || "order"}.pdf`,
   );

--- a/src/utils/invoice.js
+++ b/src/utils/invoice.js
@@ -131,7 +131,6 @@ export const generateInvoicePDF = async (order) => {
   const SLATE_500 = [100, 116, 139];
   const SLATE_400 = [148, 163, 184];
   const SLATE_200 = [226, 232, 240];
-  const SLATE_100 = [241, 245, 249];
   const STRIPE_BG = [248, 250, 252];
   const WHITE = [255, 255, 255];
 


### PR DESCRIPTION
## Summary
- Redesigns the customer dashboard orders tab with cleaner order cards, compact status chips, item summary, ETA, address and action buttons.
- Adds shareable tracking link support using native share when available, with clipboard fallback and a tracking dialog link section.
- Updates the invoice PDF generator to use the Aquakart logo asset from the repo/Cloudinary SEO logo, cleaner A4 layout, readable INR text formatting, and wider amount columns to avoid broken rupee glyphs/overlap.
- Adds a reusable branded Aquakart logo loader and wires it into the app shell, route transitions, PersistGate startup, and the common spinner wrapper.
- Adds premium loader/motion CSS so refresh/loading states feel customer-facing instead of small default React loading blocks.

## Validation
- Parsed the updated JSX/JS with TypeScript transpile locally for syntax validation before the loader follow-up.
- Could not run the full Next build in the sandbox because the environment cannot resolve github.com to clone/install dependencies.