### PR TITLE
Keep orders panel fixed height with internal scroll

### DIFF
--- a/src/styles/aqua-loader.css
+++ b/src/styles/aqua-loader.css
@@ -120,6 +120,56 @@
   text-align: center;
 }
 
+/* Keep the orders area fixed-height and scroll inside instead of expanding the page/card. */
+.grid.gap-5.lg\:grid-cols-2:has(> article.group.flex.h-full.flex-col.overflow-hidden.rounded-\[1\.75rem\]) {
+  max-height: clamp(520px, 68vh, 780px);
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  padding: 0.25rem 0.35rem 0.25rem 0;
+  scroll-behavior: smooth;
+  scrollbar-gutter: stable;
+}
+
+.grid.gap-5.lg\:grid-cols-2:has(> article.group.flex.h-full.flex-col.overflow-hidden.rounded-\[1\.75rem\])::-webkit-scrollbar {
+  width: 8px;
+}
+
+.grid.gap-5.lg\:grid-cols-2:has(> article.group.flex.h-full.flex-col.overflow-hidden.rounded-\[1\.75rem\])::-webkit-scrollbar-track {
+  background: rgba(226, 232, 240, 0.55);
+  border-radius: 999px;
+}
+
+.grid.gap-5.lg\:grid-cols-2:has(> article.group.flex.h-full.flex-col.overflow-hidden.rounded-\[1\.75rem\])::-webkit-scrollbar-thumb {
+  background: linear-gradient(180deg, #34d399, #0f766e);
+  border-radius: 999px;
+}
+
+.grid.gap-5.lg\:grid-cols-2:has(> article.group.flex.h-full.flex-col.overflow-hidden.rounded-\[1\.75rem\])
+  > article.group.flex.h-full.flex-col.overflow-hidden.rounded-\[1\.75rem\] {
+  min-height: 560px;
+  height: 560px;
+}
+
+.grid.gap-5.lg\:grid-cols-2:has(> article.group.flex.h-full.flex-col.overflow-hidden.rounded-\[1\.75rem\])
+  > article.group.flex.h-full.flex-col.overflow-hidden.rounded-\[1\.75rem\]
+  > .flex.flex-1.flex-col.gap-4.p-5 {
+  min-height: 0;
+  overflow: hidden;
+}
+
+@media (max-width: 767px) {
+  .grid.gap-5.lg\:grid-cols-2:has(> article.group.flex.h-full.flex-col.overflow-hidden.rounded-\[1\.75rem\]) {
+    max-height: 70vh;
+    padding-right: 0.15rem;
+  }
+
+  .grid.gap-5.lg\:grid-cols-2:has(> article.group.flex.h-full.flex-col.overflow-hidden.rounded-\[1\.75rem\])
+    > article.group.flex.h-full.flex-col.overflow-hidden.rounded-\[1\.75rem\] {
+    min-height: 580px;
+    height: 580px;
+  }
+}
+
 @keyframes aquaLoaderCardIn {
   from {
     opacity: 0;


### PR DESCRIPTION
## **User description**
## Summary
- Keeps the dashboard orders list at a fixed height so the main dashboard card no longer grows with the number of orders.
- Adds internal scrolling to the orders grid with a customer-facing custom scrollbar.
- Keeps individual order cards consistent in height across desktop and mobile.

## Validation
- CSS-only update scoped to the dashboard orders grid selectors.
- Could not run the full Next build in the sandbox because the environment cannot resolve github.com to clone/install dependencies.


___

## **CodeAnt-AI Description**
**Keep the orders panel at a fixed height and scroll inside it**

### What Changed
- The orders area now stays within a set height instead of stretching the dashboard as more orders load.
- The orders list scrolls inside its panel, with a custom scrollbar and smoother scrolling on desktop and mobile.
- The orders card keeps a consistent height across screen sizes so the dashboard layout stays stable.

### Impact
`✅ Cleaner dashboard layout`
`✅ Easier access to long order lists`
`✅ Fewer page-length changes while browsing orders`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
