### PR TITLE
Fix mobile collection card alignment

### DIFF
--- a/src/components/Layout/ResponsiveGrid.js
+++ b/src/components/Layout/ResponsiveGrid.js
@@ -1,0 +1,5 @@
+const ResponsiveGrid = ({ children, className = "" }) => {
+  return <div className={className}>{children}</div>;
+};
+
+export default ResponsiveGrid;

--- a/src/components/Layout/ResponsiveGrid.js
+++ b/src/components/Layout/ResponsiveGrid.js
@@ -1,5 +1,19 @@
-const ResponsiveGrid = ({ children, className = "" }) => {
-  return <div className={className}>{children}</div>;
+const ResponsiveGrid = ({
+  children,
+  minItemWidth = "260px",
+  gapClassName = "gap-4 sm:gap-5 lg:gap-6",
+  className = "",
+}) => {
+  const columns = `repeat(auto-fit, minmax(min(${minItemWidth}, 100%), 1fr))`;
+
+  return (
+    <div
+      className={`grid ${gapClassName} ${className}`}
+      style={{ gridTemplateColumns: columns }}
+    >
+      {children}
+    </div>
+  );
 };
 
 export default ResponsiveGrid;

--- a/src/pageComponents/home/index.js
+++ b/src/pageComponents/home/index.js
@@ -10,6 +10,7 @@ import {
 } from "@headlessui/react";
 import { XMarkIcon } from "@heroicons/react/24/outline";
 import AquaLayout from "@/components/Layout/Layout";
+import ResponsiveGrid from "@/components/Layout/ResponsiveGrid";
 import AquaSpinner from "@/components/common/spinner";
 import AquaCategoryCard from "@/components/cards/categoryCard";
 import { useRouter } from "next/router";
@@ -316,7 +317,7 @@ const AquaHomeComponent = ({
                   </Link>
                 </div>
 
-                <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
+                <ResponsiveGrid minItemWidth="280px" gapClassName="gap-4 sm:gap-5 lg:gap-6">
                   {initialCategories.length === 0 ? (
                     <div className="col-span-full flex h-40 items-center justify-center rounded-2xl border border-dashed border-slate-300 bg-white/50">
                       <AquaSpinner color="emerald" size="lg" />
@@ -330,7 +331,7 @@ const AquaHomeComponent = ({
                       />
                     ))
                   )}
-                </div>
+                </ResponsiveGrid>
 
                 <div className="mt-6 sm:hidden">
                   <Link

--- a/src/styles/product-loader-fixes.css
+++ b/src/styles/product-loader-fixes.css
@@ -1,6 +1,7 @@
-/* Product detail + loader polish
+/* Product detail + responsive layout polish
    - Product gallery images fill their card without empty padding gaps.
    - Route/page loaders fully cover the UI so blurred product images never bleed through.
+   - Collection cards use auto-fit sizing instead of fixed mobile columns.
 */
 
 .aqua-page-shell[aria-hidden="true"] {
@@ -41,6 +42,22 @@ main[data-route="/product/[id]"] .touch-pan-y img {
 main[data-route="/product/[id]"] .hidden.grid-cols-5 img {
   object-fit: cover !important;
   padding: 0 !important;
+}
+
+section[aria-labelledby="category-heading"] > div.grid {
+  grid-template-columns: repeat(auto-fit, minmax(min(280px, 100%), 1fr)) !important;
+  align-items: stretch;
+}
+
+section[aria-labelledby="category-heading"] > div.grid > a {
+  width: 100%;
+  min-width: 0;
+}
+
+@media (max-width: 639px) {
+  section[aria-labelledby="category-heading"] > div.grid {
+    gap: 1rem !important;
+  }
 }
 
 @media (min-width: 1024px) {


### PR DESCRIPTION
## **User description**
## Summary
- Replaced fixed mobile collection columns with a reusable `ResponsiveGrid` auto-fit layout.
- The Shop by Collection cards now become one clean column on narrow phones, then naturally flow into more columns as screen width increases.
- Added a global safety guard for the collection section so reused collection card grids do not overflow or leave broken half-width mobile gaps.

## Why
The mobile home page was using hard-coded `grid-cols-2`, so five collection cards caused an odd last row and cramped alignment on iPhone screens. This makes the layout screen-driven instead of manually fixed.

## Notes
- Focused on the screenshot issue in the Shop by Collection section.
- I could not run the local build from the connector, so please verify on iPhone Safari/mobile preview after deploy.


___

## **CodeAnt-AI Description**
**Fix collection cards on mobile by switching them to a screen-aware grid**

### What Changed
- The Shop by Collection cards now flow into as many columns as fit the screen instead of staying locked to fixed mobile columns.
- Collection cards keep a full-width, even layout on narrow phones, reducing cramped rows and awkward gaps.
- The collection section now also has a fallback layout rule so reused card grids stay aligned and do not overflow.

### Impact
`✅ Cleaner mobile collection layout`
`✅ Fewer awkward half-empty rows`
`✅ Less horizontal overflow in collection sections`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
