### PR TITLE
Fix duplicate OTP login toasts

### DIFF
--- a/src/components/common/commonDialogs/commonAuth/mobileOtp.js
+++ b/src/components/common/commonDialogs/commonAuth/mobileOtp.js
@@ -3,7 +3,14 @@ import useDialog from "@/utils/dialog";
 import { useRef, useState } from "react";
 import { useDispatch } from "react-redux";
 import AquaToast from "@/components/reusables/react-toastify";
-import { Loader2 } from "lucide-react";
+import { Loader2, MessageCircle } from "lucide-react";
+
+const getApiErrorMessage = (error, fallback) =>
+  error?.response?.data?.otpMessage ||
+  error?.response?.data?.message ||
+  error?.response?.data?.error ||
+  error?.message ||
+  fallback;
 
 const AquaAuthMobileForm = ({ signup }) => {
   const [phone, setPhone] = useState("");
@@ -28,22 +35,29 @@ const AquaAuthMobileForm = ({ signup }) => {
 
   const handleSendOtp = () => {
     if (!isValidPhone(phone) || isSendingOtp) return;
+
     setIsSendingOtp(true);
-    AquaToast({ message: "Sending WhatsApp OTP...", type: "info" });
 
     UserServiceOperations.UserMobileOtp({ phone })
       .then((res) => {
         setOtpShow(true);
-        AquaToast({ message: "OTP sent successfully", type: "success" });
+        setOtpDigits(Array(6).fill(""));
+        AquaToast({
+          message: res?.data?.otpMessage || "OTP sent successfully",
+          type: "success",
+        });
         dispatch({
           type: "SET_AUTH_STATUS_VISIBLE",
           payload: !res.data.userExist,
         });
         setTimeout(() => inputRefs.current?.[0]?.focus(), 100);
       })
-      .catch(() => {
+      .catch((error) => {
         setOtpShow(false);
-        AquaToast({ message: "Failed to send OTP", type: "error" });
+        AquaToast({
+          message: getApiErrorMessage(error, "Failed to send OTP"),
+          type: "error",
+        });
         dispatch({ type: "SET_AUTH_STATUS_VISIBLE", payload: false });
       })
       .finally(() => setIsSendingOtp(false));
@@ -52,12 +66,13 @@ const AquaAuthMobileForm = ({ signup }) => {
   const handleSubmit = (event) => {
     event.preventDefault();
     const otpValue = otpDigits.join("");
-    if (otpValue.length !== 6) return;
+    if (otpValue.length !== 6 || verifying) return;
+
     setVerifying(true);
 
     const otpPromise = UserServiceOperations.UserMobileVerify({
-      phone: Number(phone),
-      otp: Number(otpValue),
+      phone,
+      otp: otpValue,
     });
     const timeoutPromise = new Promise((_, reject) =>
       setTimeout(() => reject(new Error("Request timed out")), 15000),
@@ -74,7 +89,7 @@ const AquaAuthMobileForm = ({ signup }) => {
           message:
             err.message === "Request timed out"
               ? "Server is taking too long. Please try again."
-              : "Verification failed",
+              : getApiErrorMessage(err, "Verification failed"),
           type: "error",
         });
       })
@@ -96,12 +111,14 @@ const AquaAuthMobileForm = ({ signup }) => {
       inputRefs.current[Math.min(cur, 5)]?.focus();
       return;
     }
+
     const updated = [...otpDigits];
     if (!sanitized) {
       updated[index] = "";
       setOtpDigits(updated);
       return;
     }
+
     updated[index] = sanitized.charAt(sanitized.length - 1);
     setOtpDigits(updated);
     if (index < 5) inputRefs.current[index + 1]?.focus();
@@ -138,7 +155,6 @@ const AquaAuthMobileForm = ({ signup }) => {
 
   return (
     <form onSubmit={handleSubmit} className="space-y-4">
-      {/* Phone input */}
       <div>
         <label
           htmlFor="phone-number"
@@ -164,20 +180,13 @@ const AquaAuthMobileForm = ({ signup }) => {
           />
         </div>
         <div className="mt-1.5 flex items-center gap-1.5">
-          <svg
-            className="w-3.5 h-3.5 text-green-600 flex-shrink-0"
-            fill="currentColor"
-            viewBox="0 0 24 24"
-          >
-            <path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 01-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 01-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 012.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0012.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 005.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 00-3.48-8.413Z" />
-          </svg>
+          <MessageCircle className="h-3.5 w-3.5 text-green-600" />
           <p className="text-[11px] text-slate-400">
             WhatsApp OTP verification
           </p>
         </div>
       </div>
 
-      {/* Send OTP button */}
       {isValidPhone(phone) && !otpShow && (
         <button
           type="button"
@@ -191,16 +200,12 @@ const AquaAuthMobileForm = ({ signup }) => {
             </>
           ) : (
             <>
-              <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
-                <path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 01-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 01-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 012.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0012.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 005.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 00-3.48-8.413Z" />
-              </svg>
-              Send OTP via WhatsApp
+              <MessageCircle className="h-4 w-4" /> Send OTP via WhatsApp
             </>
           )}
         </button>
       )}
 
-      {/* OTP section */}
       {otpShow && (
         <div className="space-y-3">
           <div className="text-center">
@@ -236,14 +241,13 @@ const AquaAuthMobileForm = ({ signup }) => {
             type="button"
             onClick={handleSendOtp}
             disabled={isSendingOtp}
-            className="text-xs text-emerald-600 hover:text-emerald-700 font-semibold transition-colors"
+            className="text-xs text-emerald-600 hover:text-emerald-700 font-semibold transition-colors disabled:cursor-not-allowed disabled:opacity-50"
           >
-            Resend code
+            {isSendingOtp ? "Sending..." : "Resend code"}
           </button>
         </div>
       )}
 
-      {/* Submit */}
       <button
         type="submit"
         disabled={!canSubmit || verifying}


### PR DESCRIPTION
## Summary
- Removed the extra "Sending WhatsApp OTP..." info toast so login OTP shows only one final success or failure toast.
- Displays backend OTP failure details from `otpMessage`, `message`, or `error` instead of always showing a generic failure.
- Keeps the button loading state as the in-progress feedback.
- Sends phone and OTP as strings so backend normalization handles them consistently.
- Prevents iOS Safari focus zoom by keeping mobile form controls at a 16px font size and updating the auth phone input from `text-sm` to `text-base`.

## Why
The mobile login flow was showing an info toast before the request and then a success/error toast after the request, which created duplicate toast messages during login. The auth phone input was also using a sub-16px mobile font, so iOS Safari zoomed into the page when the user focused the phone field.

## Notes
- Backend OTP delivery fix is in AQUAKARTBACKEND PR #9.
- I could not run the app locally from the connector, so please verify by requesting OTP once from the login dialog on iPhone Safari after deploy.