### PR TITLE
Fix iOS input focus zoom in auth modal

### DIFF
--- a/src/components/common/commonDialogs/commonAuth/mobileOtp.js
+++ b/src/components/common/commonDialogs/commonAuth/mobileOtp.js
@@ -175,7 +175,7 @@ const AquaAuthMobileForm = ({ signup }) => {
             value={phone}
             onChange={handlePhoneChange}
             placeholder="9876543210"
-            className="block w-full rounded-xl border border-white/50 bg-white/40 pl-11 pr-3.5 py-3 text-sm text-slate-900 placeholder:text-slate-400 backdrop-blur-sm focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-400/30 transition-all"
+            className="block w-full rounded-xl border border-white/50 bg-white/40 pl-11 pr-3.5 py-3 text-base text-slate-900 placeholder:text-slate-400 backdrop-blur-sm focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-400/30 transition-all"
             autoComplete="tel"
           />
         </div>

--- a/src/styles/mobile-viewport.css
+++ b/src/styles/mobile-viewport.css
@@ -1,7 +1,3 @@
-/* Mobile viewport guard
-   Keeps the app pinned to the device width so fixed headers,
-   animated hero cards, shadows and horizontal carousels cannot create
-   the iOS Safari right-side blank gap. */
 html,
 body,
 #__next {
@@ -26,4 +22,12 @@ body {
   width: 100%;
   max-width: 100%;
   overflow-x: hidden;
+}
+
+@media (max-width: 767px) {
+  input,
+  select,
+  textarea {
+    font-size: 16px !important;
+  }
 }


### PR DESCRIPTION
## **User description**
## Summary
- Prevents iOS Safari from zooming the page when focusing mobile inputs by keeping form controls at 16px on mobile.
- Updates the auth phone number input from `text-sm` to `text-base` so the login modal stays stable when the keyboard opens.

## Why
The phone input used a sub-16px font on mobile. iOS Safari auto-zooms focused inputs smaller than 16px, which caused the auth modal to zoom in after typing.

## Notes
- This keeps user pinch zoom available; it only fixes the form-control font size.
- Please verify on iPhone Safari by focusing the phone input in the login dialog.


___

## **CodeAnt-AI Description**
**Stop iPhone Safari from zooming the auth form when a phone number field is focused**

### What Changed
- The phone number field in the login/signup modal now uses a larger text size so it stays steady when opened on iPhone Safari
- Mobile form fields are forced to a readable size on small screens to prevent browser zoom when users tap into inputs

### Impact
`✅ Fewer iPhone login modal zoom issues`
`✅ More stable mobile form entry`
`✅ Clearer typing experience on small screens`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
