### PR TITLE
Fix product visual pinning at the page shell

### DIFF
--- a/src/styles/product-loader-fixes.css
+++ b/src/styles/product-loader-fixes.css
@@ -13,7 +13,14 @@
 }
 
 main[data-route="/product/[id]"] {
-  overflow-x: hidden;
+  /*
+   * Keep the product story's desktop visual sticky to the viewport.
+   * `hidden` creates a scroll container on this app-level shell, so the
+   * nested sticky stage tracks a container that never scrolls. `clip`
+   * still contains the cinematic artwork without changing sticky's
+   * scrolling ancestor.
+   */
+  overflow-x: clip;
 }
 
 main[data-route="/product/[id]"] .touch-pan-y > div > .relative.flex.aspect-square {


### PR DESCRIPTION
## **User description**
## What this fixes

The screen recording showed the left product visual still scrolling away while Specifications and Regeneration continued on the right. The component's sticky rule was correct, but the outer app route still applied `overflow-x: hidden`, which created a non-scrolling sticky containing block.

## Change

- switches the product route shell from `overflow-x: hidden` to `overflow-x: clip`
- preserves horizontal artwork clipping without creating a scroll container
- restores the intended desktop behavior: the full product visual and price remain pinned while the right-hand story scrolls
- keeps the existing compact, stacked mobile layout unchanged

## Validation

- targeted ESLint passed
- Vitest: 31 tests passed across 9 files
- Next.js production build completed successfully


___

## **CodeAnt-AI Description**
**Keep the product visual pinned while the story scrolls**

### What Changed
- The desktop product visual now stays pinned in place as the right-hand story scrolls
- The product page still clips horizontal artwork, but no longer turns the page shell into a scroll container that breaks sticky behavior
- The mobile stacked layout remains unchanged

### Impact
`✅ Fixed pinned product visuals`
`✅ Smoother desktop product storytelling`
`✅ No change to mobile product layout`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
