### PR TITLE
Unify the page surface across Aquakart

### DIFF
--- a/src/components/Layout/Footer.js
+++ b/src/components/Layout/Footer.js
@@ -54,8 +54,11 @@ const AquaFooter = ({ categories = [], subcategories = [] }) => {
   const [festival, setFestival] = useState(null);
 
   useEffect(() => {
-    setMounted(true);
-    setFestival(getFestivalWish());
+    const frame = window.requestAnimationFrame(() => {
+      setMounted(true);
+      setFestival(getFestivalWish());
+    });
+    return () => window.cancelAnimationFrame(frame);
   }, []);
 
   const formattedCategories = Array.isArray(categories) ? categories : [];
@@ -71,7 +74,7 @@ const AquaFooter = ({ categories = [], subcategories = [] }) => {
   return (
     <footer
       aria-labelledby="footer-heading"
-      className="relative z-10 bg-white px-2 pb-2 pt-10 text-slate-300"
+      className="aqua-site-footer-edge relative z-10 px-2 pb-2 pt-10 text-slate-300"
     >
       <div className="relative overflow-hidden rounded-[2.5rem] bg-slate-950 px-6 pb-8 pt-16 sm:px-12 lg:px-16">
         {/* Ambient Background Effects */}

--- a/src/components/Layout/Header.js
+++ b/src/components/Layout/Header.js
@@ -61,7 +61,10 @@ const AquaHeader = () => {
 
   // Festival wish only on mount (or when you decide to change it)
   useEffect(() => {
-    setFestival(getFestivalWish());
+    const frame = window.requestAnimationFrame(() => {
+      setFestival(getFestivalWish());
+    });
+    return () => window.cancelAnimationFrame(frame);
   }, []);
 
   // Scroll handler optimized: no state updates per scroll tick, no re-binding listener
@@ -100,7 +103,7 @@ const AquaHeader = () => {
     >
       {({ open }) => (
         <>
-          <div className="relative rounded-full border border-white/50 bg-white/50 backdrop-blur-2xl shadow-[0_8px_32px_rgba(0,0,0,0.06),inset_0_1px_0_rgba(255,255,255,0.7)] transition-all duration-500 hover:bg-white/65 hover:shadow-[0_12px_40px_rgba(0,0,0,0.08),inset_0_1px_0_rgba(255,255,255,0.8)] hover:border-white/70">
+          <div className="aqua-site-header-panel relative rounded-full border border-white/65 backdrop-blur-2xl shadow-[0_8px_32px_rgba(15,23,42,0.07),inset_0_1px_0_rgba(255,255,255,0.75)] transition-all duration-500 hover:border-white/80 hover:shadow-[0_12px_40px_rgba(15,23,42,0.09),inset_0_1px_0_rgba(255,255,255,0.85)]">
             <div className="relative flex h-16 items-center justify-between px-4 sm:px-6 lg:px-8">
               {/* Mobile Menu Button */}
               <div className="absolute inset-y-0 left-0 flex items-center sm:hidden pl-2">
@@ -303,7 +306,7 @@ const AquaHeader = () => {
             leaveTo="transform scale-95 opacity-0 -translate-y-2"
           >
             <DisclosurePanel className="sm:hidden mt-2">
-              <div className="rounded-[2rem] border border-white/50 bg-white/50 backdrop-blur-3xl shadow-[0_8px_40px_rgba(0,0,0,0.08)] p-4 space-y-2 ring-1 ring-white/60">
+              <div className="aqua-site-mobile-menu space-y-2 rounded-[2rem] border border-white/65 p-4 shadow-[0_8px_40px_rgba(15,23,42,0.09)] ring-1 ring-white/70 backdrop-blur-3xl">
                 {navigation.map((item) => (
                   <DisclosureButton
                     key={item.name}

--- a/src/components/Layout/Layout.js
+++ b/src/components/Layout/Layout.js
@@ -155,8 +155,8 @@ const AquaLayout = (props) => {
     return (
       <>
         <AquaHeader />
-        <div className="flex min-h-screen w-full max-w-full overflow-x-hidden bg-white pt-24 flex-col">
-          <main className="flex min-w-0 flex-1 flex-col items-center justify-center overflow-x-hidden bg-white">
+        <div className="aqua-site-layer flex min-h-screen w-full max-w-full flex-col overflow-x-hidden pt-24">
+          <main className="aqua-site-content flex min-w-0 flex-1 flex-col items-center justify-center overflow-x-hidden">
             <div className="glass-card mx-4 max-w-md rounded-3xl p-10 text-center">
               <div className="mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-2xl bg-rose-100/80">
                 <svg
@@ -225,12 +225,12 @@ const AquaLayout = (props) => {
       )}
 
       <div
-        className={`relative flex min-h-screen w-full max-w-full flex-col bg-white pt-24 pb-16 sm:pb-0 ${
+        className={`aqua-site-layer relative flex min-h-screen w-full max-w-full flex-col pt-24 pb-16 sm:pb-0 ${
           allowPageSticky ? "overflow-x-clip" : "overflow-x-hidden"
         }`}
       >
         <main
-          className={`relative z-10 min-w-0 flex-1 bg-white ${
+          className={`aqua-site-content relative z-10 min-w-0 flex-1 ${
             allowPageSticky ? "overflow-x-clip" : "overflow-x-hidden"
           }`}
         >

--- a/src/components/Layout/MobileBottomNav.js
+++ b/src/components/Layout/MobileBottomNav.js
@@ -91,7 +91,7 @@ const MobileBottomNav = () => {
         className="border-t border-white/40"
         style={{
           background:
-            "linear-gradient(180deg, rgba(255,255,255,0.72) 0%, rgba(245,247,250,0.85) 100%)",
+            "linear-gradient(180deg, rgba(246,250,249,0.76) 0%, rgba(238,246,244,0.9) 100%)",
           backdropFilter: "blur(40px) saturate(200%)",
           WebkitBackdropFilter: "blur(40px) saturate(200%)",
           boxShadow:

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -11,6 +11,9 @@
     var(--font-roboto-mono), var(--font-montserrat), ui-monospace,
     SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New",
     monospace;
+  --aqua-page-surface: #f6faf9;
+  --aqua-page-surface-strong: #eef6f4;
+  --aqua-page-surface-rgb: 246, 250, 249;
 }
 
 /* Tailwind v4 theme tokens — so `font-sans` / `font-mono` utilities resolve to --app-font */
@@ -30,15 +33,66 @@ html {
 body {
   min-height: 100vh;
   font-family: var(--app-font);
-  background: linear-gradient(
-    135deg,
-    #f0f4ff 0%,
-    #e8f5f0 25%,
-    #f5f0ff 50%,
-    #eef7ff 75%,
-    #f0fdf4 100%
-  );
+  background:
+    radial-gradient(
+      circle at 8% 0%,
+      rgba(16, 185, 129, 0.055),
+      transparent 30rem
+    ),
+    radial-gradient(
+      circle at 92% 12%,
+      rgba(14, 165, 233, 0.04),
+      transparent 28rem
+    ),
+    linear-gradient(
+      180deg,
+      #f8fbfa 0%,
+      var(--aqua-page-surface) 48%,
+      #f3f8f7 100%
+    );
   background-attachment: fixed;
+}
+
+/* ── Shared Aquakart page canvas ─────────────────────────
+   Every route gets the same neutral surface from header to footer. Page-level
+   accent colours belong inside cards and decorative layers, not on the canvas.
+*/
+.aqua-site-layer {
+  background: transparent;
+}
+
+.aqua-site-content {
+  background: transparent;
+}
+
+.aqua-site-content
+  > :where(div, main, section):not([data-aqua-preserve-surface]) {
+  background-color: transparent !important;
+  background-image: none !important;
+}
+
+.aqua-site-header-panel,
+.aqua-site-mobile-menu {
+  background: rgba(var(--aqua-page-surface-rgb), 0.84);
+}
+
+.aqua-site-header-panel:hover {
+  background: rgba(var(--aqua-page-surface-rgb), 0.94);
+}
+
+.aqua-site-footer-edge {
+  background: transparent;
+}
+
+@media (max-width: 639px) {
+  body {
+    background-attachment: scroll;
+  }
+
+  .aqua-site-header-panel,
+  .aqua-site-mobile-menu {
+    background: rgba(var(--aqua-page-surface-rgb), 0.9);
+  }
 }
 
 /* ── Glass Utility Classes ─────────────────────────────── */


### PR DESCRIPTION
## **User description**
## Consistent visual layer

- introduces a single shared Aquakart page-surface token for every routed screen
- removes route-level full-canvas blue, indigo, green and gray backgrounds while preserving accent cards, aurora decorations and feature sections
- eliminates the hard white header-gap-to-coloured-content break
- keeps the full path from header through content to footer on one neutral, lightly tinted surface

## Shared layout updates

- makes the main layout and content canvas transparent over the shared surface
- aligns the desktop and mobile header glass with the same surface colour
- blends the footer edge into the page instead of forcing a white strip
- updates the mobile bottom navigation glass to use the same Aquakart tint
- applies the same treatment to the offline/network-error layout
- includes an explicit `data-aqua-preserve-surface` escape hatch for any future route that intentionally needs its own full-page theme

## Responsive behavior

- uses the same canvas on phone, tablet and desktop
- disables fixed-background attachment on phones for smoother scrolling
- preserves existing sticky product behavior and horizontal clipping rules

## Quality cleanup

- moves existing header/footer mount-state updates into animation frames to satisfy the current React lint rules

## Validation

- Prettier completed
- targeted ESLint passed with no warnings
- Vitest: 31 tests passed across 9 files
- Next.js production build completed successfully


___

## **CodeAnt-AI Description**
**Unify the page surface across Aquakart**

### What Changed
- Routes now share one neutral page surface from header to footer instead of switching to separate full-page background colors.
- The header, mobile menu, footer edge, and mobile bottom navigation now match the same Aquakart tint.
- Content and layout surfaces are made transparent so route pages can sit on the shared background, while still allowing specific sections to keep their own look when needed.
- The shared page surface also applies to the offline/network-error screen, and mobile scrolling no longer uses a fixed background for smoother movement.

### Impact
`✅ Consistent page background across routes`
`✅ Smoother scrolling on phones`
`✅ Fewer visual jumps between header, content, and footer`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
