### PR TITLE
Add server-rendered public invoice experience

### DIFF
--- a/src/pageComponents/invoice/InvoicePage.js
+++ b/src/pageComponents/invoice/InvoicePage.js
@@ -1,0 +1,548 @@
+import Head from "next/head";
+import Image from "next/image";
+import Link from "next/link";
+import { useState } from "react";
+import {
+  ArrowLeft,
+  BadgeCheck,
+  CalendarDays,
+  Check,
+  Copy,
+  CreditCard,
+  Download,
+  FileText,
+  Hash,
+  Landmark,
+  Mail,
+  MapPin,
+  Package,
+  Phone,
+  Printer,
+  ReceiptIndianRupee,
+  ShieldCheck,
+  Truck,
+  UserRound,
+} from "lucide-react";
+import { toast } from "sonner";
+import logo from "@/assests/logo.png";
+import priceUtils from "@/utils/priceUtils";
+import styles from "@/styles/invoice.module.css";
+
+const formatDate = (value) => {
+  if (!value) return "Not available";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "Not available";
+
+  return date.toLocaleDateString("en-IN", {
+    day: "2-digit",
+    month: "long",
+    year: "numeric",
+  });
+};
+
+const titleCase = (value) =>
+  String(value || "Not available")
+    .replace(/[_-]+/g, " ")
+    .replace(/\b\w/g, (letter) => letter.toUpperCase());
+
+const DetailLine = ({ icon: Icon, label, value }) => {
+  if (!value) return null;
+
+  return (
+    <div className={styles.detailLine}>
+      <span className={styles.detailIcon} aria-hidden="true">
+        <Icon size={16} strokeWidth={1.8} />
+      </span>
+      <div>
+        <span className={styles.detailLabel}>{label}</span>
+        <span className={styles.detailValue}>{value}</span>
+      </div>
+    </div>
+  );
+};
+
+const StatusPill = ({ status }) => {
+  const isPaid = ["paid", "completed", "success"].includes(
+    String(status).toLowerCase(),
+  );
+
+  return (
+    <span
+      className={`${styles.statusPill} ${isPaid ? styles.statusPaid : styles.statusPending}`}
+    >
+      <span className={styles.statusDot} />
+      {titleCase(status)}
+    </span>
+  );
+};
+
+const InvoiceError = ({ statusCode }) => {
+  const notFound = statusCode === 404;
+
+  return (
+    <div className={styles.errorPage}>
+      <Head>
+        <title>
+          {notFound ? "Invoice not found" : "Invoice unavailable"} | Aquakart
+        </title>
+        <meta name="robots" content="noindex, nofollow, noarchive" />
+      </Head>
+      <div className={styles.errorGlow} />
+      <div className={styles.errorCard}>
+        <div className={styles.errorLogo}>
+          <Image src={logo} alt="Aquakart" width={68} height={68} priority />
+        </div>
+        <span className={styles.eyebrow}>Aquakart invoices</span>
+        <h1>
+          {notFound
+            ? "We could not find that invoice."
+            : "The invoice is taking a pause."}
+        </h1>
+        <p>
+          {notFound
+            ? "Check the invoice link and try again. The ID may be incomplete or no longer available."
+            : "We could not reach the invoice service. Please wait a moment and try again."}
+        </p>
+        <div className={styles.errorActions}>
+          <button type="button" onClick={() => window.location.reload()}>
+            Try again
+          </button>
+          <Link href="/">
+            <ArrowLeft size={16} /> Back to Aquakart
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const ProductCard = ({ product, index }) => {
+  const lineTotal = product.productPrice * product.productQuantity;
+
+  return (
+    <article className={styles.productCard}>
+      <div className={styles.productVisual}>
+        {product.productImage ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img src={product.productImage} alt="" />
+        ) : (
+          <>
+            <span className={styles.productNumber}>
+              {String(index + 1).padStart(2, "0")}
+            </span>
+            <Package size={30} strokeWidth={1.45} aria-hidden="true" />
+          </>
+        )}
+      </div>
+
+      <div className={styles.productContent}>
+        <div className={styles.productHeading}>
+          <div>
+            <span className={styles.productKicker}>Aquakart selection</span>
+            <h3>{product.productName}</h3>
+          </div>
+          <span className={styles.quantityPill}>
+            {product.productQuantity}{" "}
+            {product.productQuantity === 1 ? "unit" : "units"}
+          </span>
+        </div>
+
+        {product.productSerialNo ? (
+          <div className={styles.serialNumber}>
+            <Hash size={13} /> Serial {product.productSerialNo}
+          </div>
+        ) : null}
+
+        <div className={styles.productPriceRow}>
+          <div>
+            <span>Unit price</span>
+            <strong>{priceUtils.formatAmount(product.productPrice)}</strong>
+          </div>
+          <span className={styles.multiply}>× {product.productQuantity}</span>
+          <div className={styles.lineTotal}>
+            <span>Line total</span>
+            <strong>{priceUtils.formatAmount(lineTotal)}</strong>
+          </div>
+        </div>
+      </div>
+    </article>
+  );
+};
+
+const InvoicePage = ({ invoice, statusCode = 200 }) => {
+  const [isDownloading, setIsDownloading] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  if (!invoice || statusCode !== 200) {
+    return <InvoiceError statusCode={statusCode} />;
+  }
+
+  const amounts = priceUtils.getInvoiceAmounts(invoice);
+  const invoiceLabel = invoice.invoice_no || invoice.id || "Invoice";
+
+  const handleDownload = async () => {
+    if (isDownloading) return;
+    setIsDownloading(true);
+    try {
+      const { downloadPublicInvoicePdf } =
+        await import("@/utils/invoice/generatePublicInvoicePdf");
+      await downloadPublicInvoicePdf(invoice);
+      toast.success("Invoice PDF downloaded");
+    } catch (error) {
+      console.error("Invoice PDF download failed", error);
+      toast.error("PDF download failed. Please use Print instead.");
+    } finally {
+      setIsDownloading(false);
+    }
+  };
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(window.location.href);
+      setCopied(true);
+      toast.success("Invoice link copied");
+      window.setTimeout(() => setCopied(false), 1800);
+    } catch {
+      toast.error("Could not copy the invoice link");
+    }
+  };
+
+  return (
+    <div className={styles.page}>
+      <Head>
+        <title>{invoiceLabel} | Aquakart Invoice</title>
+        <meta name="description" content={`Aquakart invoice ${invoiceLabel}`} />
+        <meta name="robots" content="noindex, nofollow, noarchive" />
+        <meta name="googlebot" content="noindex, nofollow, noarchive" />
+      </Head>
+
+      <div className={styles.ambientOne} aria-hidden="true" />
+      <div className={styles.ambientTwo} aria-hidden="true" />
+
+      <header className={styles.commandBar}>
+        <Link href="/" className={styles.brand} aria-label="Aquakart home">
+          <span className={styles.brandMark}>
+            <Image src={logo} alt="" width={40} height={40} priority />
+          </span>
+          <span>
+            <strong>Aquakart</strong>
+            <small>Invoice studio</small>
+          </span>
+        </Link>
+
+        <div className={styles.commandIdentity}>
+          <BadgeCheck size={17} /> Verified invoice
+          <span>{invoiceLabel}</span>
+        </div>
+
+        <div className={styles.commandActions}>
+          <button
+            type="button"
+            onClick={handleCopy}
+            className={styles.secondaryButton}
+          >
+            {copied ? <Check size={17} /> : <Copy size={17} />}
+            <span>{copied ? "Copied" : "Copy link"}</span>
+          </button>
+          <button
+            type="button"
+            onClick={() => window.print()}
+            className={styles.secondaryButton}
+          >
+            <Printer size={17} /> <span>Print</span>
+          </button>
+          <button
+            type="button"
+            onClick={handleDownload}
+            disabled={isDownloading}
+            className={styles.primaryButton}
+          >
+            <Download size={17} />
+            {isDownloading ? "Preparing PDF…" : "Download PDF"}
+          </button>
+        </div>
+      </header>
+
+      <main className={styles.invoiceShell}>
+        <section className={styles.invoiceHero}>
+          <div className={styles.heroBrand}>
+            <div className={styles.heroLogo}>
+              <Image
+                src={logo}
+                alt="Aquakart"
+                width={64}
+                height={64}
+                priority
+              />
+            </div>
+            <div>
+              <span className={styles.eyebrow}>Premium water solutions</span>
+              <h1>Tax Invoice</h1>
+              <p>GSTIN 36AJOPH6387A1Z2</p>
+            </div>
+          </div>
+
+          <div className={styles.heroInvoice}>
+            <StatusPill status={invoice.paid_status} />
+            <span>Invoice number</span>
+            <strong>{invoiceLabel}</strong>
+            <small>Issued {formatDate(invoice.date)}</small>
+          </div>
+        </section>
+
+        <section className={styles.metaStrip}>
+          <div>
+            <CalendarDays size={18} />
+            <span>Invoice date</span>
+            <strong>{formatDate(invoice.date)}</strong>
+          </div>
+          <div>
+            <CreditCard size={18} />
+            <span>Payment method</span>
+            <strong>{titleCase(invoice.payment_type)}</strong>
+          </div>
+          <div>
+            <ReceiptIndianRupee size={18} />
+            <span>Invoice value</span>
+            <strong>{priceUtils.formatAmount(amounts.grandTotal)}</strong>
+          </div>
+          <div>
+            <ShieldCheck size={18} />
+            <span>Tax treatment</span>
+            <strong>{invoice.gst ? "CGST + SGST" : "Non-GST"}</strong>
+          </div>
+        </section>
+
+        <div className={styles.invoiceGrid}>
+          <section className={styles.productsColumn}>
+            <div className={styles.sectionHeading}>
+              <div>
+                <span className={styles.sectionIndex}>01</span>
+                <div>
+                  <span className={styles.eyebrow}>Invoice contents</span>
+                  <h2>Products supplied</h2>
+                </div>
+              </div>
+              <span className={styles.itemCount}>
+                {invoice.products.length}{" "}
+                {invoice.products.length === 1 ? "item" : "items"}
+              </span>
+            </div>
+
+            <div className={styles.productList}>
+              {invoice.products.length ? (
+                invoice.products.map((product, index) => (
+                  <ProductCard
+                    key={product.id || `${product.productName}-${index}`}
+                    product={product}
+                    index={index}
+                  />
+                ))
+              ) : (
+                <div className={styles.emptyProducts}>
+                  <Package size={28} />
+                  <div>
+                    <strong>No product details available</strong>
+                    <p>
+                      The invoice total and customer record are still shown.
+                    </p>
+                  </div>
+                </div>
+              )}
+            </div>
+
+            <div className={styles.amountWords}>
+              <span>Amount in words</span>
+              <strong>{priceUtils.numberToWords(amounts.grandTotal)}</strong>
+            </div>
+
+            <div className={styles.termsCard}>
+              <ShieldCheck size={22} />
+              <div>
+                <strong>Protected by Aquakart service standards</strong>
+                <p>
+                  Warranty follows the manufacturer policy. Installation,
+                  transport and lifting are chargeable unless agreed separately.
+                  Opened or used products are not returnable.
+                </p>
+              </div>
+            </div>
+          </section>
+
+          <aside className={styles.detailsRail}>
+            <section className={styles.detailCard}>
+              <div className={styles.cardHeading}>
+                <span>
+                  <UserRound size={18} />
+                </span>
+                <div>
+                  <small>Bill to</small>
+                  <h2>Customer details</h2>
+                </div>
+              </div>
+              <DetailLine
+                icon={UserRound}
+                label="Customer"
+                value={invoice.customer_name || "Not available"}
+              />
+              <DetailLine
+                icon={Phone}
+                label="Phone"
+                value={invoice.customer_phone}
+              />
+              <DetailLine
+                icon={Mail}
+                label="Email"
+                value={invoice.customer_email}
+              />
+              <DetailLine
+                icon={MapPin}
+                label="Billing address"
+                value={invoice.customer_address}
+              />
+            </section>
+
+            {invoice.gst ? (
+              <section className={`${styles.detailCard} ${styles.gstCard}`}>
+                <div className={styles.cardHeading}>
+                  <span>
+                    <Landmark size={18} />
+                  </span>
+                  <div>
+                    <small>Registered profile</small>
+                    <h2>GST details</h2>
+                  </div>
+                </div>
+                <DetailLine
+                  icon={Landmark}
+                  label="Business name"
+                  value={invoice.gst_name || invoice.customer_name}
+                />
+                <DetailLine
+                  icon={Hash}
+                  label="GSTIN"
+                  value={invoice.gst_no || "Not available"}
+                />
+                <DetailLine
+                  icon={Phone}
+                  label="GST phone"
+                  value={invoice.gst_phone}
+                />
+                <DetailLine
+                  icon={Mail}
+                  label="GST email"
+                  value={invoice.gst_email}
+                />
+                <DetailLine
+                  icon={MapPin}
+                  label="GST address"
+                  value={invoice.gst_address}
+                />
+              </section>
+            ) : null}
+
+            {invoice.delivered_by || invoice.delivery_date ? (
+              <section className={styles.detailCard}>
+                <div className={styles.cardHeading}>
+                  <span>
+                    <Truck size={18} />
+                  </span>
+                  <div>
+                    <small>Fulfilment</small>
+                    <h2>Delivery record</h2>
+                  </div>
+                </div>
+                <DetailLine
+                  icon={Truck}
+                  label="Delivered by"
+                  value={invoice.delivered_by}
+                />
+                <DetailLine
+                  icon={CalendarDays}
+                  label="Delivery date"
+                  value={formatDate(invoice.delivery_date)}
+                />
+              </section>
+            ) : null}
+
+            <section className={styles.summaryCard}>
+              <div className={styles.summaryTopline}>
+                <div>
+                  <small>Payment summary</small>
+                  <h2>Invoice total</h2>
+                </div>
+                <FileText size={21} />
+              </div>
+
+              <div className={styles.summaryRows}>
+                <div>
+                  <span>{invoice.gst ? "Taxable value" : "Subtotal"}</span>
+                  <strong>{priceUtils.formatAmount(amounts.basePrice)}</strong>
+                </div>
+                {invoice.gst ? (
+                  <>
+                    <div>
+                      <span>
+                        CGST <small>9%</small>
+                      </span>
+                      <strong>
+                        {priceUtils.formatAmount(amounts.cgstValue)}
+                      </strong>
+                    </div>
+                    <div>
+                      <span>
+                        SGST <small>9%</small>
+                      </span>
+                      <strong>
+                        {priceUtils.formatAmount(amounts.sgstValue)}
+                      </strong>
+                    </div>
+                  </>
+                ) : null}
+              </div>
+
+              <div className={styles.grandTotal}>
+                <span>Total amount</span>
+                <strong>{priceUtils.formatAmount(amounts.grandTotal)}</strong>
+                <small>Inclusive of applicable taxes</small>
+              </div>
+
+              <div className={styles.paymentState}>
+                <StatusPill status={invoice.paid_status} />
+                <span>via {titleCase(invoice.payment_type)}</span>
+              </div>
+            </section>
+          </aside>
+        </div>
+
+        <footer className={styles.invoiceFooter}>
+          <div>
+            <strong>Thank you for choosing Aquakart.</strong>
+            <span>support@aquakart.co.in · +91 90147 74667</span>
+          </div>
+          <p>
+            This is a computer-generated invoice and does not require a
+            signature.
+          </p>
+        </footer>
+      </main>
+
+      <div className={styles.mobileDownloadBar}>
+        <div>
+          <span>Invoice total</span>
+          <strong>
+            {priceUtils.formatAmount(amounts.grandTotal, { showPaise: false })}
+          </strong>
+        </div>
+        <button type="button" onClick={handleDownload} disabled={isDownloading}>
+          <Download size={18} /> {isDownloading ? "Preparing…" : "PDF"}
+        </button>
+        <button type="button" onClick={() => window.print()}>
+          <Printer size={18} /> Print
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default InvoicePage;

--- a/src/pages/invoice/[id].js
+++ b/src/pages/invoice/[id].js
@@ -1,0 +1,68 @@
+import InvoicePage from "@/pageComponents/invoice/InvoicePage";
+import { mapInvoiceFromApi } from "@/utils/invoice/normalizeInvoice";
+
+const FETCH_TIMEOUT_MS = 10_000;
+
+const normalizeRouteId = (value) => {
+  const id = Array.isArray(value) ? value[0] : value;
+  if (typeof id !== "string") return "";
+
+  const normalized = id.trim();
+  if (!normalized || normalized.length > 160) return "";
+  return normalized;
+};
+
+export const getServerSideProps = async ({ params, res }) => {
+  res.setHeader(
+    "Cache-Control",
+    "private, no-store, no-cache, max-age=0, must-revalidate",
+  );
+  res.setHeader("X-Robots-Tag", "noindex, nofollow, noarchive");
+
+  const id = normalizeRouteId(params?.id);
+  if (!id) {
+    return { props: { invoice: null, statusCode: 404 } };
+  }
+
+  const apiBase =
+    process.env.INVOICE_API_URL || process.env.NEXT_PUBLIC_API_URL;
+  if (!apiBase) {
+    return { props: { invoice: null, statusCode: 503 } };
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+
+  try {
+    const response = await fetch(
+      `${apiBase.replace(/\/$/, "")}/invoice/${encodeURIComponent(id)}`,
+      {
+        headers: { Accept: "application/json" },
+        signal: controller.signal,
+      },
+    );
+
+    if (response.status === 404) {
+      return { props: { invoice: null, statusCode: 404 } };
+    }
+
+    if (!response.ok) {
+      return { props: { invoice: null, statusCode: 502 } };
+    }
+
+    const payload = await response.json();
+    const invoice = mapInvoiceFromApi(payload);
+
+    if (!invoice) {
+      return { props: { invoice: null, statusCode: 502 } };
+    }
+
+    return { props: { invoice, statusCode: 200 } };
+  } catch {
+    return { props: { invoice: null, statusCode: 502 } };
+  } finally {
+    clearTimeout(timeout);
+  }
+};
+
+export default InvoicePage;

--- a/src/styles/invoice.module.css
+++ b/src/styles/invoice.module.css
@@ -1,0 +1,1359 @@
+.page {
+  --invoice-ink: #07111f;
+  --invoice-muted: #64748b;
+  --invoice-green: #05845f;
+  --invoice-mint: #10b981;
+  position: relative;
+  min-height: 100vh;
+  overflow: hidden;
+  color: var(--invoice-ink);
+  background:
+    linear-gradient(rgba(226, 232, 240, 0.3) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(226, 232, 240, 0.3) 1px, transparent 1px),
+    #f3f8f7;
+  background-size: 40px 40px;
+  padding: 28px clamp(16px, 4vw, 64px) 80px;
+}
+
+.ambientOne,
+.ambientTwo {
+  position: fixed;
+  z-index: 0;
+  width: 34rem;
+  height: 34rem;
+  pointer-events: none;
+  border-radius: 999px;
+  filter: blur(100px);
+  opacity: 0.18;
+}
+
+.ambientOne {
+  top: -15rem;
+  right: -10rem;
+  background: #2dd4bf;
+}
+
+.ambientTwo {
+  bottom: -18rem;
+  left: -12rem;
+  background: #38bdf8;
+}
+
+.commandBar {
+  position: relative;
+  z-index: 5;
+  display: flex;
+  width: min(100%, 1380px);
+  min-height: 72px;
+  margin: 0 auto 24px;
+  padding: 10px 12px 10px 16px;
+  align-items: center;
+  gap: 18px;
+  border: 1px solid rgba(255, 255, 255, 0.9);
+  border-radius: 24px;
+  background: rgba(255, 255, 255, 0.82);
+  box-shadow: 0 18px 50px rgba(15, 23, 42, 0.08);
+  backdrop-filter: blur(22px) saturate(145%);
+}
+
+.brand {
+  display: inline-flex;
+  min-width: max-content;
+  align-items: center;
+  gap: 10px;
+  color: var(--invoice-ink);
+  text-decoration: none;
+}
+
+.brandMark {
+  display: grid;
+  width: 44px;
+  height: 44px;
+  place-items: center;
+  overflow: hidden;
+  border: 1px solid #dce9e5;
+  border-radius: 14px;
+  background: white;
+}
+
+.brandMark img {
+  width: 34px;
+  height: 34px;
+  object-fit: contain;
+}
+
+.brand strong,
+.brand small {
+  display: block;
+}
+
+.brand strong {
+  font-size: 0.96rem;
+  letter-spacing: -0.02em;
+}
+
+.brand small {
+  margin-top: 2px;
+  color: var(--invoice-muted);
+  font-size: 0.64rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.commandIdentity {
+  display: flex;
+  min-width: 0;
+  margin-right: auto;
+  padding-left: 18px;
+  align-items: center;
+  gap: 7px;
+  border-left: 1px solid #e2e8f0;
+  color: var(--invoice-green);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+}
+
+.commandIdentity span {
+  max-width: 13rem;
+  overflow: hidden;
+  color: var(--invoice-muted);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.commandActions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.commandActions button,
+.mobileDownloadBar button {
+  display: inline-flex;
+  min-height: 44px;
+  padding: 0 16px;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  border: 0;
+  border-radius: 14px;
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.74rem;
+  font-weight: 800;
+  transition:
+    transform 180ms ease,
+    box-shadow 180ms ease,
+    background 180ms ease;
+}
+
+.commandActions button:hover,
+.mobileDownloadBar button:hover {
+  transform: translateY(-1px);
+}
+
+.commandActions button:disabled,
+.mobileDownloadBar button:disabled {
+  cursor: wait;
+  opacity: 0.7;
+}
+
+.secondaryButton {
+  border: 1px solid #dbe5e3 !important;
+  color: #334155;
+  background: #fff;
+}
+
+.primaryButton {
+  color: #fff;
+  background: linear-gradient(135deg, #07966c, #04b184);
+  box-shadow: 0 12px 25px rgba(5, 150, 105, 0.24);
+}
+
+.invoiceShell {
+  position: relative;
+  z-index: 1;
+  width: min(100%, 1380px);
+  margin: 0 auto;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.95);
+  border-radius: 36px;
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow:
+    0 40px 100px rgba(15, 23, 42, 0.13),
+    0 1px 0 rgba(255, 255, 255, 0.9) inset;
+}
+
+.invoiceHero {
+  position: relative;
+  display: flex;
+  min-height: 230px;
+  padding: clamp(28px, 5vw, 64px);
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 32px;
+  overflow: hidden;
+  color: #fff;
+  background:
+    radial-gradient(
+      circle at 78% 10%,
+      rgba(45, 212, 191, 0.24),
+      transparent 24rem
+    ),
+    radial-gradient(
+      circle at 12% 95%,
+      rgba(14, 165, 233, 0.18),
+      transparent 22rem
+    ),
+    linear-gradient(135deg, #07111f 0%, #0a2030 54%, #064e3b 140%);
+}
+
+.invoiceHero::before {
+  position: absolute;
+  top: -11rem;
+  right: 6%;
+  width: 25rem;
+  height: 25rem;
+  border: 1px solid rgba(255, 255, 255, 0.09);
+  border-radius: 999px;
+  box-shadow:
+    0 0 0 50px rgba(255, 255, 255, 0.025),
+    0 0 0 100px rgba(255, 255, 255, 0.018);
+  content: "";
+}
+
+.heroBrand,
+.heroInvoice {
+  position: relative;
+  z-index: 1;
+}
+
+.heroBrand {
+  display: flex;
+  align-items: center;
+  gap: 18px;
+}
+
+.heroLogo {
+  display: grid;
+  width: 76px;
+  height: 76px;
+  flex: 0 0 auto;
+  place-items: center;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  border-radius: 22px;
+  background: rgba(255, 255, 255, 0.96);
+  box-shadow: 0 20px 45px rgba(0, 0, 0, 0.22);
+}
+
+.heroLogo img {
+  width: 58px;
+  height: 58px;
+  object-fit: contain;
+}
+
+.eyebrow {
+  color: #1eaa7c;
+  font-size: 0.66rem;
+  font-weight: 900;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+.heroBrand .eyebrow {
+  color: #6ee7c7;
+}
+
+.heroBrand h1 {
+  margin: 7px 0 6px;
+  font-size: clamp(2.5rem, 6vw, 5rem);
+  font-weight: 900;
+  letter-spacing: -0.075em;
+  line-height: 0.9;
+}
+
+.heroBrand p,
+.heroInvoice small {
+  margin: 0;
+  color: #a8b8c5;
+  font-size: 0.74rem;
+}
+
+.heroInvoice {
+  display: flex;
+  min-width: min(100%, 320px);
+  flex-direction: column;
+  align-items: flex-end;
+}
+
+.heroInvoice > span:not(.statusPill) {
+  margin-top: 20px;
+  color: #94a3b8;
+  font-size: 0.66rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.heroInvoice > strong {
+  display: block;
+  max-width: 100%;
+  margin: 5px 0 7px;
+  overflow-wrap: anywhere;
+  font-size: clamp(1.25rem, 3vw, 2rem);
+  letter-spacing: -0.04em;
+  text-align: right;
+}
+
+.statusPill {
+  display: inline-flex;
+  width: fit-content;
+  padding: 7px 11px;
+  align-items: center;
+  gap: 7px;
+  border: 1px solid;
+  border-radius: 999px;
+  font-size: 0.66rem;
+  font-weight: 900;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.statusDot {
+  width: 6px;
+  height: 6px;
+  border-radius: 99px;
+  background: currentcolor;
+  box-shadow: 0 0 0 4px rgba(16, 185, 129, 0.12);
+}
+
+.statusPaid {
+  border-color: rgba(110, 231, 199, 0.3);
+  color: #6ee7c7;
+  background: rgba(16, 185, 129, 0.1);
+}
+
+.statusPending {
+  border-color: rgba(251, 191, 36, 0.3);
+  color: #fcd34d;
+  background: rgba(245, 158, 11, 0.1);
+}
+
+.metaStrip {
+  display: grid;
+  padding: 0 clamp(20px, 4vw, 48px);
+  border-bottom: 1px solid #e7eeec;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  background: #fbfdfc;
+}
+
+.metaStrip > div {
+  display: grid;
+  min-height: 94px;
+  padding: 22px 20px;
+  align-content: center;
+  border-right: 1px solid #e7eeec;
+  column-gap: 10px;
+  grid-template-columns: auto 1fr;
+}
+
+.metaStrip > div:first-child {
+  border-left: 1px solid #e7eeec;
+}
+
+.metaStrip svg {
+  color: var(--invoice-green);
+  grid-row: span 2;
+}
+
+.metaStrip span {
+  color: var(--invoice-muted);
+  font-size: 0.62rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.metaStrip strong {
+  margin-top: 4px;
+  overflow: hidden;
+  font-size: 0.78rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.invoiceGrid {
+  display: grid;
+  padding: clamp(26px, 4vw, 56px);
+  align-items: start;
+  gap: clamp(28px, 4vw, 56px);
+  grid-template-columns: minmax(0, 1.32fr) minmax(330px, 0.68fr);
+}
+
+.sectionHeading,
+.sectionHeading > div {
+  display: flex;
+  align-items: center;
+}
+
+.sectionHeading {
+  margin-bottom: 22px;
+  justify-content: space-between;
+  gap: 18px;
+}
+
+.sectionHeading > div {
+  gap: 14px;
+}
+
+.sectionIndex {
+  display: grid;
+  width: 42px;
+  height: 42px;
+  flex: 0 0 auto;
+  place-items: center;
+  border-radius: 14px;
+  color: white;
+  background: var(--invoice-ink);
+  font-size: 0.7rem;
+  font-weight: 900;
+}
+
+.sectionHeading h2,
+.cardHeading h2,
+.summaryTopline h2 {
+  margin: 4px 0 0;
+  font-size: 1.05rem;
+  letter-spacing: -0.035em;
+}
+
+.itemCount {
+  padding: 7px 10px;
+  border: 1px solid #dbe8e4;
+  border-radius: 999px;
+  color: var(--invoice-muted);
+  background: #f8fbfa;
+  font-size: 0.67rem;
+  font-weight: 800;
+}
+
+.productList {
+  display: grid;
+  gap: 14px;
+}
+
+.productCard {
+  display: grid;
+  min-width: 0;
+  padding: 12px;
+  border: 1px solid #dfe9e6;
+  border-radius: 24px;
+  background: #fff;
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.045);
+  grid-template-columns: 112px minmax(0, 1fr);
+  transition:
+    border-color 180ms ease,
+    transform 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.productCard:hover {
+  border-color: #a7d9c9;
+  box-shadow: 0 18px 38px rgba(15, 23, 42, 0.08);
+  transform: translateY(-2px);
+}
+
+.productVisual {
+  position: relative;
+  display: grid;
+  min-height: 124px;
+  place-items: center;
+  overflow: hidden;
+  border-radius: 18px;
+  color: #08785a;
+  background:
+    radial-gradient(
+      circle at 70% 20%,
+      rgba(45, 212, 191, 0.22),
+      transparent 3rem
+    ),
+    linear-gradient(145deg, #effcf7, #ecf8fb);
+}
+
+.productVisual::after {
+  position: absolute;
+  inset: 0;
+  background-image:
+    linear-gradient(rgba(16, 185, 129, 0.05) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(16, 185, 129, 0.05) 1px, transparent 1px);
+  background-size: 14px 14px;
+  content: "";
+}
+
+.productVisual img {
+  position: relative;
+  z-index: 1;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+
+.productVisual svg {
+  position: relative;
+  z-index: 1;
+}
+
+.productNumber {
+  position: absolute;
+  z-index: 2;
+  top: 10px;
+  left: 10px;
+  font-size: 0.58rem;
+  font-weight: 900;
+}
+
+.productContent {
+  display: flex;
+  min-width: 0;
+  padding: 6px 8px 6px 18px;
+  flex-direction: column;
+  justify-content: space-between;
+}
+
+.productHeading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.productKicker {
+  color: var(--invoice-green);
+  font-size: 0.56rem;
+  font-weight: 900;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.productHeading h3 {
+  margin: 5px 0 0;
+  overflow-wrap: anywhere;
+  font-size: 0.98rem;
+  letter-spacing: -0.025em;
+  line-height: 1.35;
+}
+
+.quantityPill {
+  flex: 0 0 auto;
+  padding: 6px 9px;
+  border-radius: 999px;
+  color: #0f766e;
+  background: #e6faf4;
+  font-size: 0.62rem;
+  font-weight: 900;
+}
+
+.serialNumber {
+  display: inline-flex;
+  width: fit-content;
+  margin: 9px 0;
+  padding: 5px 8px;
+  align-items: center;
+  gap: 4px;
+  border-radius: 8px;
+  color: #64748b;
+  background: #f3f6f5;
+  font-size: 0.62rem;
+}
+
+.productPriceRow {
+  display: grid;
+  margin-top: 12px;
+  padding-top: 12px;
+  align-items: end;
+  gap: 12px;
+  border-top: 1px dashed #dce5e3;
+  grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
+}
+
+.productPriceRow div span,
+.amountWords span {
+  display: block;
+  margin-bottom: 4px;
+  color: var(--invoice-muted);
+  font-size: 0.57rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.productPriceRow strong {
+  font-size: 0.8rem;
+}
+
+.multiply {
+  color: #94a3b8;
+  font-size: 0.67rem;
+}
+
+.lineTotal {
+  text-align: right;
+}
+
+.lineTotal strong {
+  color: var(--invoice-green);
+}
+
+.emptyProducts {
+  display: flex;
+  padding: 24px;
+  align-items: center;
+  gap: 14px;
+  border: 1px dashed #bfd7cf;
+  border-radius: 20px;
+  color: var(--invoice-green);
+  background: #f6fbf9;
+}
+
+.emptyProducts strong,
+.emptyProducts p {
+  display: block;
+  margin: 0;
+}
+
+.emptyProducts p {
+  margin-top: 4px;
+  color: var(--invoice-muted);
+  font-size: 0.7rem;
+}
+
+.amountWords {
+  margin-top: 18px;
+  padding: 20px 22px;
+  border: 1px solid #bfe9dc;
+  border-radius: 20px;
+  background:
+    radial-gradient(
+      circle at 100% 0,
+      rgba(45, 212, 191, 0.16),
+      transparent 10rem
+    ),
+    #f0fdf9;
+}
+
+.amountWords strong {
+  font-size: 0.8rem;
+  line-height: 1.6;
+}
+
+.termsCard {
+  display: flex;
+  margin-top: 14px;
+  padding: 18px 20px;
+  align-items: flex-start;
+  gap: 12px;
+  border-radius: 20px;
+  color: #cbd5e1;
+  background: var(--invoice-ink);
+}
+
+.termsCard svg {
+  flex: 0 0 auto;
+  color: #5ee2bc;
+}
+
+.termsCard strong {
+  color: white;
+  font-size: 0.72rem;
+}
+
+.termsCard p {
+  margin: 7px 0 0;
+  font-size: 0.63rem;
+  line-height: 1.65;
+}
+
+.detailsRail {
+  position: sticky;
+  top: 24px;
+  display: grid;
+  gap: 14px;
+}
+
+.detailCard,
+.summaryCard {
+  padding: 20px;
+  border: 1px solid #dfe9e6;
+  border-radius: 24px;
+  background: #fff;
+  box-shadow: 0 14px 34px rgba(15, 23, 42, 0.05);
+}
+
+.gstCard {
+  border-color: #bee6da;
+  background: linear-gradient(
+    140deg,
+    rgba(236, 253, 245, 0.7),
+    rgba(255, 255, 255, 0.96) 60%
+  );
+}
+
+.cardHeading,
+.summaryTopline {
+  display: flex;
+  margin-bottom: 18px;
+  align-items: center;
+  gap: 11px;
+}
+
+.cardHeading > span {
+  display: grid;
+  width: 38px;
+  height: 38px;
+  flex: 0 0 auto;
+  place-items: center;
+  border-radius: 12px;
+  color: var(--invoice-green);
+  background: #eaf8f3;
+}
+
+.cardHeading small,
+.summaryTopline small {
+  display: block;
+  color: var(--invoice-green);
+  font-size: 0.56rem;
+  font-weight: 900;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.detailLine {
+  display: grid;
+  padding: 11px 0;
+  align-items: start;
+  gap: 10px;
+  border-top: 1px solid #edf2f1;
+  grid-template-columns: auto minmax(0, 1fr);
+}
+
+.detailIcon {
+  display: grid;
+  width: 30px;
+  height: 30px;
+  place-items: center;
+  border-radius: 9px;
+  color: #64748b;
+  background: #f3f6f5;
+}
+
+.detailLabel,
+.detailValue {
+  display: block;
+}
+
+.detailLabel {
+  margin-bottom: 4px;
+  color: var(--invoice-muted);
+  font-size: 0.55rem;
+  font-weight: 700;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.detailValue {
+  overflow-wrap: anywhere;
+  font-size: 0.69rem;
+  font-weight: 700;
+  line-height: 1.55;
+}
+
+.summaryCard {
+  overflow: hidden;
+  border: 0;
+  color: white;
+  background:
+    radial-gradient(
+      circle at 100% 0,
+      rgba(16, 185, 129, 0.24),
+      transparent 12rem
+    ),
+    var(--invoice-ink);
+  box-shadow: 0 22px 50px rgba(2, 6, 23, 0.2);
+}
+
+.summaryTopline {
+  justify-content: space-between;
+}
+
+.summaryTopline h2 {
+  color: white;
+}
+
+.summaryTopline > svg {
+  color: #5ee2bc;
+}
+
+.summaryRows {
+  padding: 14px 0;
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.summaryRows > div {
+  display: flex;
+  padding: 7px 0;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  color: #b6c3ce;
+  font-size: 0.69rem;
+}
+
+.summaryRows small {
+  color: #6ee7c7;
+}
+
+.summaryRows strong {
+  color: white;
+  font-size: 0.72rem;
+}
+
+.grandTotal {
+  padding: 20px 0 14px;
+}
+
+.grandTotal > span,
+.grandTotal > strong,
+.grandTotal > small {
+  display: block;
+}
+
+.grandTotal > span {
+  color: #91a3b2;
+  font-size: 0.58rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.grandTotal > strong {
+  margin: 6px 0 4px;
+  color: #6ee7c7;
+  font-size: clamp(1.6rem, 3vw, 2.35rem);
+  letter-spacing: -0.06em;
+}
+
+.grandTotal > small {
+  color: #8295a4;
+  font-size: 0.57rem;
+}
+
+.paymentState {
+  display: flex;
+  margin-top: 8px;
+  padding-top: 14px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.paymentState > span:last-child {
+  color: #94a3b8;
+  font-size: 0.61rem;
+}
+
+.invoiceFooter {
+  display: flex;
+  min-height: 104px;
+  padding: 28px clamp(26px, 4vw, 56px);
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  border-top: 1px solid #e3ebe9;
+  background: #f8fbfa;
+}
+
+.invoiceFooter strong,
+.invoiceFooter span {
+  display: block;
+}
+
+.invoiceFooter strong {
+  margin-bottom: 5px;
+  font-size: 0.74rem;
+}
+
+.invoiceFooter span,
+.invoiceFooter p {
+  margin: 0;
+  color: var(--invoice-muted);
+  font-size: 0.61rem;
+  line-height: 1.55;
+}
+
+.invoiceFooter p {
+  max-width: 25rem;
+  text-align: right;
+}
+
+.mobileDownloadBar {
+  display: none;
+}
+
+.errorPage {
+  position: relative;
+  display: grid;
+  min-height: 100vh;
+  padding: 24px;
+  place-items: center;
+  overflow: hidden;
+  background: #f3f8f7;
+}
+
+.errorGlow {
+  position: absolute;
+  width: 32rem;
+  height: 32rem;
+  border-radius: 999px;
+  background: rgba(45, 212, 191, 0.2);
+  filter: blur(90px);
+}
+
+.errorCard {
+  position: relative;
+  width: min(100%, 560px);
+  padding: clamp(28px, 6vw, 58px);
+  border: 1px solid white;
+  border-radius: 34px;
+  text-align: center;
+  background: rgba(255, 255, 255, 0.88);
+  box-shadow: 0 35px 90px rgba(15, 23, 42, 0.12);
+  backdrop-filter: blur(22px);
+}
+
+.errorLogo {
+  display: grid;
+  width: 82px;
+  height: 82px;
+  margin: 0 auto 24px;
+  place-items: center;
+  border: 1px solid #dce8e5;
+  border-radius: 24px;
+  background: white;
+}
+
+.errorLogo img {
+  object-fit: contain;
+}
+
+.errorCard h1 {
+  margin: 10px 0 12px;
+  font-size: clamp(1.8rem, 6vw, 3.1rem);
+  letter-spacing: -0.06em;
+  line-height: 1;
+}
+
+.errorCard p {
+  max-width: 28rem;
+  margin: 0 auto;
+  color: var(--invoice-muted);
+  font-size: 0.78rem;
+  line-height: 1.7;
+}
+
+.errorActions {
+  display: flex;
+  margin-top: 26px;
+  justify-content: center;
+  gap: 9px;
+}
+
+.errorActions button,
+.errorActions a {
+  display: inline-flex;
+  min-height: 44px;
+  padding: 0 16px;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  border: 0;
+  border-radius: 13px;
+  cursor: pointer;
+  color: white;
+  background: var(--invoice-ink);
+  font: inherit;
+  font-size: 0.69rem;
+  font-weight: 800;
+  text-decoration: none;
+}
+
+.errorActions a {
+  border: 1px solid #dce7e4;
+  color: #334155;
+  background: white;
+}
+
+@media (max-width: 980px) {
+  .commandIdentity,
+  .secondaryButton span {
+    display: none;
+  }
+
+  .commandIdentity {
+    margin-right: auto;
+  }
+
+  .invoiceGrid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .detailsRail {
+    position: static;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .summaryCard {
+    grid-column: 1 / -1;
+  }
+}
+
+@media (max-width: 720px) {
+  .page {
+    padding: 0 0 94px;
+    background: #f3f8f7;
+  }
+
+  .ambientOne,
+  .ambientTwo,
+  .commandActions,
+  .brand small {
+    display: none;
+  }
+
+  .commandBar {
+    position: sticky;
+    z-index: 20;
+    top: 0;
+    min-height: 62px;
+    margin: 0;
+    padding: 8px 16px;
+    border-width: 0 0 1px;
+    border-radius: 0;
+    background: rgba(255, 255, 255, 0.93);
+    box-shadow: 0 8px 25px rgba(15, 23, 42, 0.06);
+  }
+
+  .brandMark {
+    width: 40px;
+    height: 40px;
+    border-radius: 12px;
+  }
+
+  .brandMark img {
+    width: 31px;
+    height: 31px;
+  }
+
+  .commandIdentity {
+    display: flex;
+    margin-left: auto;
+    padding-left: 12px;
+    font-size: 0.61rem;
+  }
+
+  .commandIdentity > span {
+    display: block;
+    max-width: 7.5rem;
+  }
+
+  .invoiceShell {
+    width: 100%;
+    border: 0;
+    border-radius: 0;
+    box-shadow: none;
+  }
+
+  .invoiceHero {
+    min-height: 270px;
+    padding: 30px 22px;
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 32px;
+  }
+
+  .heroLogo {
+    width: 60px;
+    height: 60px;
+    border-radius: 18px;
+  }
+
+  .heroLogo img {
+    width: 47px;
+    height: 47px;
+  }
+
+  .heroBrand {
+    gap: 13px;
+  }
+
+  .heroBrand h1 {
+    font-size: 2.75rem;
+  }
+
+  .heroInvoice {
+    width: 100%;
+    min-width: 0;
+    align-items: flex-start;
+  }
+
+  .heroInvoice > span:not(.statusPill) {
+    margin-top: 15px;
+  }
+
+  .heroInvoice > strong {
+    font-size: 1.35rem;
+    text-align: left;
+  }
+
+  .metaStrip {
+    padding: 0;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .metaStrip > div,
+  .metaStrip > div:first-child {
+    min-height: 84px;
+    padding: 17px 16px;
+    border: 0;
+    border-right: 1px solid #e7eeec;
+    border-bottom: 1px solid #e7eeec;
+  }
+
+  .metaStrip > div:nth-child(even) {
+    border-right: 0;
+  }
+
+  .metaStrip strong {
+    font-size: 0.7rem;
+  }
+
+  .invoiceGrid {
+    padding: 28px 16px 34px;
+    gap: 30px;
+  }
+
+  .sectionHeading {
+    padding: 0 2px;
+  }
+
+  .sectionIndex {
+    width: 38px;
+    height: 38px;
+    border-radius: 12px;
+  }
+
+  .productCard {
+    padding: 10px;
+    border-radius: 20px;
+    grid-template-columns: 82px minmax(0, 1fr);
+  }
+
+  .productVisual {
+    min-height: 118px;
+    border-radius: 15px;
+  }
+
+  .productContent {
+    padding: 3px 4px 3px 12px;
+  }
+
+  .productHeading {
+    display: block;
+  }
+
+  .productHeading h3 {
+    padding-right: 2px;
+    font-size: 0.78rem;
+  }
+
+  .quantityPill {
+    display: inline-block;
+    margin-top: 7px;
+  }
+
+  .productPriceRow {
+    gap: 6px;
+  }
+
+  .productPriceRow strong {
+    font-size: 0.67rem;
+  }
+
+  .multiply {
+    font-size: 0.58rem;
+  }
+
+  .detailsRail {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .summaryCard {
+    grid-column: auto;
+  }
+
+  .invoiceFooter {
+    min-height: 0;
+    padding: 26px 20px;
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 10px;
+  }
+
+  .invoiceFooter p {
+    text-align: left;
+  }
+
+  .mobileDownloadBar {
+    position: fixed;
+    z-index: 30;
+    right: 10px;
+    bottom: max(10px, env(safe-area-inset-bottom));
+    left: 10px;
+    display: grid;
+    min-height: 70px;
+    padding: 8px;
+    align-items: center;
+    gap: 7px;
+    border: 1px solid rgba(255, 255, 255, 0.18);
+    border-radius: 21px;
+    color: white;
+    background: rgba(7, 17, 31, 0.95);
+    box-shadow: 0 20px 48px rgba(2, 6, 23, 0.32);
+    backdrop-filter: blur(20px);
+    grid-template-columns: minmax(0, 1fr) auto auto;
+  }
+
+  .mobileDownloadBar > div {
+    min-width: 0;
+    padding-left: 7px;
+  }
+
+  .mobileDownloadBar span,
+  .mobileDownloadBar strong {
+    display: block;
+  }
+
+  .mobileDownloadBar span {
+    color: #94a3b8;
+    font-size: 0.52rem;
+    font-weight: 800;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  .mobileDownloadBar strong {
+    margin-top: 3px;
+    overflow: hidden;
+    color: #6ee7c7;
+    font-size: 0.82rem;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .mobileDownloadBar button {
+    min-height: 50px;
+    padding: 0 12px;
+    border-radius: 15px;
+    color: #07111f;
+    background: #54e0bb;
+    font-size: 0.65rem;
+  }
+
+  .mobileDownloadBar button:last-child {
+    color: white;
+    background: #1e293b;
+  }
+
+  .errorActions {
+    flex-direction: column;
+  }
+}
+
+@media print {
+  .page {
+    padding: 0;
+    overflow: visible;
+    background: white;
+  }
+
+  .commandBar,
+  .mobileDownloadBar,
+  .ambientOne,
+  .ambientTwo {
+    display: none !important;
+  }
+
+  .invoiceShell {
+    width: 100%;
+    overflow: visible;
+    border: 0;
+    border-radius: 0;
+    box-shadow: none;
+  }
+
+  .invoiceHero {
+    min-height: 170px;
+    padding: 30px;
+    print-color-adjust: exact;
+    -webkit-print-color-adjust: exact;
+  }
+
+  .heroBrand h1 {
+    font-size: 3.4rem;
+  }
+
+  .metaStrip {
+    padding: 0 20px;
+    print-color-adjust: exact;
+    -webkit-print-color-adjust: exact;
+  }
+
+  .metaStrip > div {
+    min-height: 72px;
+    padding: 14px;
+  }
+
+  .invoiceGrid {
+    padding: 26px;
+    gap: 24px;
+    grid-template-columns: minmax(0, 1.25fr) minmax(260px, 0.75fr);
+  }
+
+  .detailsRail {
+    position: static;
+  }
+
+  .productCard,
+  .detailCard,
+  .summaryCard,
+  .amountWords,
+  .termsCard {
+    break-inside: avoid;
+    box-shadow: none;
+    print-color-adjust: exact;
+    -webkit-print-color-adjust: exact;
+  }
+
+  .productCard:hover {
+    transform: none;
+  }
+
+  .invoiceFooter {
+    print-color-adjust: exact;
+    -webkit-print-color-adjust: exact;
+  }
+}

--- a/src/utils/invoice/generatePublicInvoicePdf.js
+++ b/src/utils/invoice/generatePublicInvoicePdf.js
@@ -1,0 +1,334 @@
+import { loadJsPDF } from "@/utils/invoice";
+import priceUtils from "@/utils/priceUtils";
+
+const BRAND = [4, 120, 87];
+const BRAND_BRIGHT = [16, 185, 129];
+const INK = [15, 23, 42];
+const MUTED = [100, 116, 139];
+const LINE = [226, 232, 240];
+const SOFT = [248, 250, 252];
+const WHITE = [255, 255, 255];
+
+const safeFilePart = (value) =>
+  String(value || "invoice")
+    .trim()
+    .replace(/[^a-z0-9_-]/gi, "-")
+    .replace(/-+/g, "-");
+
+const formatPdfAmount = (value) => {
+  const amount = Number(value) || 0;
+  return `INR ${amount.toLocaleString("en-IN", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })}`;
+};
+
+const formatDate = (value) => {
+  if (!value) return "Not available";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "Not available";
+  return date.toLocaleDateString("en-IN", {
+    day: "2-digit",
+    month: "short",
+    year: "numeric",
+  });
+};
+
+const titleCase = (value) =>
+  String(value || "Not available")
+    .replace(/[_-]+/g, " ")
+    .replace(/\b\w/g, (letter) => letter.toUpperCase());
+
+const drawPageHeader = (doc, invoice, continued = false) => {
+  const width = doc.internal.pageSize.getWidth();
+  doc.setFillColor(...BRAND);
+  doc.rect(0, 0, width, 92, "F");
+  doc.setFillColor(...BRAND_BRIGHT);
+  doc.rect(0, 88, width, 4, "F");
+
+  doc.setTextColor(...WHITE);
+  doc.setFont("helvetica", "bold");
+  doc.setFontSize(24);
+  doc.text("AQUAKART", 42, 42);
+  doc.setFont("helvetica", "normal");
+  doc.setFontSize(9);
+  doc.text("Premium water solutions", 42, 59);
+  doc.text("GSTIN 36AJOPH6387A1Z2  |  aquakart.co.in", 42, 74);
+
+  doc.setFont("helvetica", "bold");
+  doc.setFontSize(12);
+  doc.text(
+    continued ? "TAX INVOICE / CONTINUED" : "TAX INVOICE",
+    width - 42,
+    42,
+    {
+      align: "right",
+    },
+  );
+  doc.setFont("helvetica", "normal");
+  doc.setFontSize(9);
+  doc.text(invoice.invoice_no || invoice.id || "Invoice", width - 42, 60, {
+    align: "right",
+  });
+};
+
+const drawFooter = (doc) => {
+  const width = doc.internal.pageSize.getWidth();
+  const height = doc.internal.pageSize.getHeight();
+  doc.setDrawColor(...LINE);
+  doc.line(42, height - 54, width - 42, height - 54);
+  doc.setFont("helvetica", "normal");
+  doc.setFontSize(7.5);
+  doc.setTextColor(...MUTED);
+  doc.text(
+    "Computer-generated invoice. No physical signature is required.",
+    42,
+    height - 38,
+  );
+  doc.text(
+    "Aquakart  |  support@aquakart.co.in  |  +91 90147 74667",
+    width - 42,
+    height - 38,
+    { align: "right" },
+  );
+};
+
+const drawInfoCard = (doc, { x, y, width, title, lines }) => {
+  const wrappedLines = lines.flatMap((line) =>
+    doc.splitTextToSize(String(line || "Not available"), width - 28),
+  );
+  const height = Math.max(92, 45 + wrappedLines.length * 12);
+
+  doc.setFillColor(...SOFT);
+  doc.setDrawColor(...LINE);
+  doc.roundedRect(x, y, width, height, 9, 9, "FD");
+  doc.setFont("helvetica", "bold");
+  doc.setFontSize(8);
+  doc.setTextColor(...BRAND);
+  doc.text(title.toUpperCase(), x + 14, y + 19);
+  doc.setFont("helvetica", "normal");
+  doc.setFontSize(8.5);
+  doc.setTextColor(...INK);
+  doc.text(wrappedLines, x + 14, y + 38, { lineHeightFactor: 1.35 });
+
+  return height;
+};
+
+const drawProductHeader = (doc, y) => {
+  const width = doc.internal.pageSize.getWidth();
+  doc.setFillColor(...INK);
+  doc.roundedRect(42, y, width - 84, 28, 6, 6, "F");
+  doc.setFont("helvetica", "bold");
+  doc.setFontSize(7.5);
+  doc.setTextColor(...WHITE);
+  doc.text("PRODUCT", 56, y + 18);
+  doc.text("QTY", width - 220, y + 18, { align: "right" });
+  doc.text("UNIT PRICE", width - 125, y + 18, { align: "right" });
+  doc.text("LINE TOTAL", width - 56, y + 18, { align: "right" });
+  return y + 34;
+};
+
+/** Download the server-normalized public invoice as a searchable A4 PDF. */
+export const downloadPublicInvoicePdf = async (invoice) => {
+  const loaded = await loadJsPDF();
+  const JsPdf = window.jspdf?.jsPDF;
+  if (!loaded || !JsPdf) {
+    throw new Error("The PDF service could not be loaded.");
+  }
+
+  const doc = new JsPdf({ unit: "pt", format: "a4", compress: true });
+  const width = doc.internal.pageSize.getWidth();
+  const height = doc.internal.pageSize.getHeight();
+  const margin = 42;
+  const contentWidth = width - margin * 2;
+  const amounts = priceUtils.getInvoiceAmounts(invoice);
+
+  drawPageHeader(doc, invoice);
+  let y = 116;
+
+  const metadata = [
+    ["Invoice number", invoice.invoice_no || invoice.id || "Not available"],
+    ["Invoice date", formatDate(invoice.date)],
+    ["Payment", titleCase(invoice.payment_type)],
+    ["Status", titleCase(invoice.paid_status)],
+  ];
+  const metaWidth = contentWidth / 4 - 7;
+
+  metadata.forEach(([label, value], index) => {
+    const x = margin + index * (metaWidth + 9.3);
+    doc.setFillColor(...SOFT);
+    doc.setDrawColor(...LINE);
+    doc.roundedRect(x, y, metaWidth, 50, 8, 8, "FD");
+    doc.setFont("helvetica", "normal");
+    doc.setFontSize(6.5);
+    doc.setTextColor(...MUTED);
+    doc.text(label.toUpperCase(), x + 10, y + 16);
+    doc.setFont("helvetica", "bold");
+    doc.setFontSize(8);
+    doc.setTextColor(...INK);
+    const valueLines = doc.splitTextToSize(String(value), metaWidth - 20);
+    doc.text(valueLines.slice(0, 2), x + 10, y + 33);
+  });
+
+  y += 66;
+  const gap = 14;
+  const cardWidth = (contentWidth - gap) / 2;
+  const customerLines = [
+    invoice.customer_name || "Customer name not available",
+    invoice.customer_phone,
+    invoice.customer_email,
+    invoice.customer_address,
+  ].filter(Boolean);
+  const gstLines = invoice.gst
+    ? [
+        invoice.gst_name || invoice.customer_name,
+        invoice.gst_no ? `GSTIN: ${invoice.gst_no}` : "GSTIN not available",
+        invoice.gst_phone,
+        invoice.gst_email,
+        invoice.gst_address,
+      ].filter(Boolean)
+    : ["This invoice does not include a GST registration profile."];
+  const customerHeight = drawInfoCard(doc, {
+    x: margin,
+    y,
+    width: cardWidth,
+    title: "Bill to",
+    lines: customerLines,
+  });
+  const gstHeight = drawInfoCard(doc, {
+    x: margin + cardWidth + gap,
+    y,
+    width: cardWidth,
+    title: invoice.gst ? "GST details" : "Tax profile",
+    lines: gstLines,
+  });
+
+  y += Math.max(customerHeight, gstHeight) + 20;
+  y = drawProductHeader(doc, y);
+
+  const addContinuationPage = () => {
+    drawFooter(doc);
+    doc.addPage();
+    drawPageHeader(doc, invoice, true);
+    y = drawProductHeader(doc, 112);
+  };
+
+  invoice.products.forEach((product, index) => {
+    const nameLines = doc.splitTextToSize(product.productName, 220);
+    const serialLines = product.productSerialNo
+      ? doc.splitTextToSize(`Serial: ${product.productSerialNo}`, 220)
+      : [];
+    const rowHeight = Math.max(
+      45,
+      22 + nameLines.length * 11 + serialLines.length * 10,
+    );
+    if (y + rowHeight > height - 170) addContinuationPage();
+
+    if (index % 2 === 1) {
+      doc.setFillColor(...SOFT);
+      doc.roundedRect(margin, y, contentWidth, rowHeight, 5, 5, "F");
+    }
+
+    const lineTotal = product.productPrice * product.productQuantity;
+    doc.setFont("helvetica", "bold");
+    doc.setFontSize(8.5);
+    doc.setTextColor(...INK);
+    doc.text(nameLines, margin + 14, y + 17);
+    if (serialLines.length) {
+      doc.setFont("helvetica", "normal");
+      doc.setFontSize(7);
+      doc.setTextColor(...MUTED);
+      doc.text(serialLines, margin + 14, y + 17 + nameLines.length * 11);
+    }
+    doc.setFont("helvetica", "normal");
+    doc.setFontSize(8);
+    doc.setTextColor(...INK);
+    doc.text(String(product.productQuantity), width - 220, y + 19, {
+      align: "right",
+    });
+    doc.text(formatPdfAmount(product.productPrice), width - 125, y + 19, {
+      align: "right",
+    });
+    doc.setFont("helvetica", "bold");
+    doc.text(formatPdfAmount(lineTotal), width - 56, y + 19, {
+      align: "right",
+    });
+    y += rowHeight + 3;
+  });
+
+  if (!invoice.products.length) {
+    doc.setFont("helvetica", "normal");
+    doc.setFontSize(9);
+    doc.setTextColor(...MUTED);
+    doc.text("No products were attached to this invoice.", margin + 14, y + 22);
+    y += 46;
+  }
+
+  if (y + 190 > height - 65) addContinuationPage();
+  y += 18;
+
+  const wordsWidth = contentWidth * 0.54;
+  doc.setFillColor(240, 253, 250);
+  doc.setDrawColor(167, 243, 208);
+  doc.roundedRect(margin, y, wordsWidth, 130, 10, 10, "FD");
+  doc.setFont("helvetica", "bold");
+  doc.setFontSize(8);
+  doc.setTextColor(...BRAND);
+  doc.text("AMOUNT IN WORDS", margin + 15, y + 22);
+  doc.setFont("helvetica", "normal");
+  doc.setFontSize(9);
+  doc.setTextColor(...INK);
+  const words = doc.splitTextToSize(
+    priceUtils.numberToWords(amounts.grandTotal),
+    wordsWidth - 30,
+  );
+  doc.text(words, margin + 15, y + 43, { lineHeightFactor: 1.4 });
+  doc.setFontSize(7.5);
+  doc.setTextColor(...MUTED);
+  doc.text(
+    "GST is included in the invoice total where applicable.",
+    margin + 15,
+    y + 109,
+  );
+
+  const summaryX = margin + wordsWidth + gap;
+  const summaryWidth = contentWidth - wordsWidth - gap;
+  doc.setFillColor(...INK);
+  doc.roundedRect(summaryX, y, summaryWidth, 130, 10, 10, "F");
+  const summaryRows = invoice.gst
+    ? [
+        ["Taxable value", amounts.basePrice],
+        ["CGST (9%)", amounts.cgstValue],
+        ["SGST (9%)", amounts.sgstValue],
+      ]
+    : [["Subtotal", amounts.grandTotal]];
+  let rowY = y + 25;
+  summaryRows.forEach(([label, value]) => {
+    doc.setFont("helvetica", "normal");
+    doc.setFontSize(7.5);
+    doc.setTextColor(203, 213, 225);
+    doc.text(label, summaryX + 14, rowY);
+    doc.setTextColor(...WHITE);
+    doc.text(formatPdfAmount(value), summaryX + summaryWidth - 14, rowY, {
+      align: "right",
+    });
+    rowY += 20;
+  });
+  doc.setDrawColor(71, 85, 105);
+  doc.line(summaryX + 14, rowY - 7, summaryX + summaryWidth - 14, rowY - 7);
+  doc.setFont("helvetica", "bold");
+  doc.setFontSize(9.5);
+  doc.setTextColor(...WHITE);
+  doc.text("INVOICE TOTAL", summaryX + 14, rowY + 9);
+  doc.text(
+    formatPdfAmount(amounts.grandTotal),
+    summaryX + summaryWidth - 14,
+    rowY + 9,
+    { align: "right" },
+  );
+
+  drawFooter(doc);
+  doc.save(
+    `Aquakart-Invoice-${safeFilePart(invoice.invoice_no || invoice.id)}.pdf`,
+  );
+};

--- a/src/utils/invoice/normalizeInvoice.js
+++ b/src/utils/invoice/normalizeInvoice.js
@@ -1,0 +1,132 @@
+import { toFiniteNumber } from "@/utils/priceUtils";
+
+const normalizeDate = (value) => {
+  if (value === undefined || value === null || value === "") return "";
+
+  const date = new Date(String(value));
+  return Number.isNaN(date.getTime()) ? "" : date.toISOString();
+};
+
+const normalizeOptionalDate = (value) => normalizeDate(value) || null;
+
+const normalizeBoolean = (value) => {
+  if (typeof value === "boolean") return value;
+  if (typeof value === "number") return value === 1;
+  if (typeof value === "string") {
+    return ["true", "1", "yes", "y"].includes(value.trim().toLowerCase());
+  }
+  return false;
+};
+
+const normalizeText = (value, fallback = "") => {
+  if (value === undefined || value === null) return fallback;
+  return String(value).trim();
+};
+
+const firstImageUrl = (product) => {
+  const candidates = [
+    product?.productImage,
+    product?.image,
+    product?.photo,
+    product?.photos?.[0]?.secure_url,
+    product?.photos?.[0]?.url,
+    typeof product?.photos?.[0] === "string" ? product.photos[0] : null,
+  ];
+
+  return candidates.find((candidate) => typeof candidate === "string") || "";
+};
+
+export const unwrapInvoicePayload = (payload) => {
+  if (!payload || typeof payload !== "object") return payload;
+  return payload.data ?? payload.invoice ?? payload;
+};
+
+export const mapInvoiceFromApi = (payload) => {
+  const inv = unwrapInvoicePayload(payload);
+  if (!inv || typeof inv !== "object" || Array.isArray(inv)) return null;
+
+  const customer = inv.customerDetails ?? {};
+  const gstDetails = inv.gstDetails ?? {};
+  const transport = inv.transport ?? {};
+  const paidStatus =
+    inv.paid_status ?? inv.paidStatus ?? inv.payment_status ?? "unpaid";
+  const paymentType = inv.payment_type ?? inv.paymentType ?? "cash";
+
+  const products = Array.isArray(inv.products)
+    ? inv.products.map((product, index) => {
+        const rawQuantity = Math.trunc(
+          toFiniteNumber(product?.productQuantity ?? product?.quantity, 1),
+        );
+
+        return {
+          id: normalizeText(product?.id ?? product?._id, `item-${index + 1}`),
+          productName: normalizeText(
+            product?.productName ?? product?.name,
+            `Product ${index + 1}`,
+          ),
+          productQuantity: Math.max(rawQuantity, 1),
+          productPrice: Math.max(
+            toFiniteNumber(product?.productPrice ?? product?.unit_price, 0),
+            0,
+          ),
+          productSerialNo: normalizeText(
+            product?.productSerialNo ?? product?.serial_no,
+          ),
+          productImage: firstImageUrl(product),
+        };
+      })
+    : [];
+
+  const computedTotal = products.reduce(
+    (sum, product) => sum + product.productPrice * product.productQuantity,
+    0,
+  );
+  const suppliedTotal = Number(inv.total_amount ?? inv.total);
+  const totalAmount =
+    Number.isFinite(suppliedTotal) && suppliedTotal >= 0
+      ? suppliedTotal
+      : computedTotal;
+  const createdAt = normalizeDate(inv.created_at ?? inv.createdAt);
+  const invoiceDate = normalizeDate(
+    inv.date ?? inv.issue_date ?? inv.created_at ?? inv.createdAt,
+  );
+
+  return {
+    id: normalizeText(inv.id ?? inv._id ?? inv.invoice_id),
+    invoice_no: normalizeText(
+      inv.invoice_no ?? inv.invoiceNo ?? inv.invoice_number,
+    ),
+    date: invoiceDate,
+    customer_name: normalizeText(customer.name ?? inv.customer_name),
+    customer_phone: normalizeText(customer.phone ?? inv.customer_phone),
+    customer_email: normalizeText(customer.email ?? inv.customer_email),
+    customer_address: normalizeText(customer.address ?? inv.customer_address),
+    gst: normalizeBoolean(inv.gst),
+    po: normalizeBoolean(inv.po),
+    quotation: normalizeBoolean(inv.quotation),
+    gst_name: normalizeText(gstDetails.gstName ?? inv.gst_name) || null,
+    gst_no: normalizeText(gstDetails.gstNo ?? inv.gst_no) || null,
+    gst_phone: normalizeText(gstDetails.gstPhone ?? inv.gst_phone) || null,
+    gst_email: normalizeText(gstDetails.gstEmail ?? inv.gst_email) || null,
+    gst_address:
+      normalizeText(gstDetails.gstAddress ?? inv.gst_address) || null,
+    products,
+    delivered_by:
+      normalizeText(transport.deliveredBy ?? inv.delivered_by) || null,
+    delivery_date: normalizeOptionalDate(
+      transport.deliveryDate ?? inv.delivery_date,
+    ),
+    paid_status: normalizeText(paidStatus, "unpaid").toLowerCase(),
+    payment_type: normalizeText(paymentType, "cash").toLowerCase(),
+    aquakart_online_user: normalizeBoolean(
+      inv.aquakart_online_user ?? inv.aquakartOnlineUser,
+    ),
+    aquakart_invoice: normalizeBoolean(
+      inv.aquakart_invoice ?? inv.aquakartInvoice,
+    ),
+    total_amount: totalAmount,
+    created_at: createdAt,
+  };
+};
+
+export { normalizeBoolean, normalizeDate };

--- a/src/utils/invoice/normalizeInvoice.test.js
+++ b/src/utils/invoice/normalizeInvoice.test.js
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { mapInvoiceFromApi } from "@/utils/invoice/normalizeInvoice";
+
+describe("mapInvoiceFromApi", () => {
+  it("normalizes the invoice contract and multiplies unit prices by quantity", () => {
+    const invoice = mapInvoiceFromApi({
+      data: {
+        _id: "invoice-id",
+        invoiceNo: "AQ-2026-101",
+        date: "2026-07-20T00:00:00.000Z",
+        customerDetails: {
+          name: "Aqua Customer",
+          phone: 9000000000,
+          address: "Hyderabad",
+        },
+        gst: "true",
+        gstDetails: { gstNo: "36AAAAA0000A1Z5" },
+        products: [
+          {
+            productName: "Water Softener",
+            quantity: 2,
+            unit_price: 15_000,
+          },
+        ],
+      },
+    });
+
+    expect(invoice.id).toBe("invoice-id");
+    expect(invoice.invoice_no).toBe("AQ-2026-101");
+    expect(invoice.gst).toBe(true);
+    expect(invoice.customer_phone).toBe("9000000000");
+    expect(invoice.products[0]).toMatchObject({
+      productName: "Water Softener",
+      productQuantity: 2,
+      productPrice: 15_000,
+    });
+    expect(invoice.total_amount).toBe(30_000);
+  });
+
+  it("does not treat the string false as a true boolean", () => {
+    const invoice = mapInvoiceFromApi({ gst: "false", products: [] });
+    expect(invoice.gst).toBe(false);
+  });
+
+  it("does not invent a missing legal invoice date", () => {
+    const invoice = mapInvoiceFromApi({ products: [] });
+    expect(invoice.date).toBe("");
+    expect(invoice.created_at).toBe("");
+  });
+});

--- a/src/utils/priceUtils.js
+++ b/src/utils/priceUtils.js
@@ -1,0 +1,173 @@
+const GST_RATE = 0.18;
+
+const toFiniteNumber = (value, fallback = 0) => {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+};
+
+const toPaise = (value) => Math.round(toFiniteNumber(value) * 100);
+const fromPaise = (value) => value / 100;
+
+const belowHundredToWords = (value) => {
+  const ones = [
+    "",
+    "One",
+    "Two",
+    "Three",
+    "Four",
+    "Five",
+    "Six",
+    "Seven",
+    "Eight",
+    "Nine",
+    "Ten",
+    "Eleven",
+    "Twelve",
+    "Thirteen",
+    "Fourteen",
+    "Fifteen",
+    "Sixteen",
+    "Seventeen",
+    "Eighteen",
+    "Nineteen",
+  ];
+  const tens = [
+    "",
+    "",
+    "Twenty",
+    "Thirty",
+    "Forty",
+    "Fifty",
+    "Sixty",
+    "Seventy",
+    "Eighty",
+    "Ninety",
+  ];
+
+  if (value < 20) return ones[value];
+  return [tens[Math.floor(value / 10)], ones[value % 10]]
+    .filter(Boolean)
+    .join(" ");
+};
+
+const integerToIndianWords = (value) => {
+  if (value === 0) return "Zero";
+
+  let remaining = value;
+  const words = [];
+  const groups = [
+    [10_000_000, "Crore"],
+    [100_000, "Lakh"],
+    [1_000, "Thousand"],
+    [100, "Hundred"],
+  ];
+
+  groups.forEach(([divisor, label]) => {
+    if (remaining < divisor) return;
+
+    const groupValue = Math.floor(remaining / divisor);
+    words.push(integerToIndianWords(groupValue), label);
+    remaining %= divisor;
+  });
+
+  if (remaining > 0) {
+    if (words.length) words.push("and");
+    words.push(belowHundredToWords(remaining));
+  }
+
+  return words.filter(Boolean).join(" ");
+};
+
+/**
+ * Money helpers used by both the public invoice and its PDF export.
+ * GST is treated as included in the displayed selling price.
+ */
+const priceUtils = {
+  GST_RATE,
+
+  getBasePrice(price) {
+    return this.getGSTBreakdown(price).basePrice;
+  },
+
+  getGSTValue(price) {
+    return this.getGSTBreakdown(price).gstValue;
+  },
+
+  getGSTBreakdown(price) {
+    const grossPaise = Math.max(toPaise(price), 0);
+    const basePaise = Math.round(grossPaise / (1 + GST_RATE));
+    const gstPaise = grossPaise - basePaise;
+    const cgstPaise = Math.floor(gstPaise / 2);
+    const sgstPaise = gstPaise - cgstPaise;
+
+    return {
+      grossPrice: fromPaise(grossPaise),
+      basePrice: fromPaise(basePaise),
+      gstValue: fromPaise(gstPaise),
+      cgstValue: fromPaise(cgstPaise),
+      sgstValue: fromPaise(sgstPaise),
+    };
+  },
+
+  getInvoiceAmounts(invoice) {
+    const products = Array.isArray(invoice?.products) ? invoice.products : [];
+    const itemsTotalPaise = products.reduce((total, product) => {
+      const quantity = Math.max(
+        Math.trunc(toFiniteNumber(product?.productQuantity, 1)),
+        1,
+      );
+      return total + toPaise(product?.productPrice) * quantity;
+    }, 0);
+
+    const suppliedTotal = Number(invoice?.total_amount);
+    const grandTotalPaise =
+      Number.isFinite(suppliedTotal) && suppliedTotal >= 0
+        ? toPaise(suppliedTotal)
+        : itemsTotalPaise;
+    const grandTotal = fromPaise(grandTotalPaise);
+    const tax = invoice?.gst
+      ? this.getGSTBreakdown(grandTotal)
+      : {
+          grossPrice: grandTotal,
+          basePrice: grandTotal,
+          gstValue: 0,
+          cgstValue: 0,
+          sgstValue: 0,
+        };
+
+    return {
+      itemsTotal: fromPaise(itemsTotalPaise),
+      grandTotal,
+      ...tax,
+    };
+  },
+
+  formatAmount(value, options = {}) {
+    const { showPaise = true } = options;
+    return Number.isFinite(Number(value))
+      ? new Intl.NumberFormat("en-IN", {
+          style: "currency",
+          currency: "INR",
+          minimumFractionDigits: showPaise ? 2 : 0,
+          maximumFractionDigits: showPaise ? 2 : 0,
+        }).format(Number(value))
+      : "₹0.00";
+  },
+
+  formatCount(value) {
+    return Number.isFinite(Number(value)) ? `${Number(value)}` : "0";
+  },
+
+  numberToWords(value) {
+    const amountPaise = Math.max(toPaise(value), 0);
+    const rupees = Math.floor(amountPaise / 100);
+    const paise = amountPaise % 100;
+    const rupeeWords = `${integerToIndianWords(rupees)} Rupees`;
+    const paiseWords = paise ? ` and ${integerToIndianWords(paise)} Paise` : "";
+
+    return `${rupeeWords}${paiseWords} Only`;
+  },
+};
+
+export default priceUtils;
+export { GST_RATE, toFiniteNumber };

--- a/src/utils/priceUtils.test.js
+++ b/src/utils/priceUtils.test.js
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import priceUtils from "@/utils/priceUtils";
+
+describe("priceUtils", () => {
+  it("splits GST-inclusive totals into matching CGST and SGST values", () => {
+    const result = priceUtils.getGSTBreakdown(15_000);
+
+    expect(result).toEqual({
+      grossPrice: 15_000,
+      basePrice: 12_711.86,
+      gstValue: 2_288.14,
+      cgstValue: 1_144.07,
+      sgstValue: 1_144.07,
+    });
+  });
+
+  it("assigns the rounding remainder to SGST", () => {
+    const result = priceUtils.getGSTBreakdown(100);
+
+    expect(result.cgstValue).toBe(7.62);
+    expect(result.sgstValue).toBe(7.63);
+    expect(result.cgstValue + result.sgstValue).toBe(result.gstValue);
+  });
+
+  it("uses quantity when calculating invoice totals", () => {
+    const result = priceUtils.getInvoiceAmounts({
+      gst: false,
+      products: [
+        { productPrice: 1_000, productQuantity: 2 },
+        { productPrice: 500, productQuantity: 3 },
+      ],
+    });
+
+    expect(result.itemsTotal).toBe(3_500);
+    expect(result.grandTotal).toBe(3_500);
+  });
+
+  it("formats Indian amount words", () => {
+    expect(priceUtils.numberToWords(125_050.5)).toBe(
+      "One Lakh Twenty Five Thousand and Fifty Rupees and Fifty Paise Only",
+    );
+  });
+});


### PR DESCRIPTION
## What changed

- adds a server-rendered public invoice route at `/invoice/[id]` backed by `${NEXT_PUBLIC_API_URL}/invoice/{id}`
- introduces a premium desktop two-column invoice with products on the left and sticky customer, GST, delivery, and payment details on the right
- adds a dedicated mobile layout with persistent PDF and print actions
- normalizes legacy/current invoice response fields without inventing missing legal dates
- calculates quantity-aware totals and splits GST-inclusive tax into CGST 9% and SGST 9%, including odd-paise reconciliation
- adds a searchable multipage A4 PDF download plus print-specific styling
- prevents invoice indexing and shared caching, and provides branded 404/service error states
- includes focused tests for invoice normalization, Indian amount words, quantities, and GST rounding

## Why

Customers need a clear, shareable Aquakart invoice at `aquakart.co.in/invoice/{id}` that remains visually polished on desktop/mobile while producing a legally readable downloadable document.

## Validation

- `npm test -- --run src/utils/priceUtils.test.js src/utils/invoice/normalizeInvoice.test.js` — 7 tests passed
- focused ESLint across all new invoice files — passed
- `npm run build` — passed; Next reports `/invoice/[id]` as server-rendered
- `npm run lint` — repository baseline still fails with 68 pre-existing errors and 21 warnings in unrelated dashboard, card, shop, and utility files
- automated browser screenshots were not run because this workspace does not include a browser binary

## Implementation notes

- GST invoices currently always show CGST + SGST as agreed; place-of-supply and IGST are intentionally out of scope.
- API `total_amount` is authoritative when present; otherwise totals are derived from unit price × quantity.
- invoice responses are marked private/no-store and noindex/noarchive because they contain customer information.