### PR TITLE
Balance invoice layout and enrich product visuals

### DIFF
--- a/src/pageComponents/invoice/InvoicePage.js
+++ b/src/pageComponents/invoice/InvoicePage.js
@@ -20,6 +20,8 @@ import {
   Printer,
   ReceiptIndianRupee,
   ShieldCheck,
+  Sparkles,
+  Tags,
   Truck,
   UserRound,
 } from "lucide-react";
@@ -124,7 +126,7 @@ const ProductCard = ({ product, index }) => {
       <div className={styles.productVisual}>
         {product.productImage ? (
           // eslint-disable-next-line @next/next/no-img-element
-          <img src={product.productImage} alt="" />
+          <img src={product.productImage} alt={product.productName} />
         ) : (
           <>
             <span className={styles.productNumber}>
@@ -140,6 +142,19 @@ const ProductCard = ({ product, index }) => {
           <div>
             <span className={styles.productKicker}>Aquakart selection</span>
             <h3>{product.productName}</h3>
+            {product.productCategory || product.productSubcategory ? (
+              <div className={styles.productTags}>
+                {product.productCategory ? (
+                  <span>
+                    <Tags size={11} aria-hidden="true" />
+                    {product.productCategory}
+                  </span>
+                ) : null}
+                {product.productSubcategory ? (
+                  <span>{product.productSubcategory}</span>
+                ) : null}
+              </div>
+            ) : null}
           </div>
           <span className={styles.quantityPill}>
             {product.productQuantity}{" "}
@@ -179,6 +194,8 @@ const InvoicePage = ({ invoice, statusCode = 200 }) => {
 
   const amounts = priceUtils.getInvoiceAmounts(invoice);
   const invoiceLabel = invoice.invoice_no || invoice.id || "Invoice";
+  const customerDisplayName =
+    invoice.customer_name || invoice.gst_name || "valued customer";
 
   const handleDownload = async () => {
     if (isDownloading) return;
@@ -310,6 +327,29 @@ const InvoicePage = ({ invoice, statusCode = 200 }) => {
             <ShieldCheck size={18} />
             <span>Tax treatment</span>
             <strong>{invoice.gst ? "CGST + SGST" : "Non-GST"}</strong>
+          </div>
+        </section>
+
+        <section className={styles.greetingCard}>
+          <span className={styles.greetingIcon} aria-hidden="true">
+            <Sparkles size={25} strokeWidth={1.7} />
+          </span>
+          <div className={styles.greetingCopy}>
+            <span className={styles.eyebrow}>A note from Aquakart</span>
+            <h2>Thank you, {customerDisplayName}.</h2>
+            <p>
+              Your purchase is documented, protected and ready whenever you need
+              it. Keep this invoice for warranty and service support.
+            </p>
+          </div>
+          <div className={styles.greetingFacts}>
+            <span>
+              <BadgeCheck size={16} /> Verified purchase
+            </span>
+            <span>
+              <Package size={16} /> {invoice.products.length}{" "}
+              {invoice.products.length === 1 ? "product" : "products"}
+            </span>
           </div>
         </section>
 

--- a/src/pages/invoice/[id].js
+++ b/src/pages/invoice/[id].js
@@ -1,4 +1,5 @@
 import InvoicePage from "@/pageComponents/invoice/InvoicePage";
+import { enrichInvoiceProducts } from "@/utils/invoice/matchInvoiceProducts";
 import { mapInvoiceFromApi } from "@/utils/invoice/normalizeInvoice";
 
 const FETCH_TIMEOUT_MS = 10_000;
@@ -10,6 +11,22 @@ const normalizeRouteId = (value) => {
   const normalized = id.trim();
   if (!normalized || normalized.length > 160) return "";
   return normalized;
+};
+
+const fetchProductCatalogue = async (apiBase, signal) => {
+  try {
+    const response = await fetch(
+      `${apiBase.replace(/\/$/, "")}/all-products?query=ecom`,
+      {
+        headers: { Accept: "application/json" },
+        signal,
+      },
+    );
+
+    return response.ok ? await response.json() : [];
+  } catch {
+    return [];
+  }
 };
 
 export const getServerSideProps = async ({ params, res }) => {
@@ -34,8 +51,13 @@ export const getServerSideProps = async ({ params, res }) => {
   const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
 
   try {
+    const catalogueApiBase = process.env.NEXT_PUBLIC_API_URL || apiBase;
+    const cataloguePromise = fetchProductCatalogue(
+      catalogueApiBase,
+      controller.signal,
+    );
     const response = await fetch(
-      `${apiBase.replace(/\/$/, "")}/crm/invoice/${encodeURIComponent(id)}`,
+      `${apiBase.replace(/\/$/, "")}/invoice/${encodeURIComponent(id)}`,
       {
         headers: { Accept: "application/json" },
         signal: controller.signal,
@@ -51,7 +73,11 @@ export const getServerSideProps = async ({ params, res }) => {
     }
 
     const payload = await response.json();
-    const invoice = mapInvoiceFromApi(payload);
+    const cataloguePayload = await cataloguePromise;
+    const invoice = enrichInvoiceProducts(
+      mapInvoiceFromApi(payload),
+      cataloguePayload,
+    );
 
     if (!invoice) {
       return { props: { invoice: null, statusCode: 502 } };

--- a/src/styles/invoice.module.css
+++ b/src/styles/invoice.module.css
@@ -384,12 +384,110 @@
   white-space: nowrap;
 }
 
+.greetingCard {
+  position: relative;
+  display: grid;
+  margin: clamp(26px, 4vw, 52px) clamp(26px, 4vw, 56px) 0;
+  padding: clamp(22px, 3vw, 32px);
+  align-items: center;
+  gap: 20px;
+  overflow: hidden;
+  border: 1px solid rgba(110, 231, 199, 0.18);
+  border-radius: 28px;
+  color: white;
+  background:
+    radial-gradient(
+      circle at 88% 15%,
+      rgba(45, 212, 191, 0.25),
+      transparent 13rem
+    ),
+    linear-gradient(125deg, #07111f, #0a2631 62%, #075742 145%);
+  box-shadow: 0 22px 52px rgba(7, 17, 31, 0.15);
+  grid-template-columns: auto minmax(0, 1fr) auto;
+}
+
+.greetingCard::after {
+  position: absolute;
+  right: -3.5rem;
+  bottom: -6rem;
+  width: 14rem;
+  height: 14rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 999px;
+  box-shadow:
+    0 0 0 35px rgba(255, 255, 255, 0.018),
+    0 0 0 70px rgba(255, 255, 255, 0.012);
+  content: "";
+}
+
+.greetingIcon {
+  display: grid;
+  width: 56px;
+  height: 56px;
+  place-items: center;
+  border: 1px solid rgba(110, 231, 199, 0.24);
+  border-radius: 18px;
+  color: #6ee7c7;
+  background: rgba(16, 185, 129, 0.12);
+  box-shadow: 0 14px 30px rgba(0, 0, 0, 0.16);
+}
+
+.greetingCopy {
+  position: relative;
+  z-index: 1;
+}
+
+.greetingCopy .eyebrow {
+  color: #6ee7c7;
+}
+
+.greetingCopy h2 {
+  margin: 6px 0 7px;
+  color: white;
+  font-size: clamp(1.2rem, 2.4vw, 1.75rem);
+  letter-spacing: -0.045em;
+}
+
+.greetingCopy p {
+  max-width: 43rem;
+  margin: 0;
+  color: #aebdca;
+  font-size: 0.72rem;
+  line-height: 1.65;
+}
+
+.greetingFacts {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  min-width: 190px;
+  gap: 8px;
+}
+
+.greetingFacts span {
+  display: flex;
+  min-height: 38px;
+  padding: 0 12px;
+  align-items: center;
+  gap: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 12px;
+  color: #d8e4e8;
+  background: rgba(255, 255, 255, 0.055);
+  font-size: 0.64rem;
+  font-weight: 800;
+}
+
+.greetingFacts svg {
+  color: #6ee7c7;
+}
+
 .invoiceGrid {
   display: grid;
-  padding: clamp(26px, 4vw, 56px);
+  padding: clamp(26px, 3vw, 40px) clamp(26px, 4vw, 56px) clamp(26px, 4vw, 56px);
   align-items: start;
-  gap: clamp(28px, 4vw, 56px);
-  grid-template-columns: minmax(0, 1.32fr) minmax(330px, 0.68fr);
+  gap: clamp(24px, 3vw, 38px);
+  grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
 .sectionHeading,
@@ -452,7 +550,7 @@
   border-radius: 24px;
   background: #fff;
   box-shadow: 0 12px 30px rgba(15, 23, 42, 0.045);
-  grid-template-columns: 112px minmax(0, 1fr);
+  grid-template-columns: 132px minmax(0, 1fr);
   transition:
     border-color 180ms ease,
     transform 180ms ease,
@@ -543,6 +641,33 @@
   font-size: 0.98rem;
   letter-spacing: -0.025em;
   line-height: 1.35;
+}
+
+.productTags {
+  display: flex;
+  margin-top: 8px;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.productTags span {
+  display: inline-flex;
+  min-height: 24px;
+  padding: 0 8px;
+  align-items: center;
+  gap: 5px;
+  border: 1px solid #dcebe6;
+  border-radius: 999px;
+  color: #49655d;
+  background: #f6fbf9;
+  font-size: 0.55rem;
+  font-weight: 800;
+}
+
+.productTags span:first-child {
+  border-color: #bde8dc;
+  color: #08785a;
+  background: #eaf9f4;
 }
 
 .quantityPill {
@@ -676,9 +801,8 @@
 }
 
 .detailsRail {
-  position: sticky;
-  top: 24px;
   display: grid;
+  align-content: start;
   gap: 14px;
 }
 
@@ -796,19 +920,30 @@
 }
 
 .summaryRows {
+  display: grid;
   padding: 14px 0;
+  gap: 8px;
   border-top: 1px solid rgba(255, 255, 255, 0.1);
   border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+  grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
 .summaryRows > div {
-  display: flex;
-  padding: 7px 0;
-  align-items: center;
-  justify-content: space-between;
-  gap: 18px;
+  display: grid;
+  min-width: 0;
+  min-height: 64px;
+  padding: 10px 12px;
+  align-content: center;
+  gap: 5px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 12px;
   color: #b6c3ce;
+  background: rgba(255, 255, 255, 0.045);
   font-size: 0.69rem;
+}
+
+.summaryRows > div:first-child {
+  grid-column: 1 / -1;
 }
 
 .summaryRows small {
@@ -817,7 +952,7 @@
 
 .summaryRows strong {
   color: white;
-  font-size: 0.72rem;
+  font-size: 0.78rem;
 }
 
 .grandTotal {
@@ -1010,6 +1145,16 @@
     grid-template-columns: minmax(0, 1fr);
   }
 
+  .greetingCard {
+    grid-template-columns: auto minmax(0, 1fr);
+  }
+
+  .greetingFacts {
+    min-width: 0;
+    grid-column: 1 / -1;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
   .detailsRail {
     position: static;
     grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -1140,8 +1285,41 @@
     font-size: 0.7rem;
   }
 
+  .greetingCard {
+    margin: 18px 16px 0;
+    padding: 19px;
+    gap: 14px;
+    border-radius: 22px;
+    grid-template-columns: 46px minmax(0, 1fr);
+  }
+
+  .greetingIcon {
+    width: 46px;
+    height: 46px;
+    border-radius: 15px;
+  }
+
+  .greetingCopy h2 {
+    margin-top: 5px;
+    font-size: 1.05rem;
+  }
+
+  .greetingCopy p {
+    font-size: 0.64rem;
+  }
+
+  .greetingFacts {
+    gap: 6px;
+  }
+
+  .greetingFacts span {
+    min-height: 36px;
+    padding: 0 9px;
+    font-size: 0.57rem;
+  }
+
   .invoiceGrid {
-    padding: 28px 16px 34px;
+    padding: 24px 16px 34px;
     gap: 30px;
   }
 
@@ -1330,7 +1508,15 @@
   .invoiceGrid {
     padding: 26px;
     gap: 24px;
-    grid-template-columns: minmax(0, 1.25fr) minmax(260px, 0.75fr);
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .greetingCard {
+    margin: 24px 26px 0;
+    padding: 20px;
+    box-shadow: none;
+    print-color-adjust: exact;
+    -webkit-print-color-adjust: exact;
   }
 
   .detailsRail {
@@ -1340,6 +1526,7 @@
   .productCard,
   .detailCard,
   .summaryCard,
+  .greetingCard,
   .amountWords,
   .termsCard {
     break-inside: avoid;

--- a/src/utils/invoice/generatePublicInvoicePdf.js
+++ b/src/utils/invoice/generatePublicInvoicePdf.js
@@ -171,6 +171,30 @@ export const downloadPublicInvoicePdf = async (invoice) => {
   });
 
   y += 66;
+  const greetingLines = doc
+    .splitTextToSize(
+      `Thank you, ${invoice.customer_name || invoice.gst_name || "valued customer"}.`,
+      contentWidth - 28,
+    )
+    .slice(0, 2);
+  const greetingHeight = greetingLines.length > 1 ? 60 : 48;
+  doc.setFillColor(240, 253, 250);
+  doc.setDrawColor(167, 243, 208);
+  doc.roundedRect(margin, y, contentWidth, greetingHeight, 8, 8, "FD");
+  doc.setFont("helvetica", "bold");
+  doc.setFontSize(9);
+  doc.setTextColor(...BRAND);
+  doc.text(greetingLines, margin + 14, y + 18, { lineHeightFactor: 1.25 });
+  doc.setFont("helvetica", "normal");
+  doc.setFontSize(7.5);
+  doc.setTextColor(...MUTED);
+  doc.text(
+    "Keep this verified invoice for warranty and Aquakart service support.",
+    margin + 14,
+    y + 20 + greetingLines.length * 11,
+  );
+
+  y += greetingHeight + 14;
   const gap = 14;
   const cardWidth = (contentWidth - gap) / 2;
   const customerLines = [
@@ -215,12 +239,21 @@ export const downloadPublicInvoicePdf = async (invoice) => {
 
   invoice.products.forEach((product, index) => {
     const nameLines = doc.splitTextToSize(product.productName, 220);
+    const categoryText = [product.productCategory, product.productSubcategory]
+      .filter(Boolean)
+      .join(" / ");
+    const categoryLines = categoryText
+      ? doc.splitTextToSize(categoryText, 220)
+      : [];
     const serialLines = product.productSerialNo
       ? doc.splitTextToSize(`Serial: ${product.productSerialNo}`, 220)
       : [];
     const rowHeight = Math.max(
       45,
-      22 + nameLines.length * 11 + serialLines.length * 10,
+      22 +
+        nameLines.length * 11 +
+        categoryLines.length * 9 +
+        serialLines.length * 10,
     );
     if (y + rowHeight > height - 170) addContinuationPage();
 
@@ -234,11 +267,19 @@ export const downloadPublicInvoicePdf = async (invoice) => {
     doc.setFontSize(8.5);
     doc.setTextColor(...INK);
     doc.text(nameLines, margin + 14, y + 17);
+    let detailY = y + 17 + nameLines.length * 11;
+    if (categoryLines.length) {
+      doc.setFont("helvetica", "normal");
+      doc.setFontSize(6.8);
+      doc.setTextColor(...BRAND);
+      doc.text(categoryLines, margin + 14, detailY);
+      detailY += categoryLines.length * 9;
+    }
     if (serialLines.length) {
       doc.setFont("helvetica", "normal");
       doc.setFontSize(7);
       doc.setTextColor(...MUTED);
-      doc.text(serialLines, margin + 14, y + 17 + nameLines.length * 11);
+      doc.text(serialLines, margin + 14, detailY);
     }
     doc.setFont("helvetica", "normal");
     doc.setFontSize(8);

--- a/src/utils/invoice/matchInvoiceProducts.js
+++ b/src/utils/invoice/matchInvoiceProducts.js
@@ -1,0 +1,162 @@
+const IGNORED_NAME_TOKENS = new Set([
+  "aquakart",
+  "online",
+  "product",
+  "products",
+]);
+
+const getTextValue = (value) => {
+  if (typeof value === "string") return value.trim();
+  if (!value || typeof value !== "object") return "";
+
+  return String(value.title ?? value.name ?? value.label ?? "").trim();
+};
+
+const firstPhotoUrl = (product) => {
+  const firstPhoto = Array.isArray(product?.photos) ? product.photos[0] : null;
+  const firstImage = Array.isArray(product?.images) ? product.images[0] : null;
+  const candidates = [
+    product?.productImage,
+    product?.image,
+    product?.photo,
+    firstPhoto?.secure_url,
+    firstPhoto?.delivery_url,
+    firstPhoto?.url,
+    typeof firstPhoto === "string" ? firstPhoto : null,
+    firstImage?.secure_url,
+    firstImage?.delivery_url,
+    firstImage?.url,
+    typeof firstImage === "string" ? firstImage : null,
+  ];
+
+  return candidates.find((candidate) => typeof candidate === "string") || "";
+};
+
+const getCatalogueArray = (payload, depth = 0) => {
+  if (depth > 3) return [];
+  if (Array.isArray(payload)) return payload;
+  if (!payload || typeof payload !== "object") return [];
+  if (Array.isArray(payload.products)) return payload.products;
+  if (Array.isArray(payload.data)) return payload.data;
+
+  return getCatalogueArray(payload.data ?? payload.result, depth + 1);
+};
+
+export const normalizeProductName = (value) =>
+  String(value || "")
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .replace(/&/g, " and ")
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim()
+    .split(/\s+/)
+    .filter((token) => token && !IGNORED_NAME_TOKENS.has(token))
+    .join(" ");
+
+export const mapCatalogueProducts = (payload) =>
+  getCatalogueArray(payload)
+    .map((product) => ({
+      id: String(product?.id ?? product?._id ?? "").trim(),
+      title: String(
+        product?.title ?? product?.name ?? product?.productName ?? "",
+      ).trim(),
+      category: getTextValue(
+        product?.category ??
+          product?.categoryTitle ??
+          product?.categoryName ??
+          product?.mainCategory ??
+          product?.productCategory,
+      ),
+      subcategory: getTextValue(
+        product?.subcategory ??
+          product?.subCategory ??
+          product?.subCategoryName ??
+          product?.productSubCategory,
+      ),
+      image: firstPhotoUrl(product),
+      slug: String(product?.slug ?? "").trim(),
+    }))
+    .filter((product) => product.title);
+
+const tokenSet = (value) => new Set(normalizeProductName(value).split(" "));
+
+const hasConflictingModelTokens = (invoiceTokens, catalogueTokens) => {
+  const invoiceModelTokens = [...invoiceTokens].filter((token) =>
+    /\d/.test(token),
+  );
+  const catalogueModelTokens = [...catalogueTokens].filter((token) =>
+    /\d/.test(token),
+  );
+
+  if (!invoiceModelTokens.length || !catalogueModelTokens.length) return false;
+  return (
+    invoiceModelTokens.some((token) => !catalogueTokens.has(token)) ||
+    catalogueModelTokens.some((token) => !invoiceTokens.has(token))
+  );
+};
+
+const getMatchScore = (invoiceName, catalogueName) => {
+  const normalizedInvoice = normalizeProductName(invoiceName);
+  const normalizedCatalogue = normalizeProductName(catalogueName);
+  if (!normalizedInvoice || !normalizedCatalogue) return 0;
+  if (normalizedInvoice === normalizedCatalogue) return 1;
+
+  const invoiceTokens = tokenSet(invoiceName);
+  const catalogueTokens = tokenSet(catalogueName);
+  if (hasConflictingModelTokens(invoiceTokens, catalogueTokens)) return 0;
+
+  const intersection = [...invoiceTokens].filter((token) =>
+    catalogueTokens.has(token),
+  ).length;
+  const smallestTokenCount = Math.min(invoiceTokens.size, catalogueTokens.size);
+  if (intersection < Math.min(2, smallestTokenCount)) return 0;
+
+  const union = new Set([...invoiceTokens, ...catalogueTokens]).size;
+  const coverage = intersection / smallestTokenCount;
+  const jaccard = union ? intersection / union : 0;
+  const isContained =
+    normalizedInvoice.includes(normalizedCatalogue) ||
+    normalizedCatalogue.includes(normalizedInvoice);
+
+  return coverage * 0.68 + jaccard * 0.22 + (isContained ? 0.1 : 0);
+};
+
+export const findCatalogueProduct = (productName, catalogue) => {
+  let bestMatch = null;
+  let bestScore = 0;
+
+  catalogue.forEach((candidate) => {
+    const score = getMatchScore(productName, candidate.title);
+    if (score > bestScore) {
+      bestMatch = candidate;
+      bestScore = score;
+    }
+  });
+
+  return bestScore >= 0.78 ? bestMatch : null;
+};
+
+export const enrichInvoiceProducts = (invoice, cataloguePayload) => {
+  if (!invoice) return invoice;
+
+  const catalogue = mapCatalogueProducts(cataloguePayload);
+  if (!catalogue.length || !Array.isArray(invoice.products)) return invoice;
+
+  return {
+    ...invoice,
+    products: invoice.products.map((product) => {
+      const match = findCatalogueProduct(product.productName, catalogue);
+      if (!match) return product;
+
+      return {
+        ...product,
+        catalogueProductId: match.id,
+        productSlug: match.slug,
+        productImage: product.productImage || match.image,
+        productCategory: product.productCategory || match.category,
+        productSubcategory: product.productSubcategory || match.subcategory,
+      };
+    }),
+  };
+};

--- a/src/utils/invoice/matchInvoiceProducts.test.js
+++ b/src/utils/invoice/matchInvoiceProducts.test.js
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import {
+  enrichInvoiceProducts,
+  findCatalogueProduct,
+  mapCatalogueProducts,
+  normalizeProductName,
+} from "@/utils/invoice/matchInvoiceProducts";
+
+const cataloguePayload = {
+  data: {
+    data: [
+      {
+        _id: "kent-excell-plus",
+        title: "Kent Excell Plus",
+        slug: "kent-excell-plus",
+        category: { title: "Water Softeners" },
+        subCategory: { title: "Automatic Softeners" },
+        photos: [
+          {
+            secure_url: "https://cdn.aquakart.test/kent-excell-plus.png",
+          },
+        ],
+      },
+      {
+        _id: "kent-automatic-50l",
+        title: "Kent Automatic Water Softener 50L",
+        photos: [{ secure_url: "https://cdn.aquakart.test/50l.png" }],
+      },
+      {
+        _id: "kent-automatic-100l",
+        title: "Kent Automatic Water Softener 100L | Aquakart",
+        photos: [{ delivery_url: "https://cdn.aquakart.test/100l.png" }],
+      },
+    ],
+  },
+};
+
+describe("invoice product catalogue matching", () => {
+  it("normalizes storefront suffixes before comparing names", () => {
+    expect(normalizeProductName("Kent Excell Plus | Aquakart")).toBe(
+      "kent excell plus",
+    );
+  });
+
+  it("maps nested catalogue payloads with category and photo metadata", () => {
+    expect(mapCatalogueProducts(cataloguePayload)[0]).toMatchObject({
+      id: "kent-excell-plus",
+      title: "Kent Excell Plus",
+      category: "Water Softeners",
+      subcategory: "Automatic Softeners",
+      image: "https://cdn.aquakart.test/kent-excell-plus.png",
+    });
+  });
+
+  it("protects numeric model and capacity tokens from incorrect matches", () => {
+    const catalogue = mapCatalogueProducts(cataloguePayload);
+    expect(
+      findCatalogueProduct("Kent Automatic Water Softener 100L", catalogue)?.id,
+    ).toBe("kent-automatic-100l");
+  });
+
+  it("adds matched catalogue visuals while keeping invoice-owned values", () => {
+    const invoice = {
+      products: [
+        {
+          productName: "Kent Excell Plus | Aquakart",
+          productImage: "",
+          productCategory: "",
+          productPrice: 58_910,
+        },
+      ],
+    };
+
+    expect(
+      enrichInvoiceProducts(invoice, cataloguePayload).products[0],
+    ).toMatchObject({
+      catalogueProductId: "kent-excell-plus",
+      productImage: "https://cdn.aquakart.test/kent-excell-plus.png",
+      productCategory: "Water Softeners",
+      productSubcategory: "Automatic Softeners",
+      productPrice: 58_910,
+    });
+  });
+
+  it("leaves unmatched invoice products untouched", () => {
+    const product = { productName: "Completely custom installation package" };
+    const enriched = enrichInvoiceProducts(
+      { products: [product] },
+      cataloguePayload,
+    );
+    expect(enriched.products[0]).toEqual(product);
+  });
+});

--- a/src/utils/invoice/normalizeInvoice.js
+++ b/src/utils/invoice/normalizeInvoice.js
@@ -23,6 +23,12 @@ const normalizeText = (value, fallback = "") => {
   return String(value).trim();
 };
 
+const normalizeLabel = (value) => {
+  if (typeof value === "string") return normalizeText(value);
+  if (!value || typeof value !== "object") return "";
+  return normalizeText(value.title ?? value.name ?? value.label);
+};
+
 const firstImageUrl = (product) => {
   const candidates = [
     product?.productImage,
@@ -73,6 +79,18 @@ export const mapInvoiceFromApi = (payload) => {
             product?.productSerialNo ?? product?.serial_no,
           ),
           productImage: firstImageUrl(product),
+          productCategory: normalizeLabel(
+            product?.productCategory ??
+              product?.category ??
+              product?.categoryTitle ??
+              product?.categoryName,
+          ),
+          productSubcategory: normalizeLabel(
+            product?.productSubcategory ??
+              product?.productSubCategory ??
+              product?.subcategory ??
+              product?.subCategory,
+          ),
         };
       })
     : [];

--- a/src/utils/invoice/normalizeInvoice.test.js
+++ b/src/utils/invoice/normalizeInvoice.test.js
@@ -20,6 +20,8 @@ describe("mapInvoiceFromApi", () => {
             productName: "Water Softener",
             quantity: 2,
             unit_price: 15_000,
+            category: { title: "Softeners" },
+            subCategory: "Automatic",
           },
         ],
       },
@@ -33,6 +35,8 @@ describe("mapInvoiceFromApi", () => {
       productName: "Water Softener",
       productQuantity: 2,
       productPrice: 15_000,
+      productCategory: "Softeners",
+      productSubcategory: "Automatic",
     });
     expect(invoice.total_amount).toBe(30_000);
   });


### PR DESCRIPTION
## What changed

- rebuilds the invoice body as an even 50/50 desktop grid with aligned card spacing
- adds a personalized Aquakart greeting card on the page and in the downloadable PDF
- presents CGST and SGST in equal visual cells
- preserves category and subcategory data from invoice payloads
- enriches invoice line items server-side from the public catalogue by normalized product-name matching
- loads matched catalogue photos and category labels without adding a client-side request
- keeps invoice rendering resilient when catalogue loading or matching is unavailable

## Why

The original invoice view gave the product column substantially more width than the customer and GST rail, which made the legal details feel compressed. Product line items also lacked the catalogue context and imagery available elsewhere in the store.

## Customer impact

Customers get a clearer, more welcoming invoice with balanced information hierarchy, recognizable product imagery, visible categories, and the same enriched context in PDF exports. Numeric model and capacity tokens are protected during matching to reduce the risk of showing the wrong product image.

## Validation

- `npm test` — 12 files / 43 tests passed
- focused invoice ESLint checks passed
- `npm run build` passed; `/invoice/[id]` remains server-rendered
- `git diff --check` passed