### PR TITLE
Refine invoice product presentation and tax details

### DIFF
--- a/src/pageComponents/invoice/InvoicePage.js
+++ b/src/pageComponents/invoice/InvoicePage.js
@@ -123,38 +123,43 @@ const ProductCard = ({ product, index }) => {
 
   return (
     <article className={styles.productCard}>
-      <div className={styles.productVisual}>
-        {product.productImage ? (
-          // eslint-disable-next-line @next/next/no-img-element
-          <img src={product.productImage} alt={product.productName} />
-        ) : (
-          <>
-            <span className={styles.productNumber}>
-              {String(index + 1).padStart(2, "0")}
-            </span>
-            <Package size={30} strokeWidth={1.45} aria-hidden="true" />
-          </>
-        )}
+      <div className={styles.productShowcase}>
+        <div className={styles.productVisual}>
+          <span className={styles.productNumber}>
+            {String(index + 1).padStart(2, "0")}
+          </span>
+          {product.productImage ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img src={product.productImage} alt={product.productName} />
+          ) : (
+            <Package size={44} strokeWidth={1.35} aria-hidden="true" />
+          )}
+        </div>
+
+        <div className={styles.productIdentity}>
+          <span className={styles.productKicker}>Aquakart selection</span>
+          <h3>{product.productName}</h3>
+          {product.productCategory || product.productSubcategory ? (
+            <div className={styles.productTags}>
+              {product.productCategory ? (
+                <span>
+                  <Tags size={11} aria-hidden="true" />
+                  {product.productCategory}
+                </span>
+              ) : null}
+              {product.productSubcategory ? (
+                <span>{product.productSubcategory}</span>
+              ) : null}
+            </div>
+          ) : null}
+        </div>
       </div>
 
       <div className={styles.productContent}>
-        <div className={styles.productHeading}>
+        <div className={styles.productTopline}>
           <div>
-            <span className={styles.productKicker}>Aquakart selection</span>
-            <h3>{product.productName}</h3>
-            {product.productCategory || product.productSubcategory ? (
-              <div className={styles.productTags}>
-                {product.productCategory ? (
-                  <span>
-                    <Tags size={11} aria-hidden="true" />
-                    {product.productCategory}
-                  </span>
-                ) : null}
-                {product.productSubcategory ? (
-                  <span>{product.productSubcategory}</span>
-                ) : null}
-              </div>
-            ) : null}
+            <span>Line item</span>
+            <strong>{String(index + 1).padStart(2, "0")}</strong>
           </div>
           <span className={styles.quantityPill}>
             {product.productQuantity}{" "}
@@ -172,12 +177,23 @@ const ProductCard = ({ product, index }) => {
           <div>
             <span>Unit price</span>
             <strong>{priceUtils.formatAmount(product.productPrice)}</strong>
+            <small>per supplied unit</small>
           </div>
-          <span className={styles.multiply}>× {product.productQuantity}</span>
+          <div>
+            <span>Quantity</span>
+            <strong>× {product.productQuantity}</strong>
+            <small>confirmed quantity</small>
+          </div>
           <div className={styles.lineTotal}>
             <span>Line total</span>
             <strong>{priceUtils.formatAmount(lineTotal)}</strong>
+            <small>invoice contribution</small>
           </div>
+        </div>
+
+        <div className={styles.productCalculationNote}>
+          <ReceiptIndianRupee size={15} aria-hidden="true" />
+          Unit price × confirmed quantity equals this line total.
         </div>
       </div>
     </article>
@@ -294,7 +310,7 @@ const InvoicePage = ({ invoice, statusCode = 200 }) => {
             </div>
             <div>
               <span className={styles.eyebrow}>Premium water solutions</span>
-              <h1>Tax Invoice</h1>
+              <h1>{invoice.gst ? "GST Tax Invoice" : "Invoice"}</h1>
               <p>GSTIN 36AJOPH6387A1Z2</p>
             </div>
           </div>
@@ -508,19 +524,31 @@ const InvoicePage = ({ invoice, statusCode = 200 }) => {
             <section className={styles.summaryCard}>
               <div className={styles.summaryTopline}>
                 <div>
-                  <small>Payment summary</small>
-                  <h2>Invoice total</h2>
+                  <small>
+                    {invoice.gst ? "GST tax invoice" : "Standard invoice"}
+                  </small>
+                  <h2>Price calculation</h2>
                 </div>
                 <FileText size={21} />
               </div>
 
               <div className={styles.summaryRows}>
-                <div>
-                  <span>{invoice.gst ? "Taxable value" : "Subtotal"}</span>
+                <div className={styles.summaryPriceCell}>
+                  <span>Base price</span>
                   <strong>{priceUtils.formatAmount(amounts.basePrice)}</strong>
+                  <small>Before applicable GST</small>
+                </div>
+                <div className={styles.summaryPriceCell}>
+                  <span>
+                    GST <small>{invoice.gst ? "18%" : "0%"}</small>
+                  </span>
+                  <strong>{priceUtils.formatAmount(amounts.gstValue)}</strong>
+                  <small>
+                    {invoice.gst ? "Included in total" : "Not applied"}
+                  </small>
                 </div>
                 {invoice.gst ? (
-                  <>
+                  <div className={styles.gstBreakdown}>
                     <div>
                       <span>
                         CGST <small>9%</small>
@@ -537,14 +565,21 @@ const InvoicePage = ({ invoice, statusCode = 200 }) => {
                         {priceUtils.formatAmount(amounts.sgstValue)}
                       </strong>
                     </div>
-                  </>
+                    <p>
+                      CGST + SGST equals the complete 18% GST value shown above.
+                    </p>
+                  </div>
                 ) : null}
               </div>
 
               <div className={styles.grandTotal}>
                 <span>Total amount</span>
                 <strong>{priceUtils.formatAmount(amounts.grandTotal)}</strong>
-                <small>Inclusive of applicable taxes</small>
+                <small>
+                  {invoice.gst
+                    ? "Base price + 18% GST"
+                    : "Base price + GST ₹0.00"}
+                </small>
               </div>
 
               <div className={styles.paymentState}>

--- a/src/styles/invoice.module.css
+++ b/src/styles/invoice.module.css
@@ -545,12 +545,13 @@
 .productCard {
   display: grid;
   min-width: 0;
-  padding: 12px;
+  padding: 14px;
+  gap: 14px;
   border: 1px solid #dfe9e6;
-  border-radius: 24px;
+  border-radius: 28px;
   background: #fff;
   box-shadow: 0 12px 30px rgba(15, 23, 42, 0.045);
-  grid-template-columns: 132px minmax(0, 1fr);
+  grid-template-columns: minmax(210px, 0.95fr) minmax(0, 1.05fr);
   transition:
     border-color 180ms ease,
     transform 180ms ease,
@@ -563,21 +564,34 @@
   transform: translateY(-2px);
 }
 
+.productShowcase {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+}
+
 .productVisual {
   position: relative;
   display: grid;
-  min-height: 124px;
+  min-height: 230px;
+  padding: 18px;
   place-items: center;
   overflow: hidden;
-  border-radius: 18px;
+  border: 1px solid rgba(16, 185, 129, 0.1);
+  border-radius: 22px;
   color: #08785a;
   background:
     radial-gradient(
-      circle at 70% 20%,
-      rgba(45, 212, 191, 0.22),
-      transparent 3rem
+      circle at 74% 24%,
+      rgba(56, 189, 248, 0.19),
+      transparent 7rem
     ),
-    linear-gradient(145deg, #effcf7, #ecf8fb);
+    radial-gradient(
+      circle at 20% 88%,
+      rgba(45, 212, 191, 0.19),
+      transparent 7rem
+    ),
+    linear-gradient(145deg, #f2fffa, #edf8fc);
 }
 
 .productVisual::after {
@@ -595,7 +609,14 @@
   z-index: 1;
   width: 100%;
   height: 100%;
+  max-height: 220px;
   object-fit: contain;
+  filter: drop-shadow(0 18px 22px rgba(15, 23, 42, 0.13));
+  transition: transform 320ms ease;
+}
+
+.productCard:hover .productVisual img {
+  transform: scale(1.035) translateY(-2px);
 }
 
 .productVisual svg {
@@ -606,25 +627,74 @@
 .productNumber {
   position: absolute;
   z-index: 2;
-  top: 10px;
-  left: 10px;
-  font-size: 0.58rem;
+  top: 13px;
+  left: 13px;
+  display: grid;
+  width: 29px;
+  height: 29px;
+  place-items: center;
+  border: 1px solid rgba(255, 255, 255, 0.9);
+  border-radius: 9px;
+  color: white;
+  background: #07111f;
+  box-shadow: 0 8px 18px rgba(7, 17, 31, 0.18);
+  font-size: 0.55rem;
   font-weight: 900;
+}
+
+.productIdentity {
+  padding: 15px 8px 5px;
+}
+
+.productIdentity h3 {
+  margin: 6px 0 0;
+  overflow-wrap: anywhere;
+  font-size: 0.96rem;
+  letter-spacing: -0.03em;
+  line-height: 1.4;
 }
 
 .productContent {
   display: flex;
   min-width: 0;
-  padding: 6px 8px 6px 18px;
+  padding: 18px;
   flex-direction: column;
   justify-content: space-between;
+  border: 1px solid #e3ece9;
+  border-radius: 22px;
+  background:
+    linear-gradient(rgba(226, 232, 240, 0.24) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(226, 232, 240, 0.24) 1px, transparent 1px),
+    #f9fcfb;
+  background-size: 18px 18px;
 }
 
-.productHeading {
+.productTopline {
   display: flex;
-  align-items: flex-start;
+  padding-bottom: 14px;
+  align-items: center;
   justify-content: space-between;
   gap: 12px;
+  border-bottom: 1px solid #e1ebe8;
+}
+
+.productTopline > div span,
+.productTopline > div strong {
+  display: block;
+}
+
+.productTopline > div span {
+  color: var(--invoice-muted);
+  font-size: 0.54rem;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.productTopline > div strong {
+  margin-top: 3px;
+  color: var(--invoice-green);
+  font-size: 0.76rem;
 }
 
 .productKicker {
@@ -633,14 +703,6 @@
   font-weight: 900;
   letter-spacing: 0.12em;
   text-transform: uppercase;
-}
-
-.productHeading h3 {
-  margin: 5px 0 0;
-  overflow-wrap: anywhere;
-  font-size: 0.98rem;
-  letter-spacing: -0.025em;
-  line-height: 1.35;
 }
 
 .productTags {
@@ -683,7 +745,7 @@
 .serialNumber {
   display: inline-flex;
   width: fit-content;
-  margin: 9px 0;
+  margin: 13px 0 0;
   padding: 5px 8px;
   align-items: center;
   gap: 4px;
@@ -695,12 +757,21 @@
 
 .productPriceRow {
   display: grid;
-  margin-top: 12px;
-  padding-top: 12px;
-  align-items: end;
-  gap: 12px;
-  border-top: 1px dashed #dce5e3;
-  grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
+  margin-top: 14px;
+  align-items: stretch;
+  gap: 8px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.productPriceRow > div {
+  display: grid;
+  min-width: 0;
+  min-height: 78px;
+  padding: 12px;
+  align-content: center;
+  border: 1px solid #dfe9e6;
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.82);
 }
 
 .productPriceRow div span,
@@ -715,19 +786,45 @@
 }
 
 .productPriceRow strong {
-  font-size: 0.8rem;
+  overflow-wrap: anywhere;
+  font-size: 0.78rem;
 }
 
-.multiply {
-  color: #94a3b8;
-  font-size: 0.67rem;
+.productPriceRow div small {
+  display: block;
+  margin-top: 5px;
+  color: #8a9aaa;
+  font-size: 0.5rem;
+  line-height: 1.4;
 }
 
 .lineTotal {
-  text-align: right;
+  grid-column: 1 / -1;
+  text-align: left;
 }
 
 .lineTotal strong {
+  color: var(--invoice-green);
+  font-size: 1.08rem;
+  letter-spacing: -0.035em;
+}
+
+.productCalculationNote {
+  display: flex;
+  margin-top: 10px;
+  padding: 10px 11px;
+  align-items: flex-start;
+  gap: 7px;
+  border-radius: 12px;
+  color: #587068;
+  background: #eaf8f3;
+  font-size: 0.55rem;
+  font-weight: 700;
+  line-height: 1.5;
+}
+
+.productCalculationNote svg {
+  flex: 0 0 auto;
   color: var(--invoice-green);
 }
 
@@ -928,11 +1025,11 @@
   grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
-.summaryRows > div {
+.summaryRows > .summaryPriceCell {
   display: grid;
   min-width: 0;
-  min-height: 64px;
-  padding: 10px 12px;
+  min-height: 82px;
+  padding: 12px;
   align-content: center;
   gap: 5px;
   border: 1px solid rgba(255, 255, 255, 0.08);
@@ -942,12 +1039,49 @@
   font-size: 0.69rem;
 }
 
-.summaryRows > div:first-child {
+.summaryPriceCell > small {
+  margin-top: 1px;
+  color: #8397a6;
+  font-size: 0.51rem;
+  line-height: 1.4;
+}
+
+.summaryRows > .gstBreakdown {
+  display: grid;
+  padding: 10px;
+  gap: 8px;
+  border: 1px solid rgba(110, 231, 199, 0.18);
+  border-radius: 14px;
+  background: rgba(16, 185, 129, 0.08);
+  grid-column: 1 / -1;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.gstBreakdown > div {
+  display: grid;
+  min-height: 62px;
+  padding: 10px;
+  align-content: center;
+  gap: 5px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.gstBreakdown p {
+  margin: 0;
+  color: #8295a4;
+  font-size: 0.51rem;
+  line-height: 1.5;
   grid-column: 1 / -1;
 }
 
 .summaryRows small {
   color: #6ee7c7;
+}
+
+.summaryRows .summaryPriceCell > small {
+  color: #8397a6;
 }
 
 .summaryRows strong {
@@ -1335,43 +1469,53 @@
 
   .productCard {
     padding: 10px;
+    gap: 10px;
     border-radius: 20px;
-    grid-template-columns: 82px minmax(0, 1fr);
+    grid-template-columns: minmax(0, 1fr);
   }
 
   .productVisual {
-    min-height: 118px;
-    border-radius: 15px;
+    min-height: 250px;
+    aspect-ratio: 4 / 3;
+    border-radius: 18px;
+  }
+
+  .productVisual img {
+    max-height: 235px;
+  }
+
+  .productIdentity {
+    padding: 14px 7px 8px;
+  }
+
+  .productIdentity h3 {
+    font-size: 0.9rem;
   }
 
   .productContent {
-    padding: 3px 4px 3px 12px;
-  }
-
-  .productHeading {
-    display: block;
-  }
-
-  .productHeading h3 {
-    padding-right: 2px;
-    font-size: 0.78rem;
+    padding: 15px;
+    border-radius: 18px;
   }
 
   .quantityPill {
-    display: inline-block;
-    margin-top: 7px;
+    padding: 6px 8px;
   }
 
   .productPriceRow {
-    gap: 6px;
+    gap: 7px;
+  }
+
+  .productPriceRow > div {
+    min-height: 73px;
+    padding: 10px;
   }
 
   .productPriceRow strong {
-    font-size: 0.67rem;
+    font-size: 0.72rem;
   }
 
-  .multiply {
-    font-size: 0.58rem;
+  .lineTotal strong {
+    font-size: 1rem;
   }
 
   .detailsRail {
@@ -1521,6 +1665,43 @@
 
   .detailsRail {
     position: static;
+  }
+
+  .productCard {
+    padding: 8px;
+    gap: 8px;
+    grid-template-columns: 112px minmax(0, 1fr);
+  }
+
+  .productVisual {
+    min-height: 132px;
+    padding: 8px;
+  }
+
+  .productVisual img {
+    max-height: 120px;
+  }
+
+  .productIdentity {
+    padding: 10px 4px 2px;
+  }
+
+  .productIdentity h3 {
+    font-size: 0.72rem;
+  }
+
+  .productContent {
+    padding: 10px;
+  }
+
+  .productPriceRow {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .productPriceRow > div,
+  .lineTotal {
+    min-height: 46px;
+    grid-column: auto;
   }
 
   .productCard,

--- a/src/utils/invoice/generatePublicInvoicePdf.js
+++ b/src/utils/invoice/generatePublicInvoicePdf.js
@@ -41,6 +41,7 @@ const titleCase = (value) =>
 
 const drawPageHeader = (doc, invoice, continued = false) => {
   const width = doc.internal.pageSize.getWidth();
+  const invoiceTitle = invoice.gst ? "GST TAX INVOICE" : "INVOICE";
   doc.setFillColor(...BRAND);
   doc.rect(0, 0, width, 92, "F");
   doc.setFillColor(...BRAND_BRIGHT);
@@ -58,7 +59,7 @@ const drawPageHeader = (doc, invoice, continued = false) => {
   doc.setFont("helvetica", "bold");
   doc.setFontSize(12);
   doc.text(
-    continued ? "TAX INVOICE / CONTINUED" : "TAX INVOICE",
+    continued ? `${invoiceTitle} / CONTINUED` : invoiceTitle,
     width - 42,
     42,
     {
@@ -230,11 +231,11 @@ export const downloadPublicInvoicePdf = async (invoice) => {
   y += Math.max(customerHeight, gstHeight) + 20;
   y = drawProductHeader(doc, y);
 
-  const addContinuationPage = () => {
+  const addContinuationPage = (showProductHeader = true) => {
     drawFooter(doc);
     doc.addPage();
     drawPageHeader(doc, invoice, true);
-    y = drawProductHeader(doc, 112);
+    y = showProductHeader ? drawProductHeader(doc, 112) : 112;
   };
 
   invoice.products.forEach((product, index) => {
@@ -305,13 +306,14 @@ export const downloadPublicInvoicePdf = async (invoice) => {
     y += 46;
   }
 
-  if (y + 190 > height - 65) addContinuationPage();
+  const summaryCardHeight = invoice.gst ? 166 : 136;
+  if (y + summaryCardHeight + 78 > height) addContinuationPage(false);
   y += 18;
 
   const wordsWidth = contentWidth * 0.54;
   doc.setFillColor(240, 253, 250);
   doc.setDrawColor(167, 243, 208);
-  doc.roundedRect(margin, y, wordsWidth, 130, 10, 10, "FD");
+  doc.roundedRect(margin, y, wordsWidth, summaryCardHeight, 10, 10, "FD");
   doc.setFont("helvetica", "bold");
   doc.setFontSize(8);
   doc.setTextColor(...BRAND);
@@ -327,22 +329,28 @@ export const downloadPublicInvoicePdf = async (invoice) => {
   doc.setFontSize(7.5);
   doc.setTextColor(...MUTED);
   doc.text(
-    "GST is included in the invoice total where applicable.",
+    invoice.gst
+      ? "The GST total is divided equally into CGST and SGST."
+      : "No GST is applied to this standard invoice.",
     margin + 15,
-    y + 109,
+    y + summaryCardHeight - 21,
   );
 
   const summaryX = margin + wordsWidth + gap;
   const summaryWidth = contentWidth - wordsWidth - gap;
   doc.setFillColor(...INK);
-  doc.roundedRect(summaryX, y, summaryWidth, 130, 10, 10, "F");
+  doc.roundedRect(summaryX, y, summaryWidth, summaryCardHeight, 10, 10, "F");
   const summaryRows = invoice.gst
     ? [
-        ["Taxable value", amounts.basePrice],
+        ["Base price", amounts.basePrice],
+        ["GST (18%)", amounts.gstValue],
         ["CGST (9%)", amounts.cgstValue],
         ["SGST (9%)", amounts.sgstValue],
       ]
-    : [["Subtotal", amounts.grandTotal]];
+    : [
+        ["Base price", amounts.basePrice],
+        ["GST (0%)", amounts.gstValue],
+      ];
   let rowY = y + 25;
   summaryRows.forEach(([label, value]) => {
     doc.setFont("helvetica", "normal");

--- a/src/utils/priceUtils.test.js
+++ b/src/utils/priceUtils.test.js
@@ -32,6 +32,10 @@ describe("priceUtils", () => {
     });
 
     expect(result.itemsTotal).toBe(3_500);
+    expect(result.basePrice).toBe(3_500);
+    expect(result.gstValue).toBe(0);
+    expect(result.cgstValue).toBe(0);
+    expect(result.sgstValue).toBe(0);
     expect(result.grandTotal).toBe(3_500);
   });
 


### PR DESCRIPTION
## What changed

- enlarges the product photo into a dedicated visual panel on the left
- places the product name, category, and subcategory directly beneath the photo
- moves quantity, unit price, and line total into a structured calculation panel on the right
- labels non-GST documents as `Invoice` and GST documents as `GST Tax Invoice`
- shows Base price, GST, and Total on every invoice
- shows the 18% GST total plus an equal CGST 9% / SGST 9% breakdown only for GST invoices
- carries the same invoice type and tax calculation detail into the downloadable PDF
- improves responsive and print layouts for the larger product treatment

## Why

This follows the first invoice redesign in #51. The earlier product line was still too compact, and the relationship between base price, GST, the CGST/SGST split, and the final total needed a clearer legal and visual hierarchy.

## Customer impact

Customers can recognize the supplied product immediately, read its identity directly below the image, and understand exactly how the invoice total is formed. Standard invoices clearly show zero GST, while GST invoices expose both the combined GST amount and its CGST/SGST split without showing those tax components on non-GST invoices.

## Validation

- `npm test` — 12 files / 43 tests passed
- focused invoice ESLint checks passed
- `npm run build` passed; `/invoice/[id]` remains server-rendered
- `git diff --check` passed