### PR TITLE
Add professional invoice terms and PO payment instructions

### DIFF
--- a/src/constants/invoiceStaticData.js
+++ b/src/constants/invoiceStaticData.js
@@ -1,0 +1,113 @@
+import {
+  CalendarCheck,
+  CreditCard,
+  Plug,
+  RefreshCcw,
+  Truck,
+  Undo2,
+  UserCheck,
+  Wrench,
+} from "lucide-react";
+
+export const termsAndConditions = [
+  {
+    icon: Truck,
+    title: "Transport and Site Handling",
+    description:
+      "Transportation, unloading and lifting charges, where applicable, shall be borne by the customer. Any additional charge will be communicated before dispatch or installation for prior acknowledgement.",
+  },
+  {
+    icon: Wrench,
+    title: "Site Plumbing Readiness",
+    description:
+      "The customer is responsible for ensuring that basic plumbing arrangements are ready before installation. Assistance from an authorised plumbing partner may be arranged at an additional, pre-communicated cost.",
+  },
+  {
+    icon: Plug,
+    title: "Materials and Utility Connections",
+    description:
+      "Standard plumbing materials, electrical points and utility connections are to be provided at site by the customer. Special requirements, including booster-pump connections, will be quoted separately before work begins.",
+  },
+  {
+    icon: CalendarCheck,
+    title: "Delivery and Installation Schedule",
+    description:
+      "Delivery and installation are ordinarily completed within seven working days of confirmed order receipt, subject to product availability, site readiness and safe accessibility.",
+  },
+  {
+    icon: CreditCard,
+    title: "Payment and Order Confirmation",
+    description:
+      "Full advance payment together with the applicable purchase order is required to confirm processing, dispatch and installation scheduling. Work commences after payment realisation and order verification.",
+  },
+  {
+    icon: Undo2,
+    title: "Sales and Returns",
+    description:
+      "Products cannot be returned after unboxing, use or commencement of installation. Customers are requested to verify the model, capacity, specifications and site suitability before authorising installation.",
+  },
+  {
+    icon: RefreshCcw,
+    title: "Transit Damage and Replacement",
+    description:
+      "Manufacturing defects or visible transit damage must be reported within 48 hours of delivery with supporting photographs and invoice details. Eligible replacements will be processed after inspection in accordance with company policy.",
+  },
+  {
+    icon: UserCheck,
+    title: "Commissioning and Service Handover",
+    description:
+      "Authorised service engineers will verify plumbing, commission the system, explain operating procedures and facilitate warranty registration to support safe and reliable product performance.",
+  },
+];
+
+export const customerCare = [
+  {
+    name: "Grundfos Customer Care",
+    description: "For Grundfos product and service-related assistance",
+    phone: "18001022535",
+  },
+  {
+    name: "Crompton Customer Care",
+    description: "For Crompton product and service-related assistance",
+    phone: "+919228880505",
+  },
+  {
+    name: "Kent Customer Care",
+    description: "For Kent product and service-related assistance",
+    phone: "+919278912345",
+  },
+];
+
+export const bankPaymentMethods = [
+  {
+    key: "iciciDetails",
+    type: "bank",
+    name: "ICICI Bank",
+    accountName: "Kundana Enterprises",
+    accountNumber: "8813356673",
+    ifsc: "ICIC0001316",
+  },
+  {
+    key: "kotakDetails",
+    type: "bank",
+    name: "Kotak Mahindra Bank",
+    accountName: "Kundana Enterprises",
+    accountNumber: "131605003314",
+    ifsc: "KKBK0007463",
+  },
+  {
+    key: "upiDetails",
+    type: "upi",
+    name: "UPI Payment",
+    gpay: "9182119842",
+    phonePe: "9182119842",
+  },
+];
+
+export const bankCopyDetails = {
+  iciciDetails:
+    "ICICI Bank\nA/c Name: Kundana Enterprises\nA/c No: 8813356673\nIFSC: ICIC0001316",
+  kotakDetails:
+    "Kotak Mahindra Bank\nA/c Name: Kundana Enterprises\nA/c No: 131605003314\nIFSC: KKBK0007463",
+  upiDetails: "UPI\nGPay: 9182119842\nPhonePe: 9182119842",
+};

--- a/src/pageComponents/invoice/InvoicePage.js
+++ b/src/pageComponents/invoice/InvoicePage.js
@@ -12,6 +12,7 @@ import {
   Download,
   FileText,
   Hash,
+  Headphones,
   Landmark,
   Mail,
   MapPin,
@@ -27,6 +28,12 @@ import {
 } from "lucide-react";
 import { toast } from "sonner";
 import logo from "@/assests/logo.png";
+import {
+  bankCopyDetails,
+  bankPaymentMethods,
+  customerCare,
+  termsAndConditions,
+} from "@/constants/invoiceStaticData";
 import priceUtils from "@/utils/priceUtils";
 import styles from "@/styles/invoice.module.css";
 
@@ -200,9 +207,100 @@ const ProductCard = ({ product, index }) => {
   );
 };
 
+const TermCard = ({ term, index }) => {
+  const Icon = term.icon;
+
+  return (
+    <article className={styles.termItem}>
+      <div className={styles.termTopline}>
+        <span className={styles.termIcon} aria-hidden="true">
+          <Icon size={18} strokeWidth={1.7} />
+        </span>
+        <span className={styles.termNumber}>
+          {String(index + 1).padStart(2, "0")}
+        </span>
+      </div>
+      <h3>{term.title}</h3>
+      <p>{term.description}</p>
+    </article>
+  );
+};
+
+const CustomerCareCard = ({ contact }) => (
+  <article className={styles.careCard}>
+    <span className={styles.careIcon} aria-hidden="true">
+      <Headphones size={18} strokeWidth={1.7} />
+    </span>
+    <div>
+      <strong>{contact.name}</strong>
+      <p>{contact.description}</p>
+      <a href={`tel:${contact.phone}`}>
+        <Phone size={13} /> {contact.phone}
+      </a>
+    </div>
+  </article>
+);
+
+const BankMethodCard = ({ method, copied, onCopy }) => {
+  const isUpi = method.type === "upi";
+
+  return (
+    <article className={styles.bankCard}>
+      <div className={styles.bankTopline}>
+        <span className={styles.bankIcon} aria-hidden="true">
+          {isUpi ? (
+            <CreditCard size={19} strokeWidth={1.7} />
+          ) : (
+            <Landmark size={19} strokeWidth={1.7} />
+          )}
+        </span>
+        <span>{isUpi ? "Digital payment" : "Bank transfer"}</span>
+      </div>
+
+      <h3>{method.name}</h3>
+
+      <dl className={styles.bankDetails}>
+        {isUpi ? (
+          <>
+            <div>
+              <dt>Google Pay</dt>
+              <dd>{method.gpay}</dd>
+            </div>
+            <div>
+              <dt>PhonePe</dt>
+              <dd>{method.phonePe}</dd>
+            </div>
+          </>
+        ) : (
+          <>
+            <div>
+              <dt>Account name</dt>
+              <dd>{method.accountName}</dd>
+            </div>
+            <div>
+              <dt>Account number</dt>
+              <dd>{method.accountNumber}</dd>
+            </div>
+            <div>
+              <dt>IFSC</dt>
+              <dd>{method.ifsc}</dd>
+            </div>
+          </>
+        )}
+      </dl>
+
+      <button type="button" onClick={() => onCopy(method)}>
+        {copied ? <Check size={14} /> : <Copy size={14} />}
+        {copied ? "Copied" : "Copy payment details"}
+      </button>
+    </article>
+  );
+};
+
 const InvoicePage = ({ invoice, statusCode = 200 }) => {
   const [isDownloading, setIsDownloading] = useState(false);
   const [copied, setCopied] = useState(false);
+  const [copiedPayment, setCopiedPayment] = useState("");
 
   if (!invoice || statusCode !== 200) {
     return <InvoiceError statusCode={statusCode} />;
@@ -237,6 +335,17 @@ const InvoicePage = ({ invoice, statusCode = 200 }) => {
       window.setTimeout(() => setCopied(false), 1800);
     } catch {
       toast.error("Could not copy the invoice link");
+    }
+  };
+
+  const handleCopyPaymentDetails = async (method) => {
+    try {
+      await navigator.clipboard.writeText(bankCopyDetails[method.key]);
+      setCopiedPayment(method.key);
+      toast.success(`${method.name} details copied`);
+      window.setTimeout(() => setCopiedPayment(""), 1800);
+    } catch {
+      toast.error("Could not copy the payment details");
     }
   };
 
@@ -411,18 +520,6 @@ const InvoicePage = ({ invoice, statusCode = 200 }) => {
               <span>Amount in words</span>
               <strong>{priceUtils.numberToWords(amounts.grandTotal)}</strong>
             </div>
-
-            <div className={styles.termsCard}>
-              <ShieldCheck size={22} />
-              <div>
-                <strong>Protected by Aquakart service standards</strong>
-                <p>
-                  Warranty follows the manufacturer policy. Installation,
-                  transport and lifting are chargeable unless agreed separately.
-                  Opened or used products are not returnable.
-                </p>
-              </div>
-            </div>
           </section>
 
           <aside className={styles.detailsRail}>
@@ -589,6 +686,97 @@ const InvoicePage = ({ invoice, statusCode = 200 }) => {
             </section>
           </aside>
         </div>
+
+        <section className={styles.legalSection}>
+          <div className={styles.legalHeading}>
+            <div className={styles.legalTitleGroup}>
+              <span className={styles.sectionIndex}>02</span>
+              <div>
+                <span className={styles.eyebrow}>Commercial framework</span>
+                <h2>Terms, responsibilities and service standards</h2>
+              </div>
+            </div>
+            <p>
+              These terms form part of this invoice and clarify the delivery,
+              installation, payment and after-sales responsibilities associated
+              with the supplied products.
+            </p>
+          </div>
+
+          <div className={styles.termsGrid}>
+            {termsAndConditions.map((term, index) => (
+              <TermCard key={term.title} term={term} index={index} />
+            ))}
+          </div>
+
+          <div className={styles.serviceAssurance}>
+            <div>
+              <ShieldCheck size={23} strokeWidth={1.7} />
+              <div>
+                <span>Service assurance</span>
+                <strong>Protected by Aquakart support standards</strong>
+              </div>
+            </div>
+            <p>
+              Retain this invoice for installation verification, warranty
+              registration, service coordination and eligible replacement
+              requests.
+            </p>
+          </div>
+
+          <div className={styles.careSection}>
+            <div className={styles.careHeading}>
+              <div>
+                <span className={styles.eyebrow}>Manufacturer assistance</span>
+                <h3>Customer-care directory</h3>
+              </div>
+              <span>Direct product support</span>
+            </div>
+            <div className={styles.careGrid}>
+              {customerCare.map((contact) => (
+                <CustomerCareCard key={contact.name} contact={contact} />
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {invoice.po ? (
+          <section className={styles.paymentInstructions}>
+            <div className={styles.paymentHeading}>
+              <div className={styles.paymentTitleGroup}>
+                <span className={styles.paymentIndex}>03</span>
+                <div>
+                  <span className={styles.eyebrow}>Purchase-order payment</span>
+                  <h2>Approved remittance details</h2>
+                </div>
+              </div>
+              <p>
+                Use the invoice number as the payment reference and share the
+                remittance confirmation with Aquakart for allocation.
+              </p>
+            </div>
+
+            <div className={styles.bankGrid}>
+              {bankPaymentMethods.map((method) => (
+                <BankMethodCard
+                  key={method.key}
+                  method={method}
+                  copied={copiedPayment === method.key}
+                  onCopy={handleCopyPaymentDetails}
+                />
+              ))}
+            </div>
+
+            <div className={styles.paymentNotice}>
+              <BadgeCheck size={18} />
+              <p>
+                Payment instructions are displayed because this invoice is
+                linked to a purchase order. Please verify the beneficiary name,
+                account number and IFSC before initiating a transfer.
+              </p>
+            </div>
+          </section>
+        ) : null}
 
         <footer className={styles.invoiceFooter}>
           <div>

--- a/src/styles/invoice.module.css
+++ b/src/styles/invoice.module.css
@@ -1134,6 +1134,424 @@
   font-size: 0.61rem;
 }
 
+.legalSection {
+  padding: clamp(32px, 5vw, 64px) clamp(26px, 4vw, 56px);
+  border-top: 1px solid #e4ece9;
+  background:
+    radial-gradient(circle at 7% 0, rgba(45, 212, 191, 0.1), transparent 18rem),
+    linear-gradient(180deg, #f8fcfa, #f2f8f6);
+}
+
+.legalHeading,
+.paymentHeading {
+  display: grid;
+  margin-bottom: 26px;
+  align-items: end;
+  gap: 28px;
+  grid-template-columns: minmax(0, 1fr) minmax(280px, 0.62fr);
+}
+
+.legalTitleGroup,
+.paymentTitleGroup {
+  display: flex;
+  align-items: center;
+  gap: 15px;
+}
+
+.legalHeading h2,
+.paymentHeading h2 {
+  margin: 5px 0 0;
+  font-size: clamp(1.35rem, 2.8vw, 2.15rem);
+  letter-spacing: -0.055em;
+  line-height: 1.05;
+}
+
+.legalHeading > p,
+.paymentHeading > p {
+  margin: 0;
+  color: var(--invoice-muted);
+  font-size: 0.68rem;
+  line-height: 1.75;
+}
+
+.termsGrid {
+  display: grid;
+  gap: 13px;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.termItem {
+  position: relative;
+  min-width: 0;
+  min-height: 218px;
+  padding: 18px;
+  overflow: hidden;
+  border: 1px solid rgba(213, 226, 221, 0.92);
+  border-radius: 22px;
+  background: rgba(255, 255, 255, 0.88);
+  box-shadow: 0 14px 34px rgba(15, 23, 42, 0.045);
+  transition:
+    transform 180ms ease,
+    border-color 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.termItem::after {
+  position: absolute;
+  right: -2.2rem;
+  bottom: -2.5rem;
+  width: 7rem;
+  height: 7rem;
+  border: 1px solid rgba(16, 185, 129, 0.08);
+  border-radius: 999px;
+  box-shadow: 0 0 0 20px rgba(16, 185, 129, 0.025);
+  content: "";
+}
+
+.termItem:hover {
+  border-color: #aedbcd;
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.075);
+  transform: translateY(-2px);
+}
+
+.termTopline {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.termIcon {
+  display: grid;
+  width: 40px;
+  height: 40px;
+  place-items: center;
+  border-radius: 13px;
+  color: var(--invoice-green);
+  background: #e9f8f2;
+}
+
+.termNumber {
+  color: #a1b1ad;
+  font-size: 0.6rem;
+  font-weight: 900;
+  letter-spacing: 0.08em;
+}
+
+.termItem h3 {
+  position: relative;
+  z-index: 1;
+  margin: 15px 0 8px;
+  font-size: 0.77rem;
+  letter-spacing: -0.025em;
+  line-height: 1.35;
+}
+
+.termItem p {
+  position: relative;
+  z-index: 1;
+  margin: 0;
+  color: #66778a;
+  font-size: 0.61rem;
+  line-height: 1.72;
+}
+
+.serviceAssurance {
+  display: grid;
+  margin-top: 16px;
+  padding: 20px 22px;
+  align-items: center;
+  gap: 24px;
+  border-radius: 22px;
+  color: white;
+  background:
+    radial-gradient(
+      circle at 90% 10%,
+      rgba(16, 185, 129, 0.24),
+      transparent 14rem
+    ),
+    var(--invoice-ink);
+  box-shadow: 0 20px 46px rgba(7, 17, 31, 0.16);
+  grid-template-columns: minmax(0, 0.85fr) minmax(280px, 1.15fr);
+}
+
+.serviceAssurance > div {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.serviceAssurance svg {
+  flex: 0 0 auto;
+  color: #6ee7c7;
+}
+
+.serviceAssurance span,
+.serviceAssurance strong {
+  display: block;
+}
+
+.serviceAssurance span {
+  color: #6ee7c7;
+  font-size: 0.55rem;
+  font-weight: 900;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.serviceAssurance strong {
+  margin-top: 4px;
+  font-size: 0.74rem;
+}
+
+.serviceAssurance p {
+  margin: 0;
+  color: #a8b8c5;
+  font-size: 0.61rem;
+  line-height: 1.65;
+}
+
+.careSection {
+  margin-top: 32px;
+}
+
+.careHeading {
+  display: flex;
+  margin-bottom: 14px;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 18px;
+}
+
+.careHeading h3 {
+  margin: 4px 0 0;
+  font-size: 1rem;
+  letter-spacing: -0.04em;
+}
+
+.careHeading > span {
+  color: var(--invoice-muted);
+  font-size: 0.57rem;
+  font-weight: 700;
+}
+
+.careGrid {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.careCard {
+  display: grid;
+  min-width: 0;
+  padding: 16px;
+  align-items: start;
+  gap: 12px;
+  border: 1px solid #dce8e4;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.75);
+  grid-template-columns: auto minmax(0, 1fr);
+}
+
+.careIcon {
+  display: grid;
+  width: 38px;
+  height: 38px;
+  place-items: center;
+  border-radius: 12px;
+  color: var(--invoice-green);
+  background: #e9f8f2;
+}
+
+.careCard strong {
+  display: block;
+  font-size: 0.69rem;
+}
+
+.careCard p {
+  margin: 5px 0 9px;
+  color: var(--invoice-muted);
+  font-size: 0.56rem;
+  line-height: 1.5;
+}
+
+.careCard a {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  color: var(--invoice-green);
+  font-size: 0.62rem;
+  font-weight: 900;
+  text-decoration: none;
+}
+
+.paymentInstructions {
+  padding: clamp(34px, 5vw, 64px) clamp(26px, 4vw, 56px);
+  color: white;
+  background:
+    radial-gradient(
+      circle at 12% 0,
+      rgba(56, 189, 248, 0.17),
+      transparent 20rem
+    ),
+    radial-gradient(
+      circle at 90% 15%,
+      rgba(16, 185, 129, 0.2),
+      transparent 24rem
+    ),
+    linear-gradient(135deg, #07111f, #0b2430 65%, #064e3b 145%);
+}
+
+.paymentInstructions .eyebrow {
+  color: #6ee7c7;
+}
+
+.paymentHeading > p {
+  color: #a7b7c4;
+}
+
+.paymentIndex {
+  display: grid;
+  width: 42px;
+  height: 42px;
+  flex: 0 0 auto;
+  place-items: center;
+  border: 1px solid rgba(110, 231, 199, 0.22);
+  border-radius: 14px;
+  color: #6ee7c7;
+  background: rgba(16, 185, 129, 0.1);
+  font-size: 0.7rem;
+  font-weight: 900;
+}
+
+.bankGrid {
+  display: grid;
+  gap: 13px;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.bankCard {
+  min-width: 0;
+  padding: 20px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 22px;
+  background: rgba(255, 255, 255, 0.075);
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.16);
+  backdrop-filter: blur(14px);
+}
+
+.bankTopline {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  color: #8fa4b2;
+  font-size: 0.55rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.bankIcon {
+  display: grid;
+  width: 36px;
+  height: 36px;
+  place-items: center;
+  border: 1px solid rgba(110, 231, 199, 0.16);
+  border-radius: 11px;
+  color: #6ee7c7;
+  background: rgba(16, 185, 129, 0.1);
+}
+
+.bankCard h3 {
+  margin: 16px 0 13px;
+  color: white;
+  font-size: 0.92rem;
+  letter-spacing: -0.035em;
+}
+
+.bankDetails {
+  display: grid;
+  margin: 0;
+  gap: 7px;
+}
+
+.bankDetails > div {
+  display: flex;
+  min-width: 0;
+  padding: 9px 10px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.bankDetails dt {
+  color: #8295a4;
+  font-size: 0.52rem;
+}
+
+.bankDetails dd {
+  margin: 0;
+  overflow-wrap: anywhere;
+  color: #e8f0f2;
+  font-size: 0.6rem;
+  font-weight: 800;
+  text-align: right;
+}
+
+.bankCard button {
+  display: inline-flex;
+  width: 100%;
+  min-height: 40px;
+  margin-top: 14px;
+  padding: 0 12px;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  border: 1px solid rgba(110, 231, 199, 0.18);
+  border-radius: 12px;
+  cursor: pointer;
+  color: #07111f;
+  background: #6ee7c7;
+  font: inherit;
+  font-size: 0.59rem;
+  font-weight: 900;
+  transition:
+    transform 180ms ease,
+    background 180ms ease;
+}
+
+.bankCard button:hover {
+  background: #99f6e4;
+  transform: translateY(-1px);
+}
+
+.paymentNotice {
+  display: flex;
+  margin-top: 14px;
+  padding: 15px 17px;
+  align-items: flex-start;
+  gap: 10px;
+  border: 1px solid rgba(110, 231, 199, 0.14);
+  border-radius: 16px;
+  color: #a7b7c4;
+  background: rgba(16, 185, 129, 0.07);
+}
+
+.paymentNotice svg {
+  flex: 0 0 auto;
+  color: #6ee7c7;
+}
+
+.paymentNotice p {
+  margin: 0;
+  font-size: 0.58rem;
+  line-height: 1.65;
+}
+
 .invoiceFooter {
   display: flex;
   min-height: 104px;
@@ -1295,6 +1713,21 @@
   }
 
   .summaryCard {
+    grid-column: 1 / -1;
+  }
+
+  .legalHeading,
+  .paymentHeading {
+    align-items: start;
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .termsGrid,
+  .bankGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .bankCard:last-child {
     grid-column: 1 / -1;
   }
 }
@@ -1527,6 +1960,55 @@
     grid-column: auto;
   }
 
+  .legalSection,
+  .paymentInstructions {
+    padding: 32px 16px;
+  }
+
+  .legalHeading,
+  .paymentHeading {
+    margin-bottom: 20px;
+    gap: 14px;
+  }
+
+  .legalTitleGroup,
+  .paymentTitleGroup {
+    align-items: flex-start;
+  }
+
+  .legalHeading h2,
+  .paymentHeading h2 {
+    font-size: 1.35rem;
+  }
+
+  .termsGrid,
+  .careGrid,
+  .bankGrid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .termItem {
+    min-height: 0;
+    padding: 17px;
+  }
+
+  .serviceAssurance {
+    padding: 18px;
+    align-items: start;
+    gap: 13px;
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .careHeading {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  .bankCard:last-child {
+    grid-column: auto;
+  }
+
   .invoiceFooter {
     min-height: 0;
     padding: 26px 20px;
@@ -1667,6 +2149,101 @@
     position: static;
   }
 
+  .legalSection {
+    padding: 26px;
+    break-before: page;
+    background: white;
+    print-color-adjust: exact;
+    -webkit-print-color-adjust: exact;
+  }
+
+  .legalHeading {
+    margin-bottom: 16px;
+    grid-template-columns: minmax(0, 1fr) minmax(220px, 0.6fr);
+  }
+
+  .legalHeading h2,
+  .paymentHeading h2 {
+    font-size: 1.3rem;
+  }
+
+  .termsGrid {
+    gap: 8px;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .termItem {
+    min-height: 0;
+    padding: 11px;
+    border-radius: 12px;
+    box-shadow: none;
+  }
+
+  .termIcon {
+    width: 30px;
+    height: 30px;
+    border-radius: 9px;
+  }
+
+  .termItem h3 {
+    margin: 9px 0 4px;
+    font-size: 0.63rem;
+  }
+
+  .termItem p {
+    font-size: 0.5rem;
+    line-height: 1.5;
+  }
+
+  .serviceAssurance {
+    margin-top: 10px;
+    padding: 12px 14px;
+    border-radius: 12px;
+    box-shadow: none;
+  }
+
+  .careSection {
+    margin-top: 16px;
+  }
+
+  .careGrid {
+    gap: 8px;
+  }
+
+  .careCard {
+    padding: 10px;
+    border-radius: 12px;
+  }
+
+  .paymentInstructions {
+    padding: 28px 26px;
+    break-before: page;
+    print-color-adjust: exact;
+    -webkit-print-color-adjust: exact;
+  }
+
+  .paymentHeading {
+    margin-bottom: 18px;
+  }
+
+  .bankGrid {
+    gap: 9px;
+  }
+
+  .bankCard {
+    padding: 14px;
+    border-radius: 14px;
+    break-inside: avoid;
+  }
+
+  .bankCard button {
+    display: none;
+  }
+
+  .paymentNotice {
+    break-inside: avoid;
+  }
+
   .productCard {
     padding: 8px;
     gap: 8px;
@@ -1717,6 +2294,10 @@
   }
 
   .productCard:hover {
+    transform: none;
+  }
+
+  .termItem:hover {
     transform: none;
   }
 

--- a/src/utils/invoice/generatePublicInvoicePdf.js
+++ b/src/utils/invoice/generatePublicInvoicePdf.js
@@ -1,4 +1,9 @@
 import { loadJsPDF } from "@/utils/invoice";
+import {
+  bankPaymentMethods,
+  customerCare,
+  termsAndConditions,
+} from "@/constants/invoiceStaticData";
 import priceUtils from "@/utils/priceUtils";
 
 const BRAND = [4, 120, 87];
@@ -39,9 +44,14 @@ const titleCase = (value) =>
     .replace(/[_-]+/g, " ")
     .replace(/\b\w/g, (letter) => letter.toUpperCase());
 
-const drawPageHeader = (doc, invoice, continued = false) => {
+const drawPageHeader = (doc, invoice, continued = false, sectionLabel = "") => {
   const width = doc.internal.pageSize.getWidth();
   const invoiceTitle = invoice.gst ? "GST TAX INVOICE" : "INVOICE";
+  const documentTitle = sectionLabel
+    ? `${invoiceTitle} / ${sectionLabel}`
+    : continued
+      ? `${invoiceTitle} / CONTINUED`
+      : invoiceTitle;
   doc.setFillColor(...BRAND);
   doc.rect(0, 0, width, 92, "F");
   doc.setFillColor(...BRAND_BRIGHT);
@@ -58,14 +68,7 @@ const drawPageHeader = (doc, invoice, continued = false) => {
 
   doc.setFont("helvetica", "bold");
   doc.setFontSize(12);
-  doc.text(
-    continued ? `${invoiceTitle} / CONTINUED` : invoiceTitle,
-    width - 42,
-    42,
-    {
-      align: "right",
-    },
-  );
+  doc.text(documentTitle, width - 42, 42, { align: "right" });
   doc.setFont("helvetica", "normal");
   doc.setFontSize(9);
   doc.text(invoice.invoice_no || invoice.id || "Invoice", width - 42, 60, {
@@ -129,14 +132,371 @@ const drawProductHeader = (doc, y) => {
   return y + 34;
 };
 
-/** Download the server-normalized public invoice as a searchable A4 PDF. */
-export const downloadPublicInvoicePdf = async (invoice) => {
-  const loaded = await loadJsPDF();
-  const JsPdf = window.jspdf?.jsPDF;
-  if (!loaded || !JsPdf) {
-    throw new Error("The PDF service could not be loaded.");
+const drawSectionHeading = (doc, { y, kicker, title, description }) => {
+  const width = doc.internal.pageSize.getWidth();
+  const contentWidth = width - 84;
+
+  doc.setFont("helvetica", "bold");
+  doc.setFontSize(7);
+  doc.setTextColor(...BRAND);
+  doc.text(kicker.toUpperCase(), 42, y);
+  doc.setFontSize(17);
+  doc.setTextColor(...INK);
+  doc.text(title, 42, y + 23);
+  doc.setFont("helvetica", "normal");
+  doc.setFontSize(8);
+  doc.setTextColor(...MUTED);
+  const descriptionLines = doc
+    .splitTextToSize(description, contentWidth)
+    .slice(0, 3);
+  doc.text(descriptionLines, 42, y + 43, { lineHeightFactor: 1.35 });
+
+  return y + 50 + descriptionLines.length * 9;
+};
+
+const getTermCardMetrics = (doc, term, cardWidth) => {
+  const titleLines = doc.splitTextToSize(term.title, cardWidth - 58);
+  const descriptionLines = doc.splitTextToSize(
+    term.description,
+    cardWidth - 26,
+  );
+  const cardHeight = Math.max(
+    88,
+    43 + titleLines.length * 9 + descriptionLines.length * 8,
+  );
+
+  return { titleLines, descriptionLines, cardHeight };
+};
+
+const drawTermCard = (doc, { x, y, width, index, metrics }) => {
+  doc.setFillColor(...SOFT);
+  doc.setDrawColor(...LINE);
+  doc.roundedRect(x, y, width, metrics.cardHeight, 8, 8, "FD");
+
+  doc.setFillColor(236, 253, 245);
+  doc.roundedRect(x + 12, y + 11, 25, 25, 7, 7, "F");
+  doc.setFont("helvetica", "bold");
+  doc.setFontSize(7);
+  doc.setTextColor(...BRAND);
+  doc.text(String(index + 1).padStart(2, "0"), x + 24.5, y + 27, {
+    align: "center",
+  });
+
+  doc.setFontSize(8);
+  doc.setTextColor(...INK);
+  doc.text(metrics.titleLines, x + 45, y + 19, { lineHeightFactor: 1.2 });
+  doc.setFont("helvetica", "normal");
+  doc.setFontSize(7.2);
+  doc.setTextColor(...MUTED);
+  doc.text(metrics.descriptionLines, x + 13, y + 48, {
+    lineHeightFactor: 1.35,
+  });
+};
+
+const drawCustomerCareDirectory = (doc, y) => {
+  const width = doc.internal.pageSize.getWidth();
+  const margin = 42;
+  const contentWidth = width - margin * 2;
+  const gap = 9;
+  const cardWidth = (contentWidth - gap * 2) / 3;
+
+  doc.setFont("helvetica", "bold");
+  doc.setFontSize(7);
+  doc.setTextColor(...BRAND);
+  doc.text("MANUFACTURER ASSISTANCE", margin, y);
+  doc.setFontSize(11);
+  doc.setTextColor(...INK);
+  doc.text("Customer-care directory", margin, y + 18);
+  y += 30;
+
+  customerCare.forEach((contact, index) => {
+    const x = margin + index * (cardWidth + gap);
+    doc.setFillColor(248, 250, 252);
+    doc.setDrawColor(...LINE);
+    doc.roundedRect(x, y, cardWidth, 73, 8, 8, "FD");
+    doc.setFont("helvetica", "bold");
+    doc.setFontSize(7.5);
+    doc.setTextColor(...INK);
+    doc.text(
+      doc.splitTextToSize(contact.name, cardWidth - 20).slice(0, 2),
+      x + 10,
+      y + 17,
+      { lineHeightFactor: 1.2 },
+    );
+    doc.setFont("helvetica", "normal");
+    doc.setFontSize(6.4);
+    doc.setTextColor(...MUTED);
+    doc.text(
+      doc.splitTextToSize(contact.description, cardWidth - 20).slice(0, 2),
+      x + 10,
+      y + 38,
+      { lineHeightFactor: 1.2 },
+    );
+    doc.setFont("helvetica", "bold");
+    doc.setFontSize(7.5);
+    doc.setTextColor(...BRAND);
+    doc.text(contact.phone, x + 10, y + 62);
+  });
+};
+
+const drawTermsAndSupportPages = (doc, invoice) => {
+  const width = doc.internal.pageSize.getWidth();
+  const height = doc.internal.pageSize.getHeight();
+  const margin = 42;
+  const contentWidth = width - margin * 2;
+  const gap = 12;
+  const cardWidth = (contentWidth - gap) / 2;
+
+  doc.addPage();
+  drawPageHeader(doc, invoice, false, "TERMS AND SUPPORT");
+  let y = drawSectionHeading(doc, {
+    y: 118,
+    kicker: "Commercial framework",
+    title: "Terms, responsibilities and service standards",
+    description:
+      "These terms form part of this invoice and clarify the delivery, installation, payment and after-sales responsibilities associated with the supplied products.",
+  });
+
+  for (let index = 0; index < termsAndConditions.length; index += 2) {
+    const pair = termsAndConditions.slice(index, index + 2);
+    const metrics = pair.map((term) =>
+      getTermCardMetrics(doc, term, cardWidth),
+    );
+    const rowHeight = Math.max(...metrics.map((item) => item.cardHeight));
+
+    if (y + rowHeight > height - 145) {
+      drawFooter(doc);
+      doc.addPage();
+      drawPageHeader(doc, invoice, false, "TERMS / CONTINUED");
+      y = 118;
+    }
+
+    pair.forEach((term, pairIndex) => {
+      drawTermCard(doc, {
+        x: margin + pairIndex * (cardWidth + gap),
+        y,
+        width: cardWidth,
+        index: index + pairIndex,
+        metrics: { ...metrics[pairIndex], cardHeight: rowHeight },
+      });
+    });
+
+    y += rowHeight + 10;
   }
 
+  if (y + 130 > height - 60) {
+    drawFooter(doc);
+    doc.addPage();
+    drawPageHeader(doc, invoice, false, "SUPPORT");
+    y = 118;
+  }
+
+  doc.setFillColor(...INK);
+  doc.roundedRect(margin, y, contentWidth, 56, 9, 9, "F");
+  doc.setFont("helvetica", "bold");
+  doc.setFontSize(7);
+  doc.setTextColor(...BRAND_BRIGHT);
+  doc.text("SERVICE ASSURANCE", margin + 14, y + 18);
+  doc.setFontSize(9);
+  doc.setTextColor(...WHITE);
+  doc.text("Protected by Aquakart support standards", margin + 14, y + 35);
+  doc.setFont("helvetica", "normal");
+  doc.setFontSize(7);
+  doc.setTextColor(174, 190, 201);
+  doc.text(
+    doc.splitTextToSize(
+      "Retain this invoice for installation verification, warranty registration and service coordination.",
+      contentWidth * 0.43,
+    ),
+    width - margin - 14,
+    y + 23,
+    { align: "right", lineHeightFactor: 1.25 },
+  );
+
+  drawCustomerCareDirectory(doc, y + 79);
+  drawFooter(doc);
+};
+
+const drawBankMethodCard = (doc, { method, x, y, width, height }) => {
+  const rows =
+    method.type === "upi"
+      ? [
+          ["Google Pay", method.gpay],
+          ["PhonePe", method.phonePe],
+        ]
+      : [
+          ["Account name", method.accountName],
+          ["Account number", method.accountNumber],
+          ["IFSC", method.ifsc],
+        ];
+
+  doc.setFillColor(...SOFT);
+  doc.setDrawColor(...LINE);
+  doc.roundedRect(x, y, width, height, 10, 10, "FD");
+  doc.setFillColor(236, 253, 245);
+  doc.roundedRect(x + 13, y + 13, 30, 30, 8, 8, "F");
+  doc.setFont("helvetica", "bold");
+  doc.setFontSize(7);
+  doc.setTextColor(...BRAND);
+  doc.text(method.type === "upi" ? "UPI" : "BANK", x + 28, y + 32, {
+    align: "center",
+  });
+  doc.setFontSize(10);
+  doc.setTextColor(...INK);
+  doc.text(method.name, x + 52, y + 25);
+  doc.setFont("helvetica", "normal");
+  doc.setFontSize(6.5);
+  doc.setTextColor(...MUTED);
+  doc.text(
+    method.type === "upi" ? "Digital payment" : "Bank transfer",
+    x + 52,
+    y + 39,
+  );
+
+  let rowY = y + 61;
+  rows.forEach(([label, value]) => {
+    doc.setDrawColor(...LINE);
+    doc.line(x + 13, rowY - 8, x + width - 13, rowY - 8);
+    doc.setFont("helvetica", "normal");
+    doc.setFontSize(7);
+    doc.setTextColor(...MUTED);
+    doc.text(label, x + 13, rowY + 5);
+    doc.setFont("helvetica", "bold");
+    doc.setTextColor(...INK);
+    doc.text(String(value), x + width - 13, rowY + 5, { align: "right" });
+    rowY += 23;
+  });
+};
+
+const drawPaymentInstructionsPage = (doc, invoice) => {
+  const width = doc.internal.pageSize.getWidth();
+  const margin = 42;
+  const contentWidth = width - margin * 2;
+  const gap = 12;
+  const cardWidth = (contentWidth - gap) / 2;
+
+  doc.addPage();
+  drawPageHeader(doc, invoice, false, "PAYMENT");
+  let y = drawSectionHeading(doc, {
+    y: 118,
+    kicker: "Purchase-order payment",
+    title: "Approved remittance details",
+    description:
+      "Use the invoice number as the payment reference and share the remittance confirmation with Aquakart for prompt allocation and order processing.",
+  });
+
+  drawBankMethodCard(doc, {
+    method: bankPaymentMethods[0],
+    x: margin,
+    y,
+    width: cardWidth,
+    height: 144,
+  });
+  drawBankMethodCard(doc, {
+    method: bankPaymentMethods[1],
+    x: margin + cardWidth + gap,
+    y,
+    width: cardWidth,
+    height: 144,
+  });
+  y += 157;
+  drawBankMethodCard(doc, {
+    method: bankPaymentMethods[2],
+    x: margin,
+    y,
+    width: contentWidth,
+    height: 112,
+  });
+  y += 132;
+
+  doc.setFont("helvetica", "bold");
+  doc.setFontSize(7);
+  doc.setTextColor(...BRAND);
+  doc.text("REMITTANCE PROCESS", margin, y);
+  doc.setFontSize(11);
+  doc.setTextColor(...INK);
+  doc.text("A clear three-step payment trail", margin, y + 18);
+  y += 32;
+
+  const steps = [
+    [
+      "01",
+      "Reference",
+      "Include the invoice number in the transfer narration.",
+    ],
+    [
+      "02",
+      "Confirmation",
+      "Share the successful payment receipt with Aquakart.",
+    ],
+    [
+      "03",
+      "Allocation",
+      "Await payment allocation and processing confirmation.",
+    ],
+  ];
+  const stepGap = 9;
+  const stepWidth = (contentWidth - stepGap * 2) / 3;
+  steps.forEach(([number, title, description], index) => {
+    const x = margin + index * (stepWidth + stepGap);
+    doc.setFillColor(...INK);
+    doc.roundedRect(x, y, stepWidth, 84, 8, 8, "F");
+    doc.setFont("helvetica", "bold");
+    doc.setFontSize(7);
+    doc.setTextColor(...BRAND_BRIGHT);
+    doc.text(number, x + 12, y + 18);
+    doc.setFontSize(8.5);
+    doc.setTextColor(...WHITE);
+    doc.text(title, x + 12, y + 35);
+    doc.setFont("helvetica", "normal");
+    doc.setFontSize(6.7);
+    doc.setTextColor(174, 190, 201);
+    doc.text(doc.splitTextToSize(description, stepWidth - 24), x + 12, y + 52, {
+      lineHeightFactor: 1.25,
+    });
+  });
+  y += 99;
+
+  doc.setFillColor(240, 253, 250);
+  doc.setDrawColor(167, 243, 208);
+  doc.roundedRect(margin, y, contentWidth, 54, 8, 8, "FD");
+  doc.setFont("helvetica", "bold");
+  doc.setFontSize(7);
+  doc.setTextColor(...BRAND);
+  doc.text("PAYMENT VERIFICATION", margin + 13, y + 18);
+  doc.setFont("helvetica", "normal");
+  doc.setFontSize(7.2);
+  doc.setTextColor(...INK);
+  doc.text(
+    doc.splitTextToSize(
+      "Payment instructions are shown because this invoice is linked to a purchase order. Verify the beneficiary name, account number and IFSC before transfer.",
+      contentWidth - 26,
+    ),
+    margin + 13,
+    y + 34,
+    { lineHeightFactor: 1.25 },
+  );
+  drawFooter(doc);
+};
+
+const addPageNumbers = (doc) => {
+  const pageCount = doc.getNumberOfPages();
+  const width = doc.internal.pageSize.getWidth();
+  const height = doc.internal.pageSize.getHeight();
+
+  for (let page = 1; page <= pageCount; page += 1) {
+    doc.setPage(page);
+    doc.setFont("helvetica", "bold");
+    doc.setFontSize(6.5);
+    doc.setTextColor(...MUTED);
+    doc.text(`PAGE ${page} OF ${pageCount}`, width / 2, height - 21, {
+      align: "center",
+    });
+  }
+};
+
+/** Download the server-normalized public invoice as a searchable A4 PDF. */
+export const createPublicInvoicePdfDocument = (JsPdf, invoice) => {
   const doc = new JsPdf({ unit: "pt", format: "a4", compress: true });
   const width = doc.internal.pageSize.getWidth();
   const height = doc.internal.pageSize.getHeight();
@@ -377,6 +737,22 @@ export const downloadPublicInvoicePdf = async (invoice) => {
   );
 
   drawFooter(doc);
+  drawTermsAndSupportPages(doc, invoice);
+  if (invoice.po) drawPaymentInstructionsPage(doc, invoice);
+  addPageNumbers(doc);
+
+  return doc;
+};
+
+/** Download the server-normalized public invoice as a searchable A4 PDF. */
+export const downloadPublicInvoicePdf = async (invoice) => {
+  const loaded = await loadJsPDF();
+  const JsPdf = window.jspdf?.jsPDF;
+  if (!loaded || !JsPdf) {
+    throw new Error("The PDF service could not be loaded.");
+  }
+
+  const doc = createPublicInvoicePdfDocument(JsPdf, invoice);
   doc.save(
     `Aquakart-Invoice-${safeFilePart(invoice.invoice_no || invoice.id)}.pdf`,
   );


### PR DESCRIPTION
## Summary
- add professionally rephrased commercial terms and responsibilities to every public invoice
- add a responsive manufacturer customer-care directory and service-assurance treatment
- show ICICI, Kotak and UPI remittance details only when `invoice.po` is true, with copy actions on the web invoice
- include the same terms, support directory and conditional PO payment instructions in the downloadable A4 PDF
- add print-safe page breaks, bounded text, and page numbering for the expanded PDF

## Validation
- `npm test` — 43 tests passed
- `npm run build` — production build passed; `/invoice/[id]` remains server-rendered
- generated a representative GST + PO PDF and rendered all 3 A4 pages to PNG for visual inspection
- verified the branch is one commit ahead of `PROD` and contains only the four intended invoice files