### PR TITLE
Remove empty bands from homepage category cards

### DIFF
--- a/src/pageComponents/home/homeHeroSection.js
+++ b/src/pageComponents/home/homeHeroSection.js
@@ -121,7 +121,7 @@ const AquaHomeHero = ({ data = [] }) => {
                   priority={index === 0}
                 />
                 <span className={styles.mosaicShade} />
-                <div>
+                <div className={styles.mosaicMeta}>
                   <span>{String(index + 1).padStart(2, "0")}</span>
                   <strong>{category.title}</strong>
                   <small>

--- a/src/styles/home.module.css
+++ b/src/styles/home.module.css
@@ -248,8 +248,7 @@
   overflow: hidden;
   border-radius: 17px;
   isolation: isolate;
-  background:
-    radial-gradient(circle at 50% 28%, #ffffff 0, #edf8f5 46%, #dcebea 100%);
+  background: #071a25;
 }
 
 .mosaicPrimary {
@@ -258,14 +257,22 @@
 
 .mosaicMedia {
   position: absolute;
-  inset: 0;
+  top: 0;
+  right: 0;
+  left: 0;
+  height: calc(100% - 82px);
+  overflow: hidden;
+  background: #edf8f5;
+}
+
+.mosaicPrimary .mosaicMedia {
+  height: calc(100% - 105px);
 }
 
 .mosaicImage {
   z-index: 0;
-  padding: 16px 16px 82px;
-  object-fit: contain;
-  object-position: center 42%;
+  object-fit: cover;
+  object-position: center;
   transition: transform 500ms ease;
 }
 
@@ -274,31 +281,29 @@
 }
 
 .mosaicShade {
-  position: absolute;
-  inset: 0;
-  z-index: 1;
-  background: linear-gradient(
-    180deg,
-    transparent 58%,
-    rgba(4, 22, 30, 0.08) 64%,
-    rgba(4, 22, 30, 0.88) 100%
-  );
-  pointer-events: none;
+  display: none;
 }
 
-.mosaicCard > div {
+.mosaicMeta {
   position: absolute;
   right: 0;
   bottom: 0;
   left: 0;
   z-index: 2;
   display: flex;
+  min-height: 82px;
+  justify-content: center;
   flex-direction: column;
   padding: 15px 17px;
+  background: linear-gradient(135deg, #17343d, #071a25);
   color: #ffffff;
 }
 
-.mosaicCard > div > span {
+.mosaicPrimary .mosaicMeta {
+  min-height: 105px;
+}
+
+.mosaicMeta > span {
   color: #9ce9d7;
   font-size: 9px;
   font-weight: 800;
@@ -859,8 +864,21 @@
     border-radius: 13px;
   }
 
-  .mosaicCard > div {
+  .mosaicMeta {
+    min-height: 64px;
     padding: 12px;
+  }
+
+  .mosaicPrimary .mosaicMeta {
+    min-height: 82px;
+  }
+
+  .mosaicMedia {
+    height: calc(100% - 64px);
+  }
+
+  .mosaicPrimary .mosaicMedia {
+    height: calc(100% - 82px);
   }
 
   .mosaicCard strong {


### PR DESCRIPTION
## **User description**
## Summary

- removes the empty top and bottom bands from the homepage category mosaic
- gives artwork a dedicated edge-to-edge media region
- gives category text a separate fixed-height caption panel
- replaces ambiguous child selectors with explicit `mosaicMedia` and `mosaicMeta` classes
- keeps desktop and mobile card proportions responsive

## Root cause

The previous `contain` image treatment intentionally preserved the entire square source asset, but produced visible whitespace inside portrait cards. A broad `.mosaicCard > div` selector also applied caption layout rules to the LazyImage wrapper.

## Validation

- targeted ESLint passed
- Vitest: 48/48 tests passed
- Next.js production build passed
- `git diff --check` passed


___

## **CodeAnt-AI Description**
**Fill homepage category cards with edge-to-edge artwork**

### What Changed
- Category artwork now fills the media area of each homepage mosaic card instead of showing empty bands
- Category titles and collection links appear in a separate, fixed-height caption panel
- Artwork and caption proportions adapt for desktop and mobile layouts

### Impact
`✅ Edge-to-edge category artwork`
`✅ Clearer card captions`
`✅ Consistent homepage card proportions`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
