### PR TITLE
Add branded GST invoice PDF and product gallery

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "firebase": "^12.17.0",
     "formidable": "^3.5.4",
     "framer-motion": "^12.43.0",
+    "jspdf": "^4.2.1",
     "lodash": "^4.18.1",
     "lodash.debounce": "^4.0.8",
     "lucide-react": "^1.28.0",

--- a/src/pageComponents/invoice/InvoicePage.js
+++ b/src/pageComponents/invoice/InvoicePage.js
@@ -10,10 +10,12 @@ import {
   Copy,
   CreditCard,
   Download,
+  ExternalLink,
   FileText,
   Hash,
   Headphones,
   Landmark,
+  Link2,
   Mail,
   MapPin,
   Package,
@@ -204,6 +206,84 @@ const ProductCard = ({ product, index }) => {
         </div>
       </div>
     </article>
+  );
+};
+
+const getProductHref = (product = {}) => {
+  const directLink = product.productLink;
+  if (directLink?.startsWith("http://") || directLink?.startsWith("https://")) {
+    return directLink;
+  }
+  if (directLink?.startsWith("/")) return directLink;
+
+  const reference =
+    product.productSlug || product.catalogueProductId || product.id;
+  return reference ? `/product/${encodeURIComponent(reference)}` : "";
+};
+
+const ProductGallery = ({ products }) => {
+  const copyProductLink = async (product) => {
+    const href = getProductHref(product);
+    if (!href) {
+      toast.error("Product link is not available");
+      return;
+    }
+
+    const absoluteUrl = href.startsWith("http")
+      ? href
+      : `${window.location.origin}${href}`;
+    try {
+      await navigator.clipboard.writeText(absoluteUrl);
+      toast.success("Product link copied");
+    } catch {
+      toast.error("Could not copy the product link");
+    }
+  };
+
+  return (
+    <aside className={styles.productGallery} aria-label="Invoice products">
+      <div className={styles.galleryTrack}>
+        {products.map((product, index) => {
+          const href = getProductHref(product);
+          return (
+            <article
+              key={product.id || `${product.productName}-${index}`}
+              className={styles.galleryItem}
+            >
+              <a
+                href={href || undefined}
+                target={href ? "_blank" : undefined}
+                rel={href ? "noreferrer" : undefined}
+                aria-label={
+                  href
+                    ? `Open ${product.productName}`
+                    : `${product.productName} has no product page`
+                }
+                className={!href ? styles.galleryLinkDisabled : ""}
+              >
+                <span>{String(index + 1).padStart(2, "0")}</span>
+                {product.productImage ? (
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img src={product.productImage} alt={product.productName} />
+                ) : (
+                  <Package size={25} />
+                )}
+              </a>
+              <button
+                type="button"
+                onClick={() => copyProductLink(product)}
+                aria-label={`Copy ${product.productName} link`}
+              >
+                <Link2 size={12} />
+              </button>
+            </article>
+          );
+        })}
+      </div>
+      <span className={styles.galleryHint}>
+        <ExternalLink size={11} /> Open product
+      </span>
+    </aside>
   );
 };
 
@@ -419,7 +499,7 @@ const InvoicePage = ({ invoice, statusCode = 200 }) => {
             </div>
             <div>
               <span className={styles.eyebrow}>Premium water solutions</span>
-              <h1>{invoice.gst ? "GST Tax Invoice" : "Invoice"}</h1>
+              <h1>{invoice.gst ? "GST Tax Invoice" : "Retail Tax Invoice"}</h1>
               <p>GSTIN 36AJOPH6387A1Z2</p>
             </div>
           </div>
@@ -451,7 +531,9 @@ const InvoicePage = ({ invoice, statusCode = 200 }) => {
           <div>
             <ShieldCheck size={18} />
             <span>Tax treatment</span>
-            <strong>{invoice.gst ? "CGST + SGST" : "Non-GST"}</strong>
+            <strong>
+              {invoice.gst ? "CGST 9% + SGST 9%" : "GST 18% included"}
+            </strong>
           </div>
         </section>
 
@@ -494,26 +576,31 @@ const InvoicePage = ({ invoice, statusCode = 200 }) => {
               </span>
             </div>
 
-            <div className={styles.productList}>
+            <div className={styles.productsExperience}>
               {invoice.products.length ? (
-                invoice.products.map((product, index) => (
-                  <ProductCard
-                    key={product.id || `${product.productName}-${index}`}
-                    product={product}
-                    index={index}
-                  />
-                ))
-              ) : (
-                <div className={styles.emptyProducts}>
-                  <Package size={28} />
-                  <div>
-                    <strong>No product details available</strong>
-                    <p>
-                      The invoice total and customer record are still shown.
-                    </p>
+                <ProductGallery products={invoice.products} />
+              ) : null}
+              <div className={styles.productList}>
+                {invoice.products.length ? (
+                  invoice.products.map((product, index) => (
+                    <ProductCard
+                      key={product.id || `${product.productName}-${index}`}
+                      product={product}
+                      index={index}
+                    />
+                  ))
+                ) : (
+                  <div className={styles.emptyProducts}>
+                    <Package size={28} />
+                    <div>
+                      <strong>No product details available</strong>
+                      <p>
+                        The invoice total and customer record are still shown.
+                      </p>
+                    </div>
                   </div>
-                </div>
-              )}
+                )}
+              </div>
             </div>
 
             <div className={styles.amountWords}>
@@ -622,7 +709,9 @@ const InvoicePage = ({ invoice, statusCode = 200 }) => {
               <div className={styles.summaryTopline}>
                 <div>
                   <small>
-                    {invoice.gst ? "GST tax invoice" : "Standard invoice"}
+                    {invoice.gst
+                      ? "GST claim tax invoice"
+                      : "Retail tax invoice"}
                   </small>
                   <h2>Price calculation</h2>
                 </div>
@@ -637,12 +726,10 @@ const InvoicePage = ({ invoice, statusCode = 200 }) => {
                 </div>
                 <div className={styles.summaryPriceCell}>
                   <span>
-                    GST <small>{invoice.gst ? "18%" : "0%"}</small>
+                    GST <small>18%</small>
                   </span>
                   <strong>{priceUtils.formatAmount(amounts.gstValue)}</strong>
-                  <small>
-                    {invoice.gst ? "Included in total" : "Not applied"}
-                  </small>
+                  <small>Included in selling price</small>
                 </div>
                 {invoice.gst ? (
                   <div className={styles.gstBreakdown}>
@@ -675,7 +762,7 @@ const InvoicePage = ({ invoice, statusCode = 200 }) => {
                 <small>
                   {invoice.gst
                     ? "Base price + 18% GST"
-                    : "Base price + GST ₹0.00"}
+                    : "Base price + included GST 18%"}
                 </small>
               </div>
 

--- a/src/styles/invoice.module.css
+++ b/src/styles/invoice.module.css
@@ -903,6 +903,111 @@
   gap: 14px;
 }
 
+.productsExperience {
+  display: grid;
+  align-items: start;
+  gap: 14px;
+  grid-template-columns: 86px minmax(0, 1fr);
+}
+
+.productGallery {
+  position: sticky;
+  top: 88px;
+  min-width: 0;
+  padding: 8px;
+  border: 1px solid #dfe9e6;
+  border-radius: 20px;
+  background: #fff;
+  box-shadow: 0 14px 34px rgba(15, 23, 42, 0.05);
+}
+
+.galleryTrack {
+  display: flex;
+  max-height: 520px;
+  flex-direction: column;
+  gap: 8px;
+  overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: #9acfc1 transparent;
+}
+
+.galleryItem {
+  position: relative;
+  flex: 0 0 auto;
+}
+
+.galleryItem > a {
+  position: relative;
+  display: grid;
+  width: 68px;
+  height: 76px;
+  place-items: center;
+  overflow: hidden;
+  border: 1px solid #e2ebe9;
+  border-radius: 13px;
+  background: #f3f8f7;
+  color: var(--invoice-green);
+  transition:
+    border-color 160ms ease,
+    transform 160ms ease;
+}
+
+.galleryItem > a:hover {
+  border-color: #63bea8;
+  transform: translateY(-2px);
+}
+
+.galleryItem > a > span {
+  position: absolute;
+  z-index: 2;
+  top: 5px;
+  left: 6px;
+  padding: 2px 4px;
+  border-radius: 4px;
+  background: rgba(7, 26, 37, 0.82);
+  color: #fff;
+  font-size: 0.42rem;
+  font-weight: 900;
+}
+
+.galleryItem img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  padding: 7px;
+}
+
+.galleryLinkDisabled {
+  cursor: default;
+  opacity: 0.58;
+}
+
+.galleryItem > button {
+  position: absolute;
+  z-index: 3;
+  right: 4px;
+  bottom: 4px;
+  display: grid;
+  width: 22px;
+  height: 22px;
+  place-items: center;
+  border-radius: 7px;
+  background: var(--invoice-ink);
+  color: #fff;
+}
+
+.galleryHint {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 3px;
+  margin-top: 8px;
+  color: var(--invoice-muted);
+  font-size: 0.42rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
 .detailCard,
 .summaryCard {
   padding: 20px;
@@ -1733,6 +1838,27 @@
 }
 
 @media (max-width: 720px) {
+  .productsExperience {
+    grid-template-columns: 1fr;
+  }
+
+  .productGallery {
+    position: static;
+  }
+
+  .galleryTrack {
+    max-height: none;
+    flex-direction: row;
+    padding-bottom: 3px;
+    overflow-x: auto;
+    overflow-y: hidden;
+  }
+
+  .galleryHint {
+    justify-content: flex-start;
+    padding-left: 3px;
+  }
+
   .page {
     padding: 0 0 94px;
     background: #f3f8f7;
@@ -2096,6 +2222,7 @@
 
   .commandBar,
   .mobileDownloadBar,
+  .productGallery,
   .ambientOne,
   .ambientTwo {
     display: none !important;
@@ -2248,6 +2375,10 @@
     padding: 8px;
     gap: 8px;
     grid-template-columns: 112px minmax(0, 1fr);
+  }
+
+  .productsExperience {
+    display: block;
   }
 
   .productVisual {

--- a/src/utils/invoice/generatePublicInvoicePdf.js
+++ b/src/utils/invoice/generatePublicInvoicePdf.js
@@ -1,10 +1,10 @@
-import { loadJsPDF } from "@/utils/invoice";
 import {
   bankPaymentMethods,
   customerCare,
   termsAndConditions,
 } from "@/constants/invoiceStaticData";
 import priceUtils from "@/utils/priceUtils";
+import logo from "@/assests/logo.png";
 
 const BRAND = [4, 120, 87];
 const BRAND_BRIGHT = [16, 185, 129];
@@ -13,6 +13,38 @@ const MUTED = [100, 116, 139];
 const LINE = [226, 232, 240];
 const SOFT = [248, 250, 252];
 const WHITE = [255, 255, 255];
+
+const getProductUrl = (product = {}) => {
+  const directLink = product.productLink;
+  if (directLink?.startsWith("http://") || directLink?.startsWith("https://")) {
+    return directLink;
+  }
+
+  const reference =
+    directLink?.replace(/^\/product\//, "") ||
+    product.productSlug ||
+    product.catalogueProductId;
+  return reference
+    ? `https://aquakart.co.in/product/${encodeURIComponent(reference)}`
+    : "";
+};
+
+const imageUrlToDataUrl = async (source) => {
+  if (!source || typeof window === "undefined") return "";
+  try {
+    const response = await fetch(source);
+    if (!response.ok) return "";
+    const blob = await response.blob();
+    return await new Promise((resolve) => {
+      const reader = new FileReader();
+      reader.onloadend = () => resolve(String(reader.result || ""));
+      reader.onerror = () => resolve("");
+      reader.readAsDataURL(blob);
+    });
+  } catch {
+    return "";
+  }
+};
 
 const safeFilePart = (value) =>
   String(value || "invoice")
@@ -46,25 +78,54 @@ const titleCase = (value) =>
 
 const drawPageHeader = (doc, invoice, continued = false, sectionLabel = "") => {
   const width = doc.internal.pageSize.getWidth();
-  const invoiceTitle = invoice.gst ? "GST TAX INVOICE" : "INVOICE";
+  const height = doc.internal.pageSize.getHeight();
+  const invoiceTitle = invoice.gst ? "GST TAX INVOICE" : "RETAIL TAX INVOICE";
   const documentTitle = sectionLabel
     ? `${invoiceTitle} / ${sectionLabel}`
     : continued
       ? `${invoiceTitle} / CONTINUED`
       : invoiceTitle;
+  if (invoice._pdfLogoDataUrl) {
+    try {
+      doc.saveGraphicsState();
+      doc.setGState(new doc.GState({ opacity: 0.045 }));
+      doc.addImage(
+        invoice._pdfLogoDataUrl,
+        "PNG",
+        width / 2 - 120,
+        height / 2 - 120,
+        240,
+        240,
+      );
+      doc.restoreGraphicsState();
+    } catch {
+      // The PDF remains valid when a browser cannot decode the logo asset.
+    }
+  }
+
   doc.setFillColor(...BRAND);
   doc.rect(0, 0, width, 92, "F");
   doc.setFillColor(...BRAND_BRIGHT);
   doc.rect(0, 88, width, 4, "F");
 
+  if (invoice._pdfLogoDataUrl) {
+    try {
+      doc.setFillColor(...WHITE);
+      doc.roundedRect(18, 18, 48, 48, 9, 9, "F");
+      doc.addImage(invoice._pdfLogoDataUrl, "PNG", 24, 24, 36, 36);
+    } catch {
+      // Text branding below is the accessible fallback.
+    }
+  }
+
   doc.setTextColor(...WHITE);
   doc.setFont("helvetica", "bold");
   doc.setFontSize(24);
-  doc.text("AQUAKART", 42, 42);
+  doc.text("AQUAKART", 78, 42);
   doc.setFont("helvetica", "normal");
   doc.setFontSize(9);
-  doc.text("Premium water solutions", 42, 59);
-  doc.text("GSTIN 36AJOPH6387A1Z2  |  aquakart.co.in", 42, 74);
+  doc.text("Premium water solutions", 78, 59);
+  doc.text("GSTIN 36AJOPH6387A1Z2  |  aquakart.co.in", 78, 74);
 
   doc.setFont("helvetica", "bold");
   doc.setFontSize(12);
@@ -572,7 +633,10 @@ export const createPublicInvoicePdfDocument = (JsPdf, invoice) => {
         invoice.gst_email,
         invoice.gst_address,
       ].filter(Boolean)
-    : ["This invoice does not include a GST registration profile."];
+    : [
+        "GST at 18% is included in the selling price.",
+        "Customer GST claim details were not requested.",
+      ];
   const customerHeight = drawInfoCard(doc, {
     x: margin,
     y,
@@ -609,12 +673,14 @@ export const createPublicInvoicePdfDocument = (JsPdf, invoice) => {
     const serialLines = product.productSerialNo
       ? doc.splitTextToSize(`Serial: ${product.productSerialNo}`, 220)
       : [];
+    const productUrl = getProductUrl(product);
     const rowHeight = Math.max(
       45,
       22 +
         nameLines.length * 11 +
         categoryLines.length * 9 +
-        serialLines.length * 10,
+        serialLines.length * 10 +
+        (productUrl ? 11 : 0),
     );
     if (y + rowHeight > height - 170) addContinuationPage();
 
@@ -641,6 +707,15 @@ export const createPublicInvoicePdfDocument = (JsPdf, invoice) => {
       doc.setFontSize(7);
       doc.setTextColor(...MUTED);
       doc.text(serialLines, margin + 14, detailY);
+      detailY += serialLines.length * 10;
+    }
+    if (productUrl) {
+      doc.setFont("helvetica", "bold");
+      doc.setFontSize(6.7);
+      doc.setTextColor(...BRAND);
+      doc.textWithLink("View product online", margin + 14, detailY, {
+        url: productUrl,
+      });
     }
     doc.setFont("helvetica", "normal");
     doc.setFontSize(8);
@@ -666,7 +741,7 @@ export const createPublicInvoicePdfDocument = (JsPdf, invoice) => {
     y += 46;
   }
 
-  const summaryCardHeight = invoice.gst ? 166 : 136;
+  const summaryCardHeight = invoice.gst ? 166 : 146;
   if (y + summaryCardHeight + 78 > height) addContinuationPage(false);
   y += 18;
 
@@ -691,7 +766,7 @@ export const createPublicInvoicePdfDocument = (JsPdf, invoice) => {
   doc.text(
     invoice.gst
       ? "The GST total is divided equally into CGST and SGST."
-      : "No GST is applied to this standard invoice.",
+      : "The selling price includes GST at 18%.",
     margin + 15,
     y + summaryCardHeight - 21,
   );
@@ -709,7 +784,7 @@ export const createPublicInvoicePdfDocument = (JsPdf, invoice) => {
       ]
     : [
         ["Base price", amounts.basePrice],
-        ["GST (0%)", amounts.gstValue],
+        ["GST (18%)", amounts.gstValue],
       ];
   let rowY = y + 25;
   summaryRows.forEach(([label, value]) => {
@@ -746,13 +821,14 @@ export const createPublicInvoicePdfDocument = (JsPdf, invoice) => {
 
 /** Download the server-normalized public invoice as a searchable A4 PDF. */
 export const downloadPublicInvoicePdf = async (invoice) => {
-  const loaded = await loadJsPDF();
-  const JsPdf = window.jspdf?.jsPDF;
-  if (!loaded || !JsPdf) {
-    throw new Error("The PDF service could not be loaded.");
-  }
+  const { jsPDF: JsPdf } = await import("jspdf");
 
-  const doc = createPublicInvoicePdfDocument(JsPdf, invoice);
+  const logoSource = typeof logo === "string" ? logo : logo?.src;
+  const logoDataUrl = await imageUrlToDataUrl(logoSource);
+  const doc = createPublicInvoicePdfDocument(JsPdf, {
+    ...invoice,
+    _pdfLogoDataUrl: logoDataUrl,
+  });
   doc.save(
     `Aquakart-Invoice-${safeFilePart(invoice.invoice_no || invoice.id)}.pdf`,
   );

--- a/src/utils/invoice/matchInvoiceProducts.js
+++ b/src/utils/invoice/matchInvoiceProducts.js
@@ -153,6 +153,13 @@ export const enrichInvoiceProducts = (invoice, cataloguePayload) => {
         ...product,
         catalogueProductId: match.id,
         productSlug: match.slug,
+        productLink:
+          product.productLink ||
+          (match.slug
+            ? `/product/${encodeURIComponent(match.slug)}`
+            : match.id
+              ? `/product/${encodeURIComponent(match.id)}`
+              : ""),
         productImage: product.productImage || match.image,
         productCategory: product.productCategory || match.category,
         productSubcategory: product.productSubcategory || match.subcategory,

--- a/src/utils/invoice/matchInvoiceProducts.test.js
+++ b/src/utils/invoice/matchInvoiceProducts.test.js
@@ -78,6 +78,7 @@ describe("invoice product catalogue matching", () => {
       productImage: "https://cdn.aquakart.test/kent-excell-plus.png",
       productCategory: "Water Softeners",
       productSubcategory: "Automatic Softeners",
+      productLink: "/product/kent-excell-plus",
       productPrice: 58_910,
     });
   });

--- a/src/utils/invoice/normalizeInvoice.js
+++ b/src/utils/invoice/normalizeInvoice.js
@@ -79,6 +79,8 @@ export const mapInvoiceFromApi = (payload) => {
             product?.productSerialNo ?? product?.serial_no,
           ),
           productImage: firstImageUrl(product),
+          productLink: normalizeText(product?.productLink ?? product?.link),
+          productSlug: normalizeText(product?.productSlug ?? product?.slug),
           productCategory: normalizeLabel(
             product?.productCategory ??
               product?.category ??

--- a/src/utils/priceUtils.js
+++ b/src/utils/priceUtils.js
@@ -125,15 +125,7 @@ const priceUtils = {
         ? toPaise(suppliedTotal)
         : itemsTotalPaise;
     const grandTotal = fromPaise(grandTotalPaise);
-    const tax = invoice?.gst
-      ? this.getGSTBreakdown(grandTotal)
-      : {
-          grossPrice: grandTotal,
-          basePrice: grandTotal,
-          gstValue: 0,
-          cgstValue: 0,
-          sgstValue: 0,
-        };
+    const tax = this.getGSTBreakdown(grandTotal);
 
     return {
       itemsTotal: fromPaise(itemsTotalPaise),

--- a/src/utils/priceUtils.test.js
+++ b/src/utils/priceUtils.test.js
@@ -22,7 +22,7 @@ describe("priceUtils", () => {
     expect(result.cgstValue + result.sgstValue).toBe(result.gstValue);
   });
 
-  it("uses quantity when calculating invoice totals", () => {
+  it("includes 18% GST in every invoice total", () => {
     const result = priceUtils.getInvoiceAmounts({
       gst: false,
       products: [
@@ -32,10 +32,10 @@ describe("priceUtils", () => {
     });
 
     expect(result.itemsTotal).toBe(3_500);
-    expect(result.basePrice).toBe(3_500);
-    expect(result.gstValue).toBe(0);
-    expect(result.cgstValue).toBe(0);
-    expect(result.sgstValue).toBe(0);
+    expect(result.basePrice).toBe(2_966.1);
+    expect(result.gstValue).toBe(533.9);
+    expect(result.cgstValue).toBe(266.95);
+    expect(result.sgstValue).toBe(266.95);
     expect(result.grandTotal).toBe(3_500);
   });
 


### PR DESCRIPTION
## Summary
- calculate inclusive 18% GST for every invoice while preserving `gst: true` as the customer claimability flag
- show CGST 9% and SGST 9% on claimable GST invoices, and combined GST 18% on retail invoices
- redesign the downloadable A4 PDF with Aquakart header branding, a low-opacity logo watermark, detailed billing/tax sections, product links, and consistent page styling
- add a responsive product image rail with open-in-new-tab and copy-link actions
- preserve product URLs during invoice normalization and catalog matching
- package jsPDF locally instead of loading it from a CDN

## Validation
- `npm test` — 48 tests passed after rebasing onto current `PROD`
- `git diff --check` — passed
- generated and rendered a two-page sample invoice with Poppler; visually checked both A4 pages for clipping, alignment, watermark, GST totals, links, and footer consistency
- the production build passed before the latest `PROD` dependency-upgrade commit; after rebasing, it is blocked by an unrelated existing footer import issue because `lucide-react@1.28.0` no longer exports `Facebook`, `Instagram`, or `Twitter`

## Notes
- Existing invoice totals remain treated as GST-inclusive.
- `gst: true` exposes the CGST/SGST claim breakdown; other invoices still display the included 18% GST total.
- This branch is rebased directly onto the current `PROD` head.