### PR TITLE
feat: integrate Find Invoice phone lookup API

### DIFF
--- a/src/services/invoice.js
+++ b/src/services/invoice.js
@@ -1,6 +1,8 @@
 import axios from "axios";
 
-const BASE = (process.env.NEXT_PUBLIC_API_URL || "").replace(/\/$/, "");
+const BASE = (
+  process.env.NEXT_PUBLIC_API_URL || "https://api.aquakart.co.in/v1"
+).replace(/\/$/, "");
 
 const normalizePhone = (value = "") => {
   const digits = String(value).replace(/\D/g, "");

--- a/src/services/invoice.js
+++ b/src/services/invoice.js
@@ -2,11 +2,71 @@ import axios from "axios";
 
 const BASE = (process.env.NEXT_PUBLIC_API_URL || "").replace(/\/$/, "");
 
+const normalizePhone = (value = "") => {
+  const digits = String(value).replace(/\D/g, "");
+  return digits.length === 12 && digits.startsWith("91")
+    ? digits.slice(2)
+    : digits.slice(0, 10);
+};
+
+const normalizeInvoice = (invoice) => {
+  if (!invoice || typeof invoice !== "object" || Array.isArray(invoice)) {
+    return null;
+  }
+
+  const id = invoice._id ?? invoice.id ?? invoice.invoice_id;
+  if (!id) return null;
+
+  const products = Array.isArray(invoice.products) ? invoice.products : [];
+
+  return {
+    id: String(id),
+    invoiceNo:
+      invoice.invoiceNo ??
+      invoice.invoice_no ??
+      invoice.invoice_number ??
+      "Invoice",
+    date:
+      invoice.date ??
+      invoice.issue_date ??
+      invoice.createdAt ??
+      invoice.created_at ??
+      null,
+    itemCount: products.length,
+    paidStatus:
+      invoice.paidStatus ??
+      invoice.paid_status ??
+      invoice.payment_status ??
+      "unpaid",
+  };
+};
+
 const findInvoicesByPhone = async (phone) => {
-  const response = await axios.post(`${BASE}/crm/public/invoices/lookup`, {
-    phone,
+  const normalizedPhone = normalizePhone(phone);
+
+  if (!/^[6-9]\d{9}$/.test(normalizedPhone)) {
+    throw new Error("Please enter a valid 10-digit Indian mobile number.");
+  }
+
+  const response = await axios.get(`${BASE}/crm/admin/invoice`, {
+    params: { phone: normalizedPhone },
+    headers: { Accept: "application/json" },
   });
-  return response.data;
+
+  const payload = response.data?.data ?? response.data?.invoice ?? response.data;
+  const invoices = Array.isArray(payload) ? payload : payload ? [payload] : [];
+  const purchases = invoices.map(normalizeInvoice).filter(Boolean);
+  const found = purchases.length > 0;
+
+  return {
+    found,
+    purchases,
+    message: found
+      ? purchases.length === 1
+        ? "We found 1 invoice linked to this phone number."
+        : `We found ${purchases.length} invoices linked to this phone number.`
+      : "No invoice was found for this phone number.",
+  };
 };
 
 const InvoiceServiceOperations = { findInvoicesByPhone };


### PR DESCRIPTION
## Summary
- replaces the obsolete `POST /crm/public/invoices/lookup` call with `GET /crm/admin/invoice?phone=<number>`
- normalizes Indian phone numbers before lookup
- maps the backend invoice response into the existing Find Invoice page model
- supports direct invoice payloads, wrapped `data`/`invoice` payloads, arrays, empty results, and field-name variants
- keeps the existing loading, found, empty, and error UI flows unchanged
- uses `https://api.aquakart.co.in/v1` as a fallback when `NEXT_PUBLIC_API_URL` is not configured

## Verification
- confirmed the Find Invoice page already consumes `InvoiceServiceOperations.findInvoicesByPhone`
- confirmed invoice selection continues to route to `/invoice/<invoice-id>`
- reviewed the frontend diff against `PROD`

## Backend blocker
The current backend `main` route registers `/crm/admin/invoice` with `userAuth.checkAdmin`. The public Find Invoice page does not possess or send an admin JWT, so the deployed endpoint must either be made safely available for this use case or replaced by a purpose-built public lookup endpoint before this can work for unauthenticated customers.

Exposing a full admin invoice response publicly should be reviewed because it may return customer PII. A minimal lookup response containing only invoice ID, invoice number, date, payment status, and item count would be safer.