### PR TITLE
feat: gate invoice viewing with Google login

### DIFF
--- a/src/pages/api/invoice-access/exchange.js
+++ b/src/pages/api/invoice-access/exchange.js
@@ -1,6 +1,7 @@
 import {
   backendInvoiceRequest,
   invoiceAccessCookie,
+  isSameOriginRequest,
 } from "@/utils/server/invoiceAccess";
 
 export default async function handler(req, res) {
@@ -9,6 +10,11 @@ export default async function handler(req, res) {
     return res
       .status(405)
       .json({ success: false, message: "Method not allowed" });
+  }
+  if (!isSameOriginRequest(req)) {
+    return res
+      .status(403)
+      .json({ success: false, message: "Invalid request origin" });
   }
   try {
     const response = await backendInvoiceRequest("/exchange", {

--- a/src/pages/api/invoice-access/login.js
+++ b/src/pages/api/invoice-access/login.js
@@ -1,0 +1,53 @@
+import {
+  backendInvoiceRequest,
+  invoiceAccessCookie,
+  isSameOriginRequest,
+} from "@/utils/server/invoiceAccess";
+
+export default async function handler(req, res) {
+  if (req.method !== "POST") {
+    res.setHeader("Allow", "POST");
+    return res
+      .status(405)
+      .json({ success: false, message: "Method not allowed" });
+  }
+  if (!isSameOriginRequest(req)) {
+    return res
+      .status(403)
+      .json({ success: false, message: "Invalid request origin" });
+  }
+
+  const firebaseIdToken = String(req.body?.firebaseIdToken || "");
+  if (!firebaseIdToken) {
+    return res
+      .status(401)
+      .json({ success: false, message: "Google login is required" });
+  }
+
+  try {
+    const response = await backendInvoiceRequest("/login", {
+      method: "POST",
+      headers: { Authorization: `Bearer ${firebaseIdToken}` },
+      body: JSON.stringify({ phone: req.body?.phone }),
+    });
+    const payload = await response.json().catch(() => ({}));
+    if (!response.ok) return res.status(response.status).json(payload);
+
+    res.setHeader(
+      "Set-Cookie",
+      invoiceAccessCookie(payload.accessToken, payload.expiresIn || 1800),
+    );
+    return res.status(200).json({
+      success: true,
+      authenticated: true,
+      invoiceCount: payload.invoiceCount,
+      redirectInvoiceId: payload.redirectInvoiceId,
+      user: payload.user,
+      message: payload.message,
+    });
+  } catch {
+    return res
+      .status(502)
+      .json({ success: false, message: "Invoice service is unavailable" });
+  }
+}

--- a/src/pages/find-invoice.js
+++ b/src/pages/find-invoice.js
@@ -1,5 +1,6 @@
 import Head from "next/head";
 import Link from "next/link";
+import { useRouter } from "next/router";
 import { useState } from "react";
 import {
   ArrowLeft,
@@ -7,7 +8,7 @@ import {
   CheckCircle2,
   FileSearch,
   Loader2,
-  Mail,
+  LogIn,
   Phone,
   ReceiptText,
   RotateCcw,
@@ -15,12 +16,16 @@ import {
 } from "lucide-react";
 
 import AquaLayout from "@/components/Layout/Layout";
+import { useAuth } from "@/context/AuthContext";
+import { getCurrentFirebaseIdToken } from "@/services/googleAuth";
 import InvoiceServiceOperations, {
   normalizeInvoicePhone,
 } from "@/services/invoice";
 import styles from "@/styles/find-invoice.module.css";
 
 const FindInvoicePage = () => {
+  const router = useRouter();
+  const { signInWithGoogle } = useAuth();
   const [phone, setPhone] = useState("");
   const [status, setStatus] = useState("idle");
   const [result, setResult] = useState(null);
@@ -50,22 +55,26 @@ const FindInvoicePage = () => {
     }
   };
 
-  const handleEmail = async () => {
-    if (status === "sending") return;
-    setStatus("sending");
+  const handleGoogleAccess = async () => {
+    if (status === "authenticating") return;
+    setStatus("authenticating");
     setMessage("");
     try {
-      const payload =
-        await InvoiceServiceOperations.requestInvoiceAccess(phone);
-      setMessage(
-        payload.message ||
-          "Your secure invoice link is on its way. Please check your email.",
+      await signInWithGoogle();
+      const firebaseIdToken = await getCurrentFirebaseIdToken();
+      const payload = await InvoiceServiceOperations.loginInvoiceAccess(
+        phone,
+        firebaseIdToken,
       );
-      setStatus("sent");
+      const destination = payload.redirectInvoiceId
+        ? `/invoice/${payload.redirectInvoiceId}`
+        : "/invoices";
+      await router.push(destination);
     } catch (error) {
       setMessage(
         error?.response?.data?.message ||
-          "We could not send the secure link. Please try again.",
+          error?.message ||
+          "We could not verify your Google account. Please try again.",
       );
       setStatus("found");
     }
@@ -105,14 +114,14 @@ const FindInvoicePage = () => {
               <h1>Find your purchase invoice.</h1>
               <p>
                 Enter the mobile number used for your purchase. For your
-                privacy, we’ll email a secure link instead of displaying order
-                details publicly.
+                privacy, Google login is required before any invoice details can
+                be opened.
               </p>
               <div className={styles.trustNote}>
                 <ShieldCheck size={18} />
                 <span>
-                  Your invoice details remain protected and links expire
-                  automatically.
+                  Firebase verifies your Google identity. Aquakart remains the
+                  owner of invoice access and purchase records.
                 </span>
               </div>
             </div>
@@ -181,7 +190,7 @@ const FindInvoicePage = () => {
                 </div>
               ) : null}
 
-              {["found", "sending"].includes(status) ? (
+              {["found", "authenticating"].includes(status) ? (
                 <div className={styles.foundState}>
                   <div className={styles.foundHeading}>
                     <CheckCircle2 size={25} />
@@ -194,38 +203,36 @@ const FindInvoicePage = () => {
                     </div>
                   </div>
                   <div className={styles.emailPanel}>
-                    <Mail size={24} />
+                    <LogIn size={24} />
                     <div>
-                      <strong>Send a secure viewing link</strong>
+                      <strong>Log in to open your invoice</strong>
                       <p>
-                        {result?.canEmail
-                          ? `We’ll send it to ${result.maskedEmail}. The link is private and expires automatically.`
-                          : "This purchase has no email address attached. Please contact Aquakart support to update your details."}
+                        Continue with Google to verify your identity. We’ll use
+                        your verified name and email to complete any missing
+                        invoice customer details.
                       </p>
                     </div>
                   </div>
                   {message ? (
                     <p className={styles.formError}>{message}</p>
                   ) : null}
-                  {result?.canEmail ? (
-                    <button
-                      className={styles.emailButton}
-                      type="button"
-                      onClick={handleEmail}
-                      disabled={status === "sending"}
-                    >
-                      {status === "sending" ? (
-                        <>
-                          <Loader2 className={styles.spinner} size={18} />{" "}
-                          Sending secure link...
-                        </>
-                      ) : (
-                        <>
-                          <Mail size={17} /> Email my invoice link
-                        </>
-                      )}
-                    </button>
-                  ) : null}
+                  <button
+                    className={styles.emailButton}
+                    type="button"
+                    onClick={handleGoogleAccess}
+                    disabled={status === "authenticating"}
+                  >
+                    {status === "authenticating" ? (
+                      <>
+                        <Loader2 className={styles.spinner} size={18} />{" "}
+                        Verifying with Google...
+                      </>
+                    ) : (
+                      <>
+                        <LogIn size={17} /> Continue with Google
+                      </>
+                    )}
+                  </button>
                   <button
                     type="button"
                     className={styles.resetButton}
@@ -233,25 +240,6 @@ const FindInvoicePage = () => {
                   >
                     <RotateCcw size={14} /> Search another phone number
                   </button>
-                </div>
-              ) : null}
-
-              {status === "sent" ? (
-                <div className={styles.resultState}>
-                  <span className={styles.resultIcon}>
-                    <Mail size={30} />
-                  </span>
-                  <span className={styles.eyebrow}>Email sent</span>
-                  <h2>Check your inbox.</h2>
-                  <p>{message}</p>
-                  <div className={styles.resultActions}>
-                    <button type="button" onClick={handleEmail}>
-                      <Mail size={15} /> Send again
-                    </button>
-                    <button type="button" onClick={resetLookup}>
-                      <RotateCcw size={15} /> Another number
-                    </button>
-                  </div>
                 </div>
               ) : null}
             </div>

--- a/src/pages/invoice/[id].js
+++ b/src/pages/invoice/[id].js
@@ -3,6 +3,7 @@ import { enrichInvoiceProducts } from "@/utils/invoice/matchInvoiceProducts";
 import { mapInvoiceFromApi } from "@/utils/invoice/normalizeInvoice";
 import {
   backendInvoiceRequest,
+  getInvoiceApiBase,
   getInvoiceAccessToken,
 } from "@/utils/server/invoiceAccess";
 
@@ -50,11 +51,7 @@ export const getServerSideProps = async ({ params, req, res }) => {
     return { props: { invoice: null, statusCode: 401 } };
   }
 
-  const apiBase =
-    process.env.INVOICE_API_URL || process.env.NEXT_PUBLIC_API_URL;
-  if (!apiBase) {
-    return { props: { invoice: null, statusCode: 503 } };
-  }
+  const apiBase = getInvoiceApiBase();
 
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);

--- a/src/services/googleAuth.js
+++ b/src/services/googleAuth.js
@@ -40,6 +40,14 @@ export const logoutGoogleUser = async () => {
   await signOut(getFirebaseAuth());
 };
 
+export const getCurrentFirebaseIdToken = async () => {
+  const currentUser = getFirebaseAuth().currentUser;
+  if (!currentUser) {
+    throw new Error("Please continue with Google first");
+  }
+  return currentUser.getIdToken(true);
+};
+
 export const getCurrentUser = async (token) => {
   const response = await fetch(authUrl("/auth/me"), {
     headers: { Authorization: `Bearer ${token}` },

--- a/src/services/invoice.js
+++ b/src/services/invoice.js
@@ -34,6 +34,14 @@ const exchangeInvoiceToken = async (token) => {
   return response.data;
 };
 
+const loginInvoiceAccess = async (phone, firebaseIdToken) => {
+  const response = await axios.post("/api/invoice-access/login", {
+    phone: assertPhone(phone),
+    firebaseIdToken,
+  });
+  return response.data;
+};
+
 const getAccessibleInvoices = async () => {
   const response = await axios.get("/api/invoice-access");
   return response.data;
@@ -50,6 +58,7 @@ const InvoiceServiceOperations = {
   lookupInvoices,
   requestInvoiceAccess,
   exchangeInvoiceToken,
+  loginInvoiceAccess,
   getAccessibleInvoices,
   emailInvoice,
 };

--- a/src/utils/server/invoiceAccess.js
+++ b/src/utils/server/invoiceAccess.js
@@ -39,3 +39,17 @@ export const invoiceAccessCookie = (token, maxAge = 1800) => {
 
 export const getInvoiceAccessToken = (req) =>
   req.cookies?.[INVOICE_ACCESS_COOKIE] || "";
+
+export const isSameOriginRequest = (req) => {
+  const origin = req.headers.origin;
+  if (!origin) return true;
+  const forwardedHost = String(req.headers["x-forwarded-host"] || "")
+    .split(",")[0]
+    .trim();
+  const host = forwardedHost || req.headers.host;
+  try {
+    return new URL(origin).host === host;
+  } catch {
+    return false;
+  }
+};

--- a/src/utils/server/invoiceAccess.login.test.js
+++ b/src/utils/server/invoiceAccess.login.test.js
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+
+import { isSameOriginRequest } from "./invoiceAccess";
+
+describe("isSameOriginRequest", () => {
+  it("accepts matching browser origins", () => {
+    expect(
+      isSameOriginRequest({
+        headers: { origin: "https://aquakart.co.in", host: "aquakart.co.in" },
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects cross-site session creation", () => {
+    expect(
+      isSameOriginRequest({
+        headers: { origin: "https://attacker.example", host: "aquakart.co.in" },
+      }),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## What changed
- replace the email-only dead end with a required Continue with Google step
- reuse the existing Firebase/AuthContext login flow
- send a fresh Firebase ID token through a same-origin BFF route
- create a secure HttpOnly invoice session after backend verification
- open a single invoice directly or show the invoice list when multiple invoices exist
- add origin validation for session-creating endpoints
- fix invoice SSR to use the same backend URL fallback as the BFF

## User impact
A customer can enter their purchase phone number, log in with Google, and immediately open invoices even when the original invoice has no email address.

## Validation
- 6/6 focused tests passed
- `npm run build` passed
- Prettier and diff checks passed

## Dependency
Deploy the matching backend PR first.