### PR TITLE
feat: add Google login to direct invoice access

### DIFF
--- a/src/features/invoiceDiscovery/flow.js
+++ b/src/features/invoiceDiscovery/flow.js
@@ -160,6 +160,19 @@ export const invoiceFlowReducer = (state, action) => {
   }
 };
 
+export const findRequestedInvoice = (invoices, requestedId) => {
+  const normalizedId = Array.isArray(requestedId)
+    ? requestedId[0]
+    : requestedId;
+  if (typeof normalizedId !== "string" || !normalizedId.trim()) return null;
+
+  return (
+    (Array.isArray(invoices) ? invoices : []).find(
+      (invoice) => String(invoice?.id || "") === normalizedId.trim(),
+    ) || null
+  );
+};
+
 export const getInvoiceEmailScenario = (invoice) => {
   if (invoice?.emailStatus === "matches") return "matches";
   if (invoice?.emailStatus === "missing") return "missing";

--- a/src/features/invoiceDiscovery/flow.test.js
+++ b/src/features/invoiceDiscovery/flow.test.js
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   createInitialInvoiceFlow,
+  findRequestedInvoice,
   getInvoiceEmailScenario,
   INVOICE_FLOW_PHASE,
   invoiceFlowReducer,
@@ -35,6 +36,13 @@ describe("invoice discovery state model", () => {
         invoices: [{ id: "invoice-1" }],
       }).phase,
     ).toBe(INVOICE_FLOW_PHASE.LIST);
+  });
+
+  it("selects the invoice requested by a direct secure link", () => {
+    const invoices = [{ id: "invoice-1" }, { id: "invoice-2" }];
+    expect(findRequestedInvoice(invoices, "invoice-2")).toEqual(invoices[1]);
+    expect(findRequestedInvoice(invoices, ["invoice-1"])).toEqual(invoices[0]);
+    expect(findRequestedInvoice(invoices, "missing")).toBeNull();
   });
 
   it("requires confirmation only for unclaimed invoices", () => {

--- a/src/pageComponents/invoice/InvoicePage.js
+++ b/src/pageComponents/invoice/InvoicePage.js
@@ -1,7 +1,8 @@
 import Head from "next/head";
 import Image from "next/image";
 import Link from "next/link";
-import { useState } from "react";
+import { useRouter } from "next/router";
+import { useEffect, useState } from "react";
 import {
   ArrowLeft,
   BadgeCheck,
@@ -30,6 +31,8 @@ import {
 } from "lucide-react";
 import { toast } from "sonner";
 import logo from "@/assests/logo.png";
+import GoogleMark from "@/components/auth/GoogleMark";
+import { useAuth } from "@/context/AuthContext";
 import {
   bankCopyDetails,
   bankPaymentMethods,
@@ -88,8 +91,51 @@ const StatusPill = ({ status }) => {
 };
 
 const InvoiceError = ({ statusCode }) => {
+  const router = useRouter();
+  const {
+    authenticated,
+    authReady,
+    loading: authLoading,
+    signInWithGoogle,
+  } = useAuth();
+  const [signingIn, setSigningIn] = useState(false);
   const notFound = statusCode === 404;
   const unauthorized = statusCode === 401 || statusCode === 403;
+  const routeId = Array.isArray(router.query.id)
+    ? router.query.id[0]
+    : router.query.id;
+  const findInvoiceHref = routeId
+    ? `/page/find-invoice?invoiceId=${encodeURIComponent(routeId)}`
+    : "/page/find-invoice";
+  const authBusy = authLoading || signingIn;
+
+  useEffect(() => {
+    if (unauthorized && authReady && authenticated && !authLoading) {
+      void router.replace(findInvoiceHref);
+    }
+  }, [
+    authLoading,
+    authReady,
+    authenticated,
+    findInvoiceHref,
+    router,
+    unauthorized,
+  ]);
+
+  const continueWithGoogle = async () => {
+    if (authBusy) return;
+    setSigningIn(true);
+    try {
+      const result = await signInWithGoogle();
+      if (!result?.redirecting) {
+        await router.push(findInvoiceHref);
+      }
+    } catch {
+      // AuthContext shows the user-facing authentication error.
+    } finally {
+      setSigningIn(false);
+    }
+  };
 
   return (
     <div className={styles.errorPage}>
@@ -119,20 +165,28 @@ const InvoiceError = ({ statusCode }) => {
         </h1>
         <p>
           {unauthorized
-            ? "Continue with Google and confirm the phone number attached to your purchase."
+            ? "Continue with Google, then verify the phone number attached to your purchase to open this invoice."
             : notFound
               ? "Check the invoice link and try again. The ID may be incomplete or no longer available."
               : "We could not reach the invoice service. Please wait a moment and try again."}
         </p>
         <div className={styles.errorActions}>
           {unauthorized ? (
-            <Link href="/page/find-invoice">Find my invoices</Link>
+            <button
+              type="button"
+              className={styles.googleSignInButton}
+              onClick={continueWithGoogle}
+              disabled={authBusy}
+            >
+              <GoogleMark />
+              {authBusy ? "Checking Google session…" : "Continue with Google"}
+            </button>
           ) : (
             <button type="button" onClick={() => window.location.reload()}>
               Try again
             </button>
           )}
-          <Link href="/">
+          <Link href="/" className={styles.homeButton}>
             <ArrowLeft size={16} /> Back to Aquakart
           </Link>
         </div>

--- a/src/pages/find-invoice.js
+++ b/src/pages/find-invoice.js
@@ -1,5 +1,6 @@
 import Head from "next/head";
 import Link from "next/link";
+import { useRouter } from "next/router";
 import { useEffect, useReducer, useRef } from "react";
 import {
   ArrowLeft,
@@ -24,6 +25,7 @@ import InvoiceShareDialog from "@/components/invoice/InvoiceShareDialog";
 import { useAuth } from "@/context/AuthContext";
 import {
   createInitialInvoiceFlow,
+  findRequestedInvoice,
   INVOICE_FLOW_PHASE,
   invoiceFlowReducer,
   validateDeliveryEmail,
@@ -66,6 +68,7 @@ const friendlyAuthError = (error) => {
 };
 
 const FindInvoicePage = () => {
+  const router = useRouter();
   const {
     authenticated,
     authReady,
@@ -137,6 +140,13 @@ const FindInvoicePage = () => {
           user: payload.user,
           message: payload.message,
         });
+        const requestedInvoice = findRequestedInvoice(
+          payload.invoices,
+          router.query.invoiceId,
+        );
+        if (requestedInvoice) {
+          dispatch({ type: "SELECT_INVOICE", invoice: requestedInvoice });
+        }
       }
     } catch (error) {
       if (accountSwitch && authenticated) {
@@ -183,6 +193,13 @@ const FindInvoicePage = () => {
         user: payload.user,
         message: payload.message,
       });
+      const requestedInvoice = findRequestedInvoice(
+        payload.invoices,
+        router.query.invoiceId,
+      );
+      if (requestedInvoice) {
+        dispatch({ type: "SELECT_INVOICE", invoice: requestedInvoice });
+      }
     } catch (error) {
       if (error?.response?.status === 401) {
         dispatch({

--- a/src/styles/invoice.module.css
+++ b/src/styles/invoice.module.css
@@ -1788,6 +1788,35 @@
   background: white;
 }
 
+.errorActions .googleSignInButton {
+  border: 1px solid #d5e0de;
+  color: #243b43;
+  background: #fff;
+  box-shadow: 0 12px 28px rgba(15, 23, 42, 0.08);
+}
+
+.errorActions .googleSignInButton:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 32px rgba(15, 23, 42, 0.12);
+}
+
+.errorActions .googleSignInButton:disabled {
+  cursor: wait;
+  opacity: 0.65;
+}
+
+.errorActions .homeButton {
+  border-color: var(--invoice-ink);
+  color: #fff;
+  background: var(--invoice-ink);
+}
+
+.errorActions .googleSignInButton:focus-visible,
+.errorActions .homeButton:focus-visible {
+  outline: 3px solid rgba(5, 132, 95, 0.3);
+  outline-offset: 3px;
+}
+
 @media (max-width: 980px) {
   .commandIdentity,
   .secondaryButton span {


### PR DESCRIPTION
## Summary

Adds Google authentication directly to the protected `/invoice/[id]` screen instead of showing only a “Find my invoices” link.

## User flow

- Shows an accessible “Continue with Google” button with the official Google mark for 401/403 invoice access.
- Supports the existing popup-to-redirect Firebase fallback.
- Preserves the requested invoice ID when moving into phone verification.
- Automatically opens the requested invoice’s confirmation/share dialog after the verified phone lookup succeeds.
- Redirects users who already have a valid Google session into verification without asking them to sign in again.
- Keeps the existing no-store and no-index behavior for protected invoice pages.

## Files

- `src/pageComponents/invoice/InvoicePage.js`
- `src/pages/find-invoice.js`
- `src/features/invoiceDiscovery/flow.js`
- `src/features/invoiceDiscovery/flow.test.js`
- `src/styles/invoice.module.css`

## Validation

- All modified JavaScript and CSS files pass Prettier parser validation.
- Added state-helper coverage for matching a requested direct invoice ID, including array query parameters and missing IDs.
- The previous workspace checkout was not retained, so the full frontend test/build suite has not been rerun for this follow-up commit.
- No GitHub Actions workflow/status checks are currently reported for the commit.