### PR TITLE
fix: keep direct invoice login on requested URL

### DIFF
--- a/src/pageComponents/invoice/InvoicePage.js
+++ b/src/pageComponents/invoice/InvoicePage.js
@@ -2,7 +2,7 @@ import Head from "next/head";
 import Image from "next/image";
 import Link from "next/link";
 import { useRouter } from "next/router";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import {
   ArrowLeft,
   BadgeCheck,
@@ -33,6 +33,8 @@ import { toast } from "sonner";
 import logo from "@/assests/logo.png";
 import GoogleMark from "@/components/auth/GoogleMark";
 import { useAuth } from "@/context/AuthContext";
+import { getCurrentFirebaseIdToken } from "@/services/googleAuth";
+import InvoiceServiceOperations from "@/services/invoice";
 import {
   bankCopyDetails,
   bankPaymentMethods,
@@ -96,9 +98,15 @@ const InvoiceError = ({ statusCode }) => {
     authenticated,
     authReady,
     loading: authLoading,
+    session,
     signInWithGoogle,
   } = useAuth();
   const [signingIn, setSigningIn] = useState(false);
+  const [openingInvoice, setOpeningInvoice] = useState(false);
+  const [accessError, setAccessError] = useState("");
+  const [verificationRequired, setVerificationRequired] = useState(false);
+  const attemptedDirectAccess = useRef(false);
+  const directAccessInFlight = useRef(false);
   const notFound = statusCode === 404;
   const unauthorized = statusCode === 401 || statusCode === 403;
   const routeId = Array.isArray(router.query.id)
@@ -107,28 +115,80 @@ const InvoiceError = ({ statusCode }) => {
   const findInvoiceHref = routeId
     ? `/page/find-invoice?invoiceId=${encodeURIComponent(routeId)}`
     : "/page/find-invoice";
-  const authBusy = authLoading || signingIn;
+  const authBusy = authLoading || signingIn || openingInvoice;
+
+  const requestDirectAccess = useCallback(
+    async (backendSessionToken) => {
+      if (!routeId || !backendSessionToken || directAccessInFlight.current) {
+        return;
+      }
+
+      attemptedDirectAccess.current = true;
+      directAccessInFlight.current = true;
+      setOpeningInvoice(true);
+      setAccessError("");
+      setVerificationRequired(false);
+
+      try {
+        const firebaseIdToken = await getCurrentFirebaseIdToken();
+        await InvoiceServiceOperations.loginDirectInvoiceAccess(
+          routeId,
+          firebaseIdToken,
+          backendSessionToken,
+        );
+        window.location.replace(router.asPath);
+      } catch (error) {
+        setVerificationRequired(
+          Boolean(error?.response?.data?.verificationRequired),
+        );
+        setAccessError(
+          error?.response?.data?.message ||
+            error?.message ||
+            "We could not verify access to this invoice.",
+        );
+      } finally {
+        directAccessInFlight.current = false;
+        setOpeningInvoice(false);
+      }
+    },
+    [routeId, router.asPath],
+  );
 
   useEffect(() => {
-    if (unauthorized && authReady && authenticated && !authLoading) {
-      void router.replace(findInvoiceHref);
+    if (
+      unauthorized &&
+      authReady &&
+      authenticated &&
+      session?.token &&
+      !authLoading &&
+      !attemptedDirectAccess.current
+    ) {
+      void requestDirectAccess(session.token);
     }
   }, [
     authLoading,
     authReady,
     authenticated,
-    findInvoiceHref,
-    router,
+    requestDirectAccess,
+    session?.token,
     unauthorized,
   ]);
 
   const continueWithGoogle = async () => {
     if (authBusy) return;
+
+    if (authenticated && session?.token) {
+      attemptedDirectAccess.current = false;
+      await requestDirectAccess(session.token);
+      return;
+    }
+
     setSigningIn(true);
+    setAccessError("");
     try {
       const result = await signInWithGoogle();
       if (!result?.redirecting) {
-        await router.push(findInvoiceHref);
+        await requestDirectAccess(result?.token || session?.token);
       }
     } catch {
       // AuthContext shows the user-facing authentication error.
@@ -136,6 +196,14 @@ const InvoiceError = ({ statusCode }) => {
       setSigningIn(false);
     }
   };
+
+  const primaryActionLabel = openingInvoice
+    ? "Opening invoice…"
+    : signingIn || authLoading
+      ? "Checking Google session…"
+      : authenticated
+        ? "Open invoice"
+        : "Continue with Google";
 
   return (
     <div className={styles.errorPage}>
@@ -165,11 +233,16 @@ const InvoiceError = ({ statusCode }) => {
         </h1>
         <p>
           {unauthorized
-            ? "Continue with Google, then verify the phone number attached to your purchase to open this invoice."
+            ? "Continue with Google to verify ownership and open this invoice at the same secure link."
             : notFound
               ? "Check the invoice link and try again. The ID may be incomplete or no longer available."
               : "We could not reach the invoice service. Please wait a moment and try again."}
         </p>
+        {accessError ? (
+          <p className={styles.accessError} role="alert">
+            {accessError}
+          </p>
+        ) : null}
         <div className={styles.errorActions}>
           {unauthorized ? (
             <button
@@ -179,13 +252,21 @@ const InvoiceError = ({ statusCode }) => {
               disabled={authBusy}
             >
               <GoogleMark />
-              {authBusy ? "Checking Google session…" : "Continue with Google"}
+              {primaryActionLabel}
             </button>
           ) : (
             <button type="button" onClick={() => window.location.reload()}>
               Try again
             </button>
           )}
+          {verificationRequired ? (
+            <Link
+              href={findInvoiceHref}
+              className={styles.phoneVerificationLink}
+            >
+              Verify purchase phone
+            </Link>
+          ) : null}
           <Link href="/" className={styles.homeButton}>
             <ArrowLeft size={16} /> Back to Aquakart
           </Link>

--- a/src/pages/api/invoice-access/[id]/login.js
+++ b/src/pages/api/invoice-access/[id]/login.js
@@ -1,0 +1,72 @@
+import {
+  backendInvoiceRequest,
+  invoiceAccessCookie,
+  isSameOriginRequest,
+} from "@/utils/server/invoiceAccess";
+
+const normalizeInvoiceId = (value) => {
+  const id = Array.isArray(value) ? value[0] : value;
+  if (typeof id !== "string") return "";
+  const normalized = id.trim();
+  return normalized && normalized.length <= 160 ? normalized : "";
+};
+
+export default async function handler(req, res) {
+  res.setHeader("Cache-Control", "private, no-store, max-age=0");
+  if (req.method !== "POST") {
+    res.setHeader("Allow", "POST");
+    return res
+      .status(405)
+      .json({ success: false, message: "Method not allowed" });
+  }
+  if (!isSameOriginRequest(req)) {
+    return res
+      .status(403)
+      .json({ success: false, message: "Invalid request origin" });
+  }
+
+  const invoiceId = normalizeInvoiceId(req.query.id);
+  const firebaseIdToken = String(req.body?.firebaseIdToken || "");
+  const backendSessionToken = String(req.body?.backendSessionToken || "");
+  if (!invoiceId) {
+    return res
+      .status(404)
+      .json({ success: false, message: "Invoice not found" });
+  }
+  if (!firebaseIdToken || !backendSessionToken) {
+    return res
+      .status(401)
+      .json({ success: false, message: "Google login is required" });
+  }
+
+  try {
+    const response = await backendInvoiceRequest(
+      `/${encodeURIComponent(invoiceId)}/login`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${firebaseIdToken}`,
+          "X-Aquakart-Session": backendSessionToken,
+        },
+      },
+    );
+    const payload = await response.json().catch(() => ({}));
+    if (!response.ok) return res.status(response.status).json(payload);
+
+    res.setHeader(
+      "Set-Cookie",
+      invoiceAccessCookie(payload.accessToken, payload.expiresIn || 1800),
+    );
+    return res.status(200).json({
+      success: true,
+      authenticated: true,
+      redirectInvoiceId: payload.redirectInvoiceId,
+      invoice: payload.invoice,
+      message: payload.message,
+    });
+  } catch {
+    return res
+      .status(502)
+      .json({ success: false, message: "Invoice service is unavailable" });
+  }
+}

--- a/src/services/invoice.js
+++ b/src/services/invoice.js
@@ -48,6 +48,22 @@ const exchangeInvoiceToken = async (token) => {
   return response.data;
 };
 
+export const directInvoiceLoginPath = (invoiceId) =>
+  `/api/invoice-access/${encodeURIComponent(String(invoiceId || ""))}/login`;
+
+const loginDirectInvoiceAccess = async (
+  invoiceId,
+  firebaseIdToken,
+  backendSessionToken,
+) => {
+  if (!invoiceId) throw new Error("Invoice ID is required.");
+  const response = await axios.post(directInvoiceLoginPath(invoiceId), {
+    firebaseIdToken,
+    backendSessionToken,
+  });
+  return response.data;
+};
+
 const loginInvoiceAccess = async (
   phone,
   firebaseIdToken,
@@ -119,6 +135,7 @@ const InvoiceServiceOperations = {
   requestInvoiceAccess,
   exchangeInvoiceToken,
   loginInvoiceAccess,
+  loginDirectInvoiceAccess,
   getAccessibleInvoices,
   emailInvoice,
   claimInvoice,

--- a/src/services/invoice.test.js
+++ b/src/services/invoice.test.js
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  directInvoiceLoginPath,
   isValidInvoiceEmail,
   normalizeInvoiceEmail,
   normalizeInvoicePhone,
@@ -29,5 +30,14 @@ describe("invoice delivery email", () => {
     expect(
       isValidInvoiceEmail("customer@example.com\r\nBcc:x@example.com"),
     ).toBe(false);
+  });
+});
+
+
+describe("direct invoice Google login", () => {
+  it("builds an invoice-scoped BFF path safely", () => {
+    expect(directInvoiceLoginPath("invoice/with spaces")).toBe(
+      "/api/invoice-access/invoice%2Fwith%20spaces/login",
+    );
   });
 });

--- a/src/styles/invoice.module.css
+++ b/src/styles/invoice.module.css
@@ -1811,7 +1811,26 @@
   background: var(--invoice-ink);
 }
 
+.errorCard .accessError {
+  margin-top: 16px;
+  padding: 11px 13px;
+  border: 1px solid #f4c9c4;
+  border-radius: 12px;
+  background: #fff1ef;
+  color: #a33228;
+  font-size: 0.68rem;
+  font-weight: 700;
+  line-height: 1.5;
+}
+
+.errorActions .phoneVerificationLink {
+  border-color: #b9ded2;
+  color: #087a5d;
+  background: #edf9f5;
+}
+
 .errorActions .googleSignInButton:focus-visible,
+.errorActions .phoneVerificationLink:focus-visible,
 .errorActions .homeButton:focus-visible {
   outline: 3px solid rgba(5, 132, 95, 0.3);
   outline-offset: 3px;


### PR DESCRIPTION
## Summary

Keeps direct invoice access on the requested `/invoice/:id` URL after Google sign-in instead of redirecting every user to `/page/find-invoice`.

## Root cause

Google sign-in created the Aquakart user session, but the direct page still lacked the separate HTTP-only invoice access cookie. The previous implementation redirected to the finder to create it through phone lookup.

## Changes

- Adds an invoice-specific Next.js BFF route at `POST /api/invoice-access/:id/login`.
- Exchanges the Firebase ID token and Aquakart backend session for an invoice-scoped HTTP-only cookie.
- Reloads the same direct invoice URL after successful verification so server-side rendering opens the invoice.
- Handles popup and Firebase redirect login completion.
- Prevents duplicate direct-access requests.
- Does not automatically navigate to the finder.
- Shows “Verify purchase phone” only when the backend reports that the Google UID/email does not match the invoice.
- Adds service path encoding coverage and explicit loading/error states.

## Backend dependency

- SVSKHD/AQUAKARTBACKEND#18

Deploy the backend endpoint before or together with this frontend change.

## Validation

- Branch is one commit ahead and zero behind current `PROD`.
- All five modified JavaScript/CSS/test files pass parser validation.
- Live inspection reproduced the current secure-access page at the reported invoice URL.
- Full frontend tests/build were not rerun because the previous local checkout was not retained.