### PR TITLE
fix: bypass API proxy for invoice BFF routes

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -122,6 +122,12 @@ const nextConfig = {
 
   async rewrites() {
     return [
+      // Keep invoice authentication on the Next.js server. The generic /api
+      // proxy below would otherwise send these BFF requests to Express.
+      {
+        source: "/invoice-gateway/:path*",
+        destination: "/api/invoice-access/:path*",
+      },
       {
         source: "/api/:path*",
         destination: "https://api.aquakart.co.in/v1/:path*",

--- a/src/services/invoice.js
+++ b/src/services/invoice.js
@@ -28,7 +28,7 @@ const assertPhone = (phone) => {
 };
 
 const lookupInvoices = async (phone, firebaseIdToken, backendSessionToken) => {
-  const response = await axios.post("/api/invoice-access/lookup", {
+  const response = await axios.post("/invoice-gateway/lookup", {
     phone: assertPhone(phone),
     firebaseIdToken,
     backendSessionToken,
@@ -37,19 +37,19 @@ const lookupInvoices = async (phone, firebaseIdToken, backendSessionToken) => {
 };
 
 const requestInvoiceAccess = async (phone) => {
-  const response = await axios.post("/api/invoice-access/request", {
+  const response = await axios.post("/invoice-gateway/request", {
     phone: assertPhone(phone),
   });
   return response.data;
 };
 
 const exchangeInvoiceToken = async (token) => {
-  const response = await axios.post("/api/invoice-access/exchange", { token });
+  const response = await axios.post("/invoice-gateway/exchange", { token });
   return response.data;
 };
 
 export const directInvoiceLoginPath = (invoiceId) =>
-  `/api/invoice-access/${encodeURIComponent(String(invoiceId || ""))}/login`;
+  `/invoice-gateway/${encodeURIComponent(String(invoiceId || ""))}/login`;
 
 const loginDirectInvoiceAccess = async (
   invoiceId,
@@ -69,7 +69,7 @@ const loginInvoiceAccess = async (
   firebaseIdToken,
   backendSessionToken,
 ) => {
-  const response = await axios.post("/api/invoice-access/login", {
+  const response = await axios.post("/invoice-gateway/login", {
     phone: assertPhone(phone),
     firebaseIdToken,
     backendSessionToken,
@@ -78,20 +78,20 @@ const loginInvoiceAccess = async (
 };
 
 const getAccessibleInvoices = async () => {
-  const response = await axios.get("/api/invoice-access");
+  const response = await axios.get("/invoice-gateway");
   return response.data;
 };
 
 const emailInvoice = async (invoiceId) => {
   const response = await axios.post(
-    `/api/invoice-access/${encodeURIComponent(invoiceId)}/share/email`,
+    `/invoice-gateway/${encodeURIComponent(invoiceId)}/share/email`,
   );
   return response.data;
 };
 
 const claimInvoice = async (invoiceId, emailAction) => {
   const response = await axios.post(
-    `/api/invoice-access/${encodeURIComponent(invoiceId)}/claim`,
+    `/invoice-gateway/${encodeURIComponent(invoiceId)}/claim`,
     { emailAction },
   );
   return response.data;
@@ -99,7 +99,7 @@ const claimInvoice = async (invoiceId, emailAction) => {
 
 const updateInvoiceEmail = async (invoiceId) => {
   const response = await axios.patch(
-    `/api/invoice-access/${encodeURIComponent(invoiceId)}/email`,
+    `/invoice-gateway/${encodeURIComponent(invoiceId)}/email`,
     { confirm: true },
   );
   return response.data;
@@ -114,7 +114,7 @@ const shareInvoiceByEmail = async (
     throw new Error("Enter a valid delivery email address.");
   }
   const response = await axios.post(
-    `/api/invoice-access/${encodeURIComponent(invoiceId)}/share/email`,
+    `/invoice-gateway/${encodeURIComponent(invoiceId)}/share/email`,
     {
       recipientEmail: normalizeInvoiceEmail(recipientEmail),
       shareRequestId,
@@ -125,7 +125,7 @@ const shareInvoiceByEmail = async (
 
 const getWhatsAppSharingStatus = async (invoiceId) => {
   const response = await axios.get(
-    `/api/invoice-access/${encodeURIComponent(invoiceId)}/share/whatsapp`,
+    `/invoice-gateway/${encodeURIComponent(invoiceId)}/share/whatsapp`,
   );
   return response.data;
 };

--- a/src/services/invoice.test.js
+++ b/src/services/invoice.test.js
@@ -37,7 +37,7 @@ describe("invoice delivery email", () => {
 describe("direct invoice Google login", () => {
   it("builds an invoice-scoped BFF path safely", () => {
     expect(directInvoiceLoginPath("invoice/with spaces")).toBe(
-      "/api/invoice-access/invoice%2Fwith%20spaces/login",
+      "/invoice-gateway/invoice%2Fwith%20spaces/login",
     );
   });
 });


### PR DESCRIPTION
## Summary

Fixes the production 404 affecting direct Google invoice login and all other invoice BFF calls.

## Root cause

`next.config.mjs` proxies every public `/api/:path*` request to `https://api.aquakart.co.in/v1/:path*`. The invoice client called `/api/invoice-access/:path*`, so production rewrote the request to Express as `/v1/invoice-access/:path*` instead of executing the Next.js API handler.

Observed production response:

`Cannot POST /v1/invoice-access/:id/login`

This HTML 404 also caused Axios to show the generic “Request failed with status code 404” message.

## Changes

- Adds a non-colliding public gateway: `/invoice-gateway/:path*`.
- Internally rewrites that gateway to the existing Next route `/api/invoice-access/:path*`.
- Moves all eleven invoice client operations to the gateway:
  - lookup
  - request access
  - token exchange
  - phone login
  - direct invoice Google login
  - list
  - claim
  - permanent email update
  - email delivery
  - legacy email action
  - WhatsApp status
- Keeps the existing generic `/api/* -> backend /v1/*` proxy unchanged for the rest of the application.
- Updates direct-login path coverage.

## Validation

- Confirmed the backend direct-login endpoint is deployed: an unauthenticated request returns the expected JSON `401`.
- Confirmed the current frontend path is incorrectly proxied and returns the reproduced HTML `404`.
- Branch is one commit ahead and zero behind current `PROD`.
- All three modified JavaScript/config/test files pass parser validation.
- Verified that invoice service code contains zero remaining `/api/invoice-access` client paths and eleven `/invoice-gateway` paths.

## Security

No credentials are included. The existing same-origin check, server-side Firebase/backend-token forwarding, HTTP-only invoice cookie, and no-store headers remain unchanged.