### PR TITLE
fix: hide internal identifiers from invoice PDFs

### DIFF
--- a/src/utils/invoice/generatePublicInvoicePdf.js
+++ b/src/utils/invoice/generatePublicInvoicePdf.js
@@ -14,17 +14,45 @@ const LINE = [226, 232, 240];
 const SOFT = [248, 250, 252];
 const WHITE = [255, 255, 255];
 
+const MONGO_OBJECT_ID = /^[a-f\d]{24}$/i;
+const UUID =
+  /^[a-f\d]{8}-[a-f\d]{4}-[1-5][a-f\d]{3}-[89ab][a-f\d]{3}-[a-f\d]{12}$/i;
+
+export const isInternalInvoiceIdentifier = (value) => {
+  const normalized = String(value || "").trim();
+  return MONGO_OBJECT_ID.test(normalized) || UUID.test(normalized);
+};
+
+const containsInternalInvoiceIdentifier = (value) =>
+  String(value || "")
+    .split(/[\s/?#&=|]+/)
+    .some(isInternalInvoiceIdentifier);
+
+export const getPublicInvoiceReference = (invoice = {}) => {
+  const invoiceNumber = String(invoice.invoice_no || "").trim();
+  return invoiceNumber && !isInternalInvoiceIdentifier(invoiceNumber)
+    ? invoiceNumber
+    : "Invoice";
+};
+
+export const getPublicProductClassification = (product = {}) =>
+  [product.productCategory, product.productSubcategory]
+    .map((value) => String(value || "").trim())
+    .filter((value) => value && !containsInternalInvoiceIdentifier(value))
+    .join(" / ");
+
 const getProductUrl = (product = {}) => {
   const directLink = product.productLink;
-  if (directLink?.startsWith("http://") || directLink?.startsWith("https://")) {
+  if (
+    (directLink?.startsWith("http://") || directLink?.startsWith("https://")) &&
+    !containsInternalInvoiceIdentifier(directLink)
+  ) {
     return directLink;
   }
 
   const reference =
-    directLink?.replace(/^\/product\//, "") ||
-    product.productSlug ||
-    product.catalogueProductId;
-  return reference
+    directLink?.replace(/^\/product\//, "") || product.productSlug;
+  return reference && !containsInternalInvoiceIdentifier(reference)
     ? `https://aquakart.co.in/product/${encodeURIComponent(reference)}`
     : "";
 };
@@ -132,7 +160,7 @@ const drawPageHeader = (doc, invoice, continued = false, sectionLabel = "") => {
   doc.text(documentTitle, width - 42, 42, { align: "right" });
   doc.setFont("helvetica", "normal");
   doc.setFontSize(9);
-  doc.text(invoice.invoice_no || invoice.id || "Invoice", width - 42, 60, {
+  doc.text(getPublicInvoiceReference(invoice), width - 42, 60, {
     align: "right",
   });
 };
@@ -201,18 +229,20 @@ const drawSectionHeading = (doc, { y, kicker, title, description }) => {
   doc.setFontSize(7);
   doc.setTextColor(...BRAND);
   doc.text(kicker.toUpperCase(), 42, y);
-  doc.setFontSize(17);
+  doc.setFontSize(15);
   doc.setTextColor(...INK);
-  doc.text(title, 42, y + 23);
+  const titleLines = doc.splitTextToSize(title, contentWidth).slice(0, 2);
+  doc.text(titleLines, 42, y + 23, { lineHeightFactor: 1.15 });
   doc.setFont("helvetica", "normal");
   doc.setFontSize(8);
   doc.setTextColor(...MUTED);
+  const descriptionY = y + 29 + titleLines.length * 15;
   const descriptionLines = doc
     .splitTextToSize(description, contentWidth)
     .slice(0, 3);
-  doc.text(descriptionLines, 42, y + 43, { lineHeightFactor: 1.35 });
+  doc.text(descriptionLines, 42, descriptionY, { lineHeightFactor: 1.35 });
 
-  return y + 50 + descriptionLines.length * 9;
+  return descriptionY + 7 + descriptionLines.length * 9;
 };
 
 const getTermCardMetrics = (doc, term, cardWidth) => {
@@ -559,6 +589,7 @@ const addPageNumbers = (doc) => {
 /** Download the server-normalized public invoice as a searchable A4 PDF. */
 export const createPublicInvoicePdfDocument = (JsPdf, invoice) => {
   const doc = new JsPdf({ unit: "pt", format: "a4", compress: true });
+  doc.setCharSpace(0);
   const width = doc.internal.pageSize.getWidth();
   const height = doc.internal.pageSize.getHeight();
   const margin = 42;
@@ -569,7 +600,7 @@ export const createPublicInvoicePdfDocument = (JsPdf, invoice) => {
   let y = 116;
 
   const metadata = [
-    ["Invoice number", invoice.invoice_no || invoice.id || "Not available"],
+    ["Invoice number", getPublicInvoiceReference(invoice)],
     ["Invoice date", formatDate(invoice.date)],
     ["Payment", titleCase(invoice.payment_type)],
     ["Status", titleCase(invoice.paid_status)],
@@ -663,16 +694,21 @@ export const createPublicInvoicePdfDocument = (JsPdf, invoice) => {
   };
 
   invoice.products.forEach((product, index) => {
-    const nameLines = doc.splitTextToSize(product.productName, 220);
-    const categoryText = [product.productCategory, product.productSubcategory]
-      .filter(Boolean)
-      .join(" / ");
+    const publicProductName =
+      product.productName &&
+      !containsInternalInvoiceIdentifier(product.productName)
+        ? product.productName
+        : "Product";
+    const nameLines = doc.splitTextToSize(publicProductName, 220);
+    const categoryText = getPublicProductClassification(product);
     const categoryLines = categoryText
       ? doc.splitTextToSize(categoryText, 220)
       : [];
-    const serialLines = product.productSerialNo
-      ? doc.splitTextToSize(`Serial: ${product.productSerialNo}`, 220)
-      : [];
+    const serialLines =
+      product.productSerialNo &&
+      !containsInternalInvoiceIdentifier(product.productSerialNo)
+        ? doc.splitTextToSize(`Serial: ${product.productSerialNo}`, 220)
+        : [];
     const productUrl = getProductUrl(product);
     const rowHeight = Math.max(
       45,
@@ -830,6 +866,6 @@ export const downloadPublicInvoicePdf = async (invoice) => {
     _pdfLogoDataUrl: logoDataUrl,
   });
   doc.save(
-    `Aquakart-Invoice-${safeFilePart(invoice.invoice_no || invoice.id)}.pdf`,
+    `Aquakart-Invoice-${safeFilePart(getPublicInvoiceReference(invoice))}.pdf`,
   );
 };

--- a/src/utils/invoice/generatePublicInvoicePdf.test.js
+++ b/src/utils/invoice/generatePublicInvoicePdf.test.js
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getPublicInvoiceReference,
+  getPublicProductClassification,
+  isInternalInvoiceIdentifier,
+} from "./generatePublicInvoicePdf";
+
+describe("public invoice PDF privacy", () => {
+  it("recognizes internal Mongo and UUID identifiers", () => {
+    expect(isInternalInvoiceIdentifier("66b388e5aaee5040f671f5fe")).toBe(true);
+    expect(
+      isInternalInvoiceIdentifier("550e8400-e29b-41d4-a716-446655440000"),
+    ).toBe(true);
+    expect(isInternalInvoiceIdentifier("AQ-2026-101")).toBe(false);
+  });
+
+  it("never falls back to the database ID as the public invoice reference", () => {
+    expect(
+      getPublicInvoiceReference({
+        id: "66b388e5aaee5040f671f5fe",
+        invoice_no: "",
+      }),
+    ).toBe("Invoice");
+    expect(getPublicInvoiceReference({ invoice_no: "AQ-2026-101" })).toBe(
+      "AQ-2026-101",
+    );
+  });
+
+  it("removes internal identifiers from product classifications", () => {
+    expect(
+      getPublicProductClassification({
+        productCategory: "66b388e5aaee5040f671f5fe",
+        productSubcategory: "Water softeners",
+      }),
+    ).toBe("Water softeners");
+    expect(
+      getPublicProductClassification({
+        productCategory: "66b388e5aaee5040f671f5fe",
+        productSubcategory: "6533f07c7986c193b3c620d2",
+      }),
+    ).toBe("");
+  });
+});


### PR DESCRIPTION
## Summary

Removes internal and confidential database identifiers from customer-facing invoice PDFs and cleans the product/terms presentation.

## Problem reproduced

The supplied PDF printed raw Mongo identifiers under the product name:

- product/category database ObjectIds
- catalogue references embedded in product links
- a raw invoice database ID fallback when no legal invoice number was available

These values are implementation details and must not be exposed in a downloaded customer document.

## Changes

- Detects Mongo ObjectIds and UUIDs before rendering PDF content.
- Removes internal category/subcategory IDs from product rows.
- Never uses `catalogueProductId` to create a customer PDF hyperlink.
- Suppresses product links containing an internal identifier.
- Suppresses an internal-ID product name or serial fallback.
- Never falls back from the legal invoice number to `invoice.id` in:
  - page headers
  - invoice metadata
  - downloaded filenames
- Keeps the official invoice number and legitimate customer/warranty fields.
- Wraps long section headings and resets character spacing for a cleaner terms page.

## Validation

- Generated and rendered a fresh two-page A4 PDF using the same ObjectId pattern as the supplied document.
- Text extraction confirmed none of the invoice, product, category or subcategory database IDs remained.
- Visual review confirmed the product row shows only the customer-facing name, quantity and prices.
- `npm test`: 21 test files and 74 tests passed.
- `npm run build`: Next.js production build passed.
- Added privacy tests covering Mongo IDs, UUIDs, invoice-number fallback and mixed product classification values.
- Branch is one commit ahead and zero behind current `PROD`.