### PR TITLE
fix: clean up customer invoice access screen

### DIFF
--- a/src/pageComponents/invoice/InvoicePage.js
+++ b/src/pageComponents/invoice/InvoicePage.js
@@ -116,6 +116,11 @@ const InvoiceError = ({ statusCode }) => {
     ? `/page/find-invoice?invoiceId=${encodeURIComponent(routeId)}`
     : "/page/find-invoice";
   const authBusy = authLoading || signingIn || openingInvoice;
+  const clientAccessMessage = verificationRequired
+    ? "For your privacy, confirm the mobile number used for this purchase."
+    : accessError
+      ? "We could not open the invoice just now. Please try again."
+      : "";
 
   const requestDirectAccess = useCallback(
     async (backendSessionToken) => {
@@ -226,24 +231,45 @@ const InvoiceError = ({ statusCode }) => {
         <span className={styles.eyebrow}>Aquakart invoices</span>
         <h1>
           {unauthorized
-            ? "Secure access is required."
+            ? verificationRequired
+              ? "One quick verification."
+              : "Open your invoice."
             : notFound
               ? "We could not find that invoice."
               : "The invoice is taking a pause."}
         </h1>
         <p>
           {unauthorized
-            ? "Continue with Google to verify ownership and open this invoice at the same secure link."
+            ? verificationRequired
+              ? "Your invoice is protected. Verify the purchase mobile number to continue."
+              : authenticated
+                ? "You are signed in. We are securely matching this invoice to your account."
+                : "Sign in with Google to securely view and download your invoice."
             : notFound
               ? "Check the invoice link and try again. The ID may be incomplete or no longer available."
               : "We could not reach the invoice service. Please wait a moment and try again."}
         </p>
-        {accessError ? (
-          <p className={styles.accessError} role="alert">
-            {accessError}
+        {clientAccessMessage ? (
+          <p
+            className={
+              verificationRequired ? styles.accessNotice : styles.accessError
+            }
+            role={verificationRequired ? "status" : "alert"}
+          >
+            {clientAccessMessage}
           </p>
         ) : null}
-        <div className={styles.errorActions}>
+        <div
+          className={`${styles.errorActions} ${verificationRequired ? styles.verificationActions : ""}`}
+        >
+          {verificationRequired ? (
+            <Link
+              href={findInvoiceHref}
+              className={styles.phoneVerificationLink}
+            >
+              Verify purchase mobile
+            </Link>
+          ) : null}
           {unauthorized ? (
             <button
               type="button"
@@ -252,21 +278,13 @@ const InvoiceError = ({ statusCode }) => {
               disabled={authBusy}
             >
               <GoogleMark />
-              {primaryActionLabel}
+              {verificationRequired ? "Try Google again" : primaryActionLabel}
             </button>
           ) : (
             <button type="button" onClick={() => window.location.reload()}>
               Try again
             </button>
           )}
-          {verificationRequired ? (
-            <Link
-              href={findInvoiceHref}
-              className={styles.phoneVerificationLink}
-            >
-              Verify purchase phone
-            </Link>
-          ) : null}
           <Link href="/" className={styles.homeButton}>
             <ArrowLeft size={16} /> Back to Aquakart
           </Link>

--- a/src/styles/invoice.module.css
+++ b/src/styles/invoice.module.css
@@ -1757,10 +1757,10 @@
 }
 
 .errorActions {
-  display: flex;
+  display: grid;
   margin-top: 26px;
-  justify-content: center;
   gap: 9px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
 .errorActions button,
@@ -1793,6 +1793,11 @@
   color: #243b43;
   background: #fff;
   box-shadow: 0 12px 28px rgba(15, 23, 42, 0.08);
+  grid-column: 1 / -1;
+}
+
+.errorActions.verificationActions .googleSignInButton {
+  grid-column: auto;
 }
 
 .errorActions .googleSignInButton:hover:not(:disabled) {
@@ -1806,9 +1811,11 @@
 }
 
 .errorActions .homeButton {
+  min-height: 40px;
   border-color: var(--invoice-ink);
   color: #fff;
   background: var(--invoice-ink);
+  grid-column: 1 / -1;
 }
 
 .errorCard .accessError {
@@ -1819,6 +1826,18 @@
   background: #fff1ef;
   color: #a33228;
   font-size: 0.68rem;
+  font-weight: 700;
+  line-height: 1.5;
+}
+
+.errorCard .accessNotice {
+  margin-top: 16px;
+  padding: 12px 14px;
+  border: 1px solid #b9ded2;
+  border-radius: 12px;
+  background: #edf9f5;
+  color: #087a5d;
+  font-size: 0.7rem;
   font-weight: 700;
   line-height: 1.5;
 }
@@ -2257,7 +2276,15 @@
   }
 
   .errorActions {
-    flex-direction: column;
+    grid-template-columns: 1fr;
+  }
+
+  .errorActions .homeButton {
+    grid-column: auto;
+  }
+
+  .errorActions .googleSignInButton {
+    grid-column: auto;
   }
 }
 


### PR DESCRIPTION
## Summary

Cleans the customer-facing invoice access screen and removes the technical account-mismatch message.

## Changes

- Uses clear customer language: “Open your invoice” and “One quick verification.”
- Replaces the raw backend mismatch response with a privacy-focused mobile verification explanation.
- Makes purchase-mobile verification the primary recovery action.
- Keeps Google retry and Back to Aquakart actions clear and correctly aligned on desktop and mobile.
- Avoids exposing internal authorization details to customers.

## Validation

- `npm test`: 21 test files and 74 tests passed.
- `npm run build`: Next.js production build passed.
- Prettier check/write completed for the changed files.