### PR TITLE
fix: make customer invoice access fast and recoverable

### DIFF
--- a/src/components/invoice/InvoiceShareDialog.jsx
+++ b/src/components/invoice/InvoiceShareDialog.jsx
@@ -246,7 +246,7 @@ const InvoiceShareDialog = ({
                         className={styles.viewLink}
                         href={`/invoice/${invoice.id}`}
                       >
-                        View or download invoice <ExternalLink />
+                        Open invoice <ExternalLink />
                       </Link>
                     ) : null}
                   </>

--- a/src/context/AuthContext.js
+++ b/src/context/AuthContext.js
@@ -18,6 +18,15 @@ import {
 } from "@/services/googleAuth";
 
 const AuthContext = createContext(null);
+const AUTH_RESTORE_TIMEOUT_MS = 4_000;
+
+const restoreGoogleLogin = () =>
+  Promise.race([
+    completeGoogleRedirectLogin(),
+    new Promise((resolve) =>
+      setTimeout(() => resolve(null), AUTH_RESTORE_TIMEOUT_MS),
+    ),
+  ]);
 
 const safeReturnPath = (value) =>
   typeof value === "string" && value.startsWith("/") && !value.startsWith("//")
@@ -59,7 +68,7 @@ export const AuthProvider = ({ children }) => {
     if (redirectChecked.current) return undefined;
     redirectChecked.current = true;
     let active = true;
-    completeGoogleRedirectLogin()
+    restoreGoogleLogin()
       .then((result) => {
         if (!active || !result) return null;
         return applyLoginResult(result);

--- a/src/pages/find-invoice.js
+++ b/src/pages/find-invoice.js
@@ -37,6 +37,7 @@ import InvoiceServiceOperations, {
 import styles from "@/styles/find-invoice.module.css";
 
 const LOOKUP_STORAGE_KEY = "aquakart_invoice_lookup_phone";
+const AUTH_UI_TIMEOUT_MS = 8_000;
 
 const money = (value) =>
   new Intl.NumberFormat("en-IN", {
@@ -107,6 +108,17 @@ const FindInvoicePage = () => {
       dispatch({ type: "AUTH_REQUIRED" });
     }
   }, [authLoading, authReady, authenticated, flow.phase, session?.user]);
+
+  useEffect(() => {
+    if (flow.phase !== INVOICE_FLOW_PHASE.AUTHENTICATING) return undefined;
+    const timeout = window.setTimeout(() => {
+      dispatch({
+        type: "AUTH_REQUIRED",
+        error: "Google verification took too long. Please try again.",
+      });
+    }, AUTH_UI_TIMEOUT_MS);
+    return () => window.clearTimeout(timeout);
+  }, [flow.phase]);
 
   const updatePhone = (value) => {
     const phone = normalizeInvoicePhone(value);
@@ -359,14 +371,11 @@ const FindInvoicePage = () => {
               <span className={styles.iconBox}>
                 <ReceiptText size={27} />
               </span>
-              <span className={styles.eyebrow}>
-                Protected invoice discovery
-              </span>
-              <h1>Find, confirm and share your invoice.</h1>
+              <span className={styles.eyebrow}>Aquakart invoices</span>
+              <h1>Find your invoice.</h1>
               <p>
-                Google verifies who you are. Aquakart then checks invoice
-                ownership before showing, updating or emailing any purchase
-                record.
+                Sign in with Google, enter the mobile number used for your
+                purchase, and open your invoice securely.
               </p>
               <div className={styles.trustGrid}>
                 <span>
@@ -385,8 +394,8 @@ const FindInvoicePage = () => {
               {isAuthenticating ? (
                 <div className={styles.centerState}>
                   <Loader2 className={styles.spinner} />
-                  <h2>Verifying with Google…</h2>
-                  <p>Your entered invoice-search details will be preserved.</p>
+                  <h2>Checking your account…</h2>
+                  <p>This should take only a moment.</p>
                 </div>
               ) : null}
 

--- a/src/pages/invoice/[id].js
+++ b/src/pages/invoice/[id].js
@@ -7,7 +7,8 @@ import {
   getInvoiceAccessToken,
 } from "@/utils/server/invoiceAccess";
 
-const FETCH_TIMEOUT_MS = 10_000;
+const FETCH_TIMEOUT_MS = 6_000;
+const CATALOGUE_GRACE_MS = 750;
 
 const normalizeRouteId = (value) => {
   const id = Array.isArray(value) ? value[0] : value;
@@ -18,19 +19,23 @@ const normalizeRouteId = (value) => {
   return normalized;
 };
 
-const fetchProductCatalogue = async (apiBase, signal) => {
+const fetchProductCatalogue = async (apiBase) => {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), CATALOGUE_GRACE_MS);
   try {
     const response = await fetch(
       `${apiBase.replace(/\/$/, "")}/all-products?query=ecom`,
       {
         headers: { Accept: "application/json" },
-        signal,
+        signal: controller.signal,
       },
     );
 
     return response.ok ? await response.json() : [];
   } catch {
     return [];
+  } finally {
+    clearTimeout(timeout);
   }
 };
 
@@ -58,10 +63,7 @@ export const getServerSideProps = async ({ params, req, res }) => {
 
   try {
     const catalogueApiBase = process.env.NEXT_PUBLIC_API_URL || apiBase;
-    const cataloguePromise = fetchProductCatalogue(
-      catalogueApiBase,
-      controller.signal,
-    );
+    const cataloguePromise = fetchProductCatalogue(catalogueApiBase);
     const response = await backendInvoiceRequest(`/${encodeURIComponent(id)}`, {
       headers: { Authorization: `Bearer ${accessToken}` },
       signal: controller.signal,

--- a/src/services/googleAuth.js
+++ b/src/services/googleAuth.js
@@ -7,6 +7,8 @@ import {
 import { getFirebaseAuth, getGoogleProvider } from "@/lib/firebase/client";
 
 const API_URL = (process.env.NEXT_PUBLIC_API_URL || "").replace(/\/+$/, "");
+const AUTH_REQUEST_TIMEOUT_MS = 6_000;
+const FIREBASE_OPERATION_TIMEOUT_MS = 5_000;
 const authUrl = (path) =>
   `${API_URL.endsWith("/v1") ? API_URL : `${API_URL}/v1`}${path}`;
 
@@ -20,17 +22,49 @@ const parseResponse = async (response) => {
   return data;
 };
 
+const withTimeout = (promise, timeoutMs, message) =>
+  new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => reject(new Error(message)), timeoutMs);
+    Promise.resolve(promise).then(
+      (value) => {
+        clearTimeout(timeout);
+        resolve(value);
+      },
+      (error) => {
+        clearTimeout(timeout);
+        reject(error);
+      },
+    );
+  });
+
 const exchangeGoogleCredential = async (credential) => {
   const firebaseAuth = getFirebaseAuth();
-  const firebaseIdToken = await credential.user.getIdToken();
+  const firebaseIdToken = await withTimeout(
+    credential.user.getIdToken(),
+    FIREBASE_OPERATION_TIMEOUT_MS,
+    "Google verification took too long. Please try again.",
+  );
 
-  const response = await fetch(authUrl("/auth/google"), {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${firebaseIdToken}`,
-      "Content-Type": "application/json",
-    },
-  });
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), AUTH_REQUEST_TIMEOUT_MS);
+  let response;
+  try {
+    response = await fetch(authUrl("/auth/google"), {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${firebaseIdToken}`,
+        "Content-Type": "application/json",
+      },
+      signal: controller.signal,
+    });
+  } catch (error) {
+    if (error?.name === "AbortError") {
+      throw new Error("Google sign-in took too long. Please try again.");
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+  }
 
   try {
     return await parseResponse(response);
@@ -70,12 +104,20 @@ export const logoutGoogleUser = async () => {
 
 export const getCurrentFirebaseIdToken = async () => {
   const firebaseAuth = getFirebaseAuth();
-  await firebaseAuth.authStateReady?.();
+  await withTimeout(
+    firebaseAuth.authStateReady?.(),
+    FIREBASE_OPERATION_TIMEOUT_MS,
+    "Google verification took too long. Please try again.",
+  );
   const currentUser = firebaseAuth.currentUser;
   if (!currentUser) {
     throw new Error("Please continue with Google first");
   }
-  return currentUser.getIdToken(true);
+  return withTimeout(
+    currentUser.getIdToken(true),
+    FIREBASE_OPERATION_TIMEOUT_MS,
+    "Google verification took too long. Please try again.",
+  );
 };
 
 export const getCurrentUser = async (token) => {

--- a/src/services/invoice.js
+++ b/src/services/invoice.js
@@ -1,5 +1,10 @@
 import axios from "axios";
 
+export const INVOICE_REQUEST_TIMEOUT_MS = 6_000;
+
+const invoiceRequest = (config) =>
+  axios({ timeout: INVOICE_REQUEST_TIMEOUT_MS, ...config });
+
 export const normalizeInvoicePhone = (value = "") => {
   const digits = String(value).replace(/\D/g, "");
   return digits.length === 12 && digits.startsWith("91")
@@ -28,23 +33,29 @@ const assertPhone = (phone) => {
 };
 
 const lookupInvoices = async (phone, firebaseIdToken, backendSessionToken) => {
-  const response = await axios.post("/invoice-gateway/lookup", {
-    phone: assertPhone(phone),
-    firebaseIdToken,
-    backendSessionToken,
+  const response = await invoiceRequest({
+    method: "post",
+    url: "/invoice-gateway/lookup",
+    data: { phone: assertPhone(phone), firebaseIdToken, backendSessionToken },
   });
   return response.data;
 };
 
 const requestInvoiceAccess = async (phone) => {
-  const response = await axios.post("/invoice-gateway/request", {
-    phone: assertPhone(phone),
+  const response = await invoiceRequest({
+    method: "post",
+    url: "/invoice-gateway/request",
+    data: { phone: assertPhone(phone) },
   });
   return response.data;
 };
 
 const exchangeInvoiceToken = async (token) => {
-  const response = await axios.post("/invoice-gateway/exchange", { token });
+  const response = await invoiceRequest({
+    method: "post",
+    url: "/invoice-gateway/exchange",
+    data: { token },
+  });
   return response.data;
 };
 
@@ -57,9 +68,10 @@ const loginDirectInvoiceAccess = async (
   backendSessionToken,
 ) => {
   if (!invoiceId) throw new Error("Invoice ID is required.");
-  const response = await axios.post(directInvoiceLoginPath(invoiceId), {
-    firebaseIdToken,
-    backendSessionToken,
+  const response = await invoiceRequest({
+    method: "post",
+    url: directInvoiceLoginPath(invoiceId),
+    data: { firebaseIdToken, backendSessionToken },
   });
   return response.data;
 };
@@ -69,10 +81,10 @@ const loginInvoiceAccess = async (
   firebaseIdToken,
   backendSessionToken,
 ) => {
-  const response = await axios.post("/invoice-gateway/login", {
-    phone: assertPhone(phone),
-    firebaseIdToken,
-    backendSessionToken,
+  const response = await invoiceRequest({
+    method: "post",
+    url: "/invoice-gateway/login",
+    data: { phone: assertPhone(phone), firebaseIdToken, backendSessionToken },
   });
   return response.data;
 };

--- a/src/styles/find-invoice.module.css
+++ b/src/styles/find-invoice.module.css
@@ -21,7 +21,7 @@
 }
 
 .shell {
-  width: min(100% - 32px, 1200px);
+  width: min(100% - 32px, 760px);
   margin: 0 auto;
   padding: 28px 0 90px;
 }
@@ -38,9 +38,9 @@
 
 .lookupCard {
   display: grid;
-  min-height: 650px;
+  min-height: 0;
   overflow: hidden;
-  grid-template-columns: minmax(0, 0.9fr) minmax(0, 1.1fr);
+  grid-template-columns: 1fr;
   border: 1px solid rgba(255, 255, 255, 0.86);
   border-radius: 34px;
   background: rgba(255, 255, 255, 0.68);
@@ -55,8 +55,8 @@
   align-items: flex-start;
   justify-content: center;
   flex-direction: column;
-  padding: clamp(42px, 6vw, 72px);
-  border-right: 1px solid rgba(190, 216, 210, 0.62);
+  padding: clamp(28px, 5vw, 44px);
+  border-bottom: 1px solid rgba(190, 216, 210, 0.62);
   background:
     radial-gradient(
       circle at 10% 96%,
@@ -76,7 +76,7 @@
   width: 60px;
   height: 60px;
   place-items: center;
-  margin-bottom: 25px;
+  margin-bottom: 16px;
   border: 1px solid rgba(255, 255, 255, 0.9);
   border-radius: 19px;
   background: rgba(255, 255, 255, 0.76);
@@ -95,25 +95,26 @@
 .intro h1 {
   max-width: 500px;
   margin: 13px 0 0;
-  font-size: clamp(40px, 4.5vw, 64px);
+  font-size: clamp(34px, 7vw, 50px);
   letter-spacing: -0.058em;
   line-height: 0.98;
 }
 
 .intro > p {
   max-width: 510px;
-  margin: 22px 0 0;
+  margin: 14px 0 0;
   color: var(--muted);
   font-size: 13px;
   line-height: 1.75;
 }
 
 .trustGrid {
-  display: grid;
+  display: flex;
+  flex-wrap: wrap;
   width: 100%;
   gap: 10px;
-  margin-top: 34px;
-  padding-top: 24px;
+  margin-top: 22px;
+  padding-top: 18px;
   border-top: 1px solid rgba(177, 207, 199, 0.76);
 }
 
@@ -136,7 +137,8 @@
   min-width: 0;
   align-items: center;
   justify-content: center;
-  padding: clamp(32px, 5vw, 64px);
+  min-height: 310px;
+  padding: clamp(28px, 5vw, 44px);
 }
 
 .phoneForm,
@@ -537,7 +539,7 @@
   }
 
   .interaction {
-    min-height: 410px;
+    min-height: 300px;
   }
 
   .resultActions,

--- a/src/styles/invoice-share-dialog.module.css
+++ b/src/styles/invoice-share-dialog.module.css
@@ -290,8 +290,13 @@
 }
 
 .viewLink {
+  width: 100%;
+  min-height: 52px;
   margin-top: 12px;
-  color: #0b725a;
+  border: 1px solid #087a5d;
+  background: #087a5d;
+  color: #fff;
+  box-shadow: 0 12px 24px rgba(8, 122, 93, 0.18);
 }
 
 .error,


### PR DESCRIPTION
## Summary

Removes indefinite invoice-loading states and replaces the oversized Find Invoice split screen with a compact, focused customer flow.

## Root causes

- Firebase redirect/session restoration had no deadline and could leave the page on “Verifying with Google” indefinitely.
- Firebase token and invoice access calls had no client timeout.
- `/invoice/:id` waited up to 10 seconds for optional full-catalogue enrichment before rendering the invoice.

## Changes

- Caps Google redirect restoration at 4 seconds.
- Caps Firebase token operations at 5 seconds and auth exchange/invoice requests at 6 seconds.
- Adds an 8-second UI watchdog with a clear retry message.
- Reduces the `/invoice/:id` primary timeout to 6 seconds.
- Gives optional product catalogue enrichment only 750 ms; the invoice remains usable without it.
- Rebuilds Find Invoice as a compact single-card experience with shorter customer copy.
- Preserves the entered purchase mobile number across retries.

## Validation

- `npm test`: 21 test files, 74 tests passed.
- `npm run build`: Next.js production build passed.
- Changed files formatted and `git diff --check` passed.