### PR TITLE
Simplify direct customer invoice access

### DIFF
--- a/src/context/AuthContext.js
+++ b/src/context/AuthContext.js
@@ -15,14 +15,17 @@ import {
   loginWithGoogle,
   logoutBackendUser,
   logoutGoogleUser,
+  restoreExistingGoogleLogin,
 } from "@/services/googleAuth";
 
 const AuthContext = createContext(null);
-const AUTH_RESTORE_TIMEOUT_MS = 4_000;
+const AUTH_RESTORE_TIMEOUT_MS = 12_000;
 
 const restoreGoogleLogin = () =>
   Promise.race([
-    completeGoogleRedirectLogin(),
+    completeGoogleRedirectLogin().then(
+      (redirectResult) => redirectResult || restoreExistingGoogleLogin(),
+    ),
     new Promise((resolve) =>
       setTimeout(() => resolve(null), AUTH_RESTORE_TIMEOUT_MS),
     ),
@@ -42,7 +45,7 @@ export const AuthProvider = ({ children }) => {
   const redirectChecked = useRef(false);
 
   const applyLoginResult = useCallback(
-    async (result, requestedReturnPath) => {
+    async (result, requestedReturnPath, showSuccess = true) => {
       if (!result || result.redirecting) return result;
       dispatch({ type: "LOGGED_IN_USER", payload: result });
       dispatch({ type: "SET_AUTH_DIALOG_VISIBLE", payload: false });
@@ -54,7 +57,7 @@ export const AuthProvider = ({ children }) => {
         requestedReturnPath || storedReturnPath || router.asPath,
       );
       window.sessionStorage.removeItem("aquakart_auth_return_to");
-      toast.success(result.message);
+      if (showSuccess) toast.success(result.message);
 
       if (returnPath !== router.asPath) {
         await router.replace(returnPath);
@@ -71,7 +74,7 @@ export const AuthProvider = ({ children }) => {
     restoreGoogleLogin()
       .then((result) => {
         if (!active || !result) return null;
-        return applyLoginResult(result);
+        return applyLoginResult(result, undefined, false);
       })
       .catch((error) => {
         if (active) {

--- a/src/pageComponents/invoice/InvoicePage.js
+++ b/src/pageComponents/invoice/InvoicePage.js
@@ -104,7 +104,6 @@ const InvoiceError = ({ statusCode }) => {
   const [signingIn, setSigningIn] = useState(false);
   const [openingInvoice, setOpeningInvoice] = useState(false);
   const [accessError, setAccessError] = useState("");
-  const [verificationRequired, setVerificationRequired] = useState(false);
   const attemptedDirectAccess = useRef(false);
   const directAccessInFlight = useRef(false);
   const notFound = statusCode === 404;
@@ -112,15 +111,10 @@ const InvoiceError = ({ statusCode }) => {
   const routeId = Array.isArray(router.query.id)
     ? router.query.id[0]
     : router.query.id;
-  const findInvoiceHref = routeId
-    ? `/page/find-invoice?invoiceId=${encodeURIComponent(routeId)}`
-    : "/page/find-invoice";
   const authBusy = authLoading || signingIn || openingInvoice;
-  const clientAccessMessage = verificationRequired
-    ? "For your privacy, confirm the mobile number used for this purchase."
-    : accessError
-      ? "We could not open the invoice just now. Please try again."
-      : "";
+  const clientAccessMessage = accessError
+    ? "We could not open the invoice just now. Please try again."
+    : "";
 
   const requestDirectAccess = useCallback(
     async (backendSessionToken) => {
@@ -132,7 +126,6 @@ const InvoiceError = ({ statusCode }) => {
       directAccessInFlight.current = true;
       setOpeningInvoice(true);
       setAccessError("");
-      setVerificationRequired(false);
 
       try {
         const firebaseIdToken = await getCurrentFirebaseIdToken();
@@ -142,15 +135,14 @@ const InvoiceError = ({ statusCode }) => {
           backendSessionToken,
         );
         window.location.replace(router.asPath);
+        return true;
       } catch (error) {
-        setVerificationRequired(
-          Boolean(error?.response?.data?.verificationRequired),
-        );
         setAccessError(
           error?.response?.data?.message ||
             error?.message ||
             "We could not verify access to this invoice.",
         );
+        return false;
       } finally {
         directAccessInFlight.current = false;
         setOpeningInvoice(false);
@@ -184,8 +176,8 @@ const InvoiceError = ({ statusCode }) => {
 
     if (authenticated && session?.token) {
       attemptedDirectAccess.current = false;
-      await requestDirectAccess(session.token);
-      return;
+      const opened = await requestDirectAccess(session.token);
+      if (opened) return;
     }
 
     setSigningIn(true);
@@ -231,45 +223,29 @@ const InvoiceError = ({ statusCode }) => {
         <span className={styles.eyebrow}>Aquakart invoices</span>
         <h1>
           {unauthorized
-            ? verificationRequired
-              ? "One quick verification."
-              : "Open your invoice."
+            ? "Open your invoice."
             : notFound
               ? "We could not find that invoice."
               : "The invoice is taking a pause."}
         </h1>
         <p>
           {unauthorized
-            ? verificationRequired
-              ? "Your invoice is protected. Verify the purchase mobile number to continue."
-              : authenticated
-                ? "You are signed in. We are securely matching this invoice to your account."
-                : "Sign in with Google to securely view and download your invoice."
+            ? authenticated
+              ? "You are signed in. We are securely opening this invoice with your verified email."
+              : "Continue with Google once to securely view and download your invoice."
             : notFound
               ? "Check the invoice link and try again. The ID may be incomplete or no longer available."
               : "We could not reach the invoice service. Please wait a moment and try again."}
         </p>
         {clientAccessMessage ? (
           <p
-            className={
-              verificationRequired ? styles.accessNotice : styles.accessError
-            }
-            role={verificationRequired ? "status" : "alert"}
+            className={styles.accessError}
+            role="alert"
           >
             {clientAccessMessage}
           </p>
         ) : null}
-        <div
-          className={`${styles.errorActions} ${verificationRequired ? styles.verificationActions : ""}`}
-        >
-          {verificationRequired ? (
-            <Link
-              href={findInvoiceHref}
-              className={styles.phoneVerificationLink}
-            >
-              Verify purchase mobile
-            </Link>
-          ) : null}
+        <div className={styles.errorActions}>
           {unauthorized ? (
             <button
               type="button"
@@ -278,7 +254,7 @@ const InvoiceError = ({ statusCode }) => {
               disabled={authBusy}
             >
               <GoogleMark />
-              {verificationRequired ? "Try Google again" : primaryActionLabel}
+              {primaryActionLabel}
             </button>
           ) : (
             <button type="button" onClick={() => window.location.reload()}>

--- a/src/services/googleAuth.js
+++ b/src/services/googleAuth.js
@@ -37,10 +37,10 @@ const withTimeout = (promise, timeoutMs, message) =>
     );
   });
 
-const exchangeGoogleCredential = async (credential) => {
+const exchangeGoogleUser = async (user) => {
   const firebaseAuth = getFirebaseAuth();
   const firebaseIdToken = await withTimeout(
-    credential.user.getIdToken(),
+    user.getIdToken(),
     FIREBASE_OPERATION_TIMEOUT_MS,
     "Google verification took too long. Please try again.",
   );
@@ -85,7 +85,7 @@ export const loginWithGoogle = async () => {
   const firebaseAuth = getFirebaseAuth();
   try {
     const credential = await signInWithPopup(firebaseAuth, getGoogleProvider());
-    return exchangeGoogleCredential(credential);
+    return exchangeGoogleUser(credential.user);
   } catch (error) {
     if (!shouldUseRedirectFallback(error)) throw error;
     await signInWithRedirect(firebaseAuth, getGoogleProvider());
@@ -95,7 +95,19 @@ export const loginWithGoogle = async () => {
 
 export const completeGoogleRedirectLogin = async () => {
   const credential = await getRedirectResult(getFirebaseAuth());
-  return credential ? exchangeGoogleCredential(credential) : null;
+  return credential ? exchangeGoogleUser(credential.user) : null;
+};
+
+export const restoreExistingGoogleLogin = async () => {
+  const firebaseAuth = getFirebaseAuth();
+  await withTimeout(
+    firebaseAuth.authStateReady?.(),
+    FIREBASE_OPERATION_TIMEOUT_MS,
+    "Google session check took too long.",
+  );
+  return firebaseAuth.currentUser
+    ? exchangeGoogleUser(firebaseAuth.currentUser)
+    : null;
 };
 
 export const logoutGoogleUser = async () => {


### PR DESCRIPTION
## What changed

- Silently restores an existing Firebase Google session and refreshes the Aquakart backend session.
- Preserves `/invoice/{id}` throughout authentication.
- Automatically retries direct invoice access for signed-in customers.
- Falls back to the single existing `Continue with Google` action when a session cannot be restored.
- Removes the purchase-phone verification detour from the direct invoice page.
- Reloads directly into the existing invoice view after access is issued.
- Suppresses welcome toasts during silent session restoration.

## User impact

Customers opening a direct invoice link either see their invoice automatically when already signed in, or complete one Google sign-in and immediately see the invoice. The existing invoice UI is unchanged.

## Coordination

Requires the matching backend PR from `SVSKHD/AQUAKARTBACKEND` so the verified Google email is applied automatically during direct access.

## Validation

- Directly relevant frontend tests: 11/11 passed.
- Complete suite reached 63 passing tests; four unrelated UI suites could not load because the repository has no lockfile and the temporary dependency installation left `next`/`heroicons` incomplete.
- `git diff --check`: passed.