### PR TITLE
Fix direct invoice login request

### DIFF
--- a/src/pageComponents/invoice/InvoicePage.js
+++ b/src/pageComponents/invoice/InvoicePage.js
@@ -117,8 +117,8 @@ const InvoiceError = ({ statusCode }) => {
     : "";
 
   const requestDirectAccess = useCallback(
-    async (backendSessionToken) => {
-      if (!routeId || !backendSessionToken || directAccessInFlight.current) {
+    async () => {
+      if (!routeId || directAccessInFlight.current) {
         return;
       }
 
@@ -132,7 +132,6 @@ const InvoiceError = ({ statusCode }) => {
         await InvoiceServiceOperations.loginDirectInvoiceAccess(
           routeId,
           firebaseIdToken,
-          backendSessionToken,
         );
         window.location.replace(router.asPath);
         return true;
@@ -160,7 +159,7 @@ const InvoiceError = ({ statusCode }) => {
       !authLoading &&
       !attemptedDirectAccess.current
     ) {
-      void requestDirectAccess(session.token);
+      void requestDirectAccess();
     }
   }, [
     authLoading,
@@ -176,7 +175,7 @@ const InvoiceError = ({ statusCode }) => {
 
     if (authenticated && session?.token) {
       attemptedDirectAccess.current = false;
-      const opened = await requestDirectAccess(session.token);
+      const opened = await requestDirectAccess();
       if (opened) return;
     }
 
@@ -185,7 +184,7 @@ const InvoiceError = ({ statusCode }) => {
     try {
       const result = await signInWithGoogle();
       if (!result?.redirecting) {
-        await requestDirectAccess(result?.token || session?.token);
+        await requestDirectAccess();
       }
     } catch {
       // AuthContext shows the user-facing authentication error.

--- a/src/pages/api/invoice-access/[id]/login.js
+++ b/src/pages/api/invoice-access/[id]/login.js
@@ -27,13 +27,12 @@ export default async function handler(req, res) {
 
   const invoiceId = normalizeInvoiceId(req.query.id);
   const firebaseIdToken = String(req.body?.firebaseIdToken || "");
-  const backendSessionToken = String(req.body?.backendSessionToken || "");
   if (!invoiceId) {
     return res
       .status(404)
       .json({ success: false, message: "Invoice not found" });
   }
-  if (!firebaseIdToken || !backendSessionToken) {
+  if (!firebaseIdToken) {
     return res
       .status(401)
       .json({ success: false, message: "Google login is required" });
@@ -46,7 +45,6 @@ export default async function handler(req, res) {
         method: "POST",
         headers: {
           Authorization: `Bearer ${firebaseIdToken}`,
-          "X-Aquakart-Session": backendSessionToken,
         },
       },
     );

--- a/src/services/invoice.js
+++ b/src/services/invoice.js
@@ -62,16 +62,12 @@ const exchangeInvoiceToken = async (token) => {
 export const directInvoiceLoginPath = (invoiceId) =>
   `/invoice-gateway/${encodeURIComponent(String(invoiceId || ""))}/login`;
 
-const loginDirectInvoiceAccess = async (
-  invoiceId,
-  firebaseIdToken,
-  backendSessionToken,
-) => {
+const loginDirectInvoiceAccess = async (invoiceId, firebaseIdToken) => {
   if (!invoiceId) throw new Error("Invoice ID is required.");
   const response = await invoiceRequest({
     method: "post",
     url: directInvoiceLoginPath(invoiceId),
-    data: { firebaseIdToken, backendSessionToken },
+    data: { firebaseIdToken },
   });
   return response.data;
 };


### PR DESCRIPTION
## Root cause

The direct-invoice BFF and client service still required and forwarded the general Aquakart backend session token, even though the direct route already has a verified Firebase Google token. This contributed a redundant authorization step to the observed `403` flow.

## What changed

- Direct invoice BFF requires only the Firebase ID token.
- Stops forwarding `X-Aquakart-Session` for direct invoice login.
- Simplifies the direct invoice service payload to `{ firebaseIdToken }`.
- Keeps the existing automatic reload into `/invoice/{id}` after the access cookie is created.
- No invoice UI/layout changes.

## Coordination

Merge and deploy backend PR #23 first, then this frontend PR.

## Validation

- Focused frontend tests: 9/9 passed.
- `git diff --check` passed.