### PR TITLE
Load public invoices fresh on the client

### DIFF
--- a/src/pages/api/invoice-access/[id]/index.js
+++ b/src/pages/api/invoice-access/[id]/index.js
@@ -5,6 +5,12 @@ import {
 } from "@/utils/server/invoiceAccess";
 
 export default async function handler(req, res) {
+  res.setHeader(
+    "Cache-Control",
+    "private, no-store, no-cache, max-age=0, must-revalidate",
+  );
+  res.setHeader("X-Robots-Tag", "noindex, nofollow, noarchive");
+
   if (req.method !== "GET") {
     res.setHeader("Allow", "GET");
     return res

--- a/src/pages/fetch-invoice.js
+++ b/src/pages/fetch-invoice.js
@@ -1,0 +1,3 @@
+import FindInvoicePage from "./find-invoice";
+
+export default FindInvoicePage;

--- a/src/pages/find-invoice.js
+++ b/src/pages/find-invoice.js
@@ -581,8 +581,4 @@ const FindInvoicePage = () => {
   );
 };
 
-export const getServerSideProps = async () => ({
-  redirect: { destination: "/page/find-invoice", permanent: false },
-});
-
 export default FindInvoicePage;

--- a/src/pages/invoice/[id].js
+++ b/src/pages/invoice/[id].js
@@ -1,13 +1,11 @@
+import { useRouter } from "next/router";
+import { useEffect, useState } from "react";
+
 import InvoicePage from "@/pageComponents/invoice/InvoicePage";
+import InvoiceServiceOperations from "@/services/invoice";
 import { enrichInvoiceProducts } from "@/utils/invoice/matchInvoiceProducts";
 import { mapInvoiceFromApi } from "@/utils/invoice/normalizeInvoice";
-import {
-  backendInvoiceRequest,
-  getInvoiceApiBase,
-  getInvoiceAccessToken,
-} from "@/utils/server/invoiceAccess";
 
-const FETCH_TIMEOUT_MS = 6_000;
 const CATALOGUE_GRACE_MS = 750;
 
 const normalizeRouteId = (value) => {
@@ -19,81 +17,86 @@ const normalizeRouteId = (value) => {
   return normalized;
 };
 
-const fetchProductCatalogue = async (apiBase) => {
+const fetchProductCatalogue = async (signal) => {
   const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), CATALOGUE_GRACE_MS);
-  try {
-    const response = await fetch(
-      `${apiBase.replace(/\/$/, "")}/all-products?query=ecom`,
-      {
-        headers: { Accept: "application/json" },
-        signal: controller.signal,
-      },
-    );
+  const timeout = window.setTimeout(
+    () => controller.abort(),
+    CATALOGUE_GRACE_MS,
+  );
+  const abort = () => controller.abort();
+  signal.addEventListener("abort", abort, { once: true });
 
+  try {
+    const response = await fetch("/api/all-products?query=ecom", {
+      cache: "no-store",
+      headers: { Accept: "application/json", "Cache-Control": "no-cache" },
+      signal: controller.signal,
+    });
     return response.ok ? await response.json() : [];
   } catch {
     return [];
   } finally {
-    clearTimeout(timeout);
+    window.clearTimeout(timeout);
+    signal.removeEventListener("abort", abort);
   }
 };
 
-export const getServerSideProps = async ({ params, req, res }) => {
-  res.setHeader(
-    "Cache-Control",
-    "private, no-store, no-cache, max-age=0, must-revalidate",
-  );
-  res.setHeader("X-Robots-Tag", "noindex, nofollow, noarchive");
+const PublicInvoiceRoute = () => {
+  const router = useRouter();
+  const [state, setState] = useState({
+    invoice: null,
+    statusCode: 0,
+    loading: true,
+  });
 
-  const id = normalizeRouteId(params?.id);
-  if (!id) {
-    return { props: { invoice: null, statusCode: 404 } };
-  }
+  useEffect(() => {
+    if (!router.isReady) return undefined;
 
-  const accessToken = getInvoiceAccessToken(req);
-  if (!accessToken) {
-    return { props: { invoice: null, statusCode: 401 } };
-  }
-
-  const apiBase = getInvoiceApiBase();
-
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
-
-  try {
-    const catalogueApiBase = process.env.NEXT_PUBLIC_API_URL || apiBase;
-    const cataloguePromise = fetchProductCatalogue(catalogueApiBase);
-    const response = await backendInvoiceRequest(`/${encodeURIComponent(id)}`, {
-      headers: { Authorization: `Bearer ${accessToken}` },
-      signal: controller.signal,
-    });
-
-    if ([401, 403, 404].includes(response.status)) {
-      return { props: { invoice: null, statusCode: response.status } };
+    const id = normalizeRouteId(router.query.id);
+    if (!id) {
+      setState({ invoice: null, statusCode: 404, loading: false });
+      return undefined;
     }
 
-    if (!response.ok) {
-      return { props: { invoice: null, statusCode: 502 } };
-    }
+    const controller = new AbortController();
+    setState((current) => ({ ...current, loading: true }));
 
-    const payload = await response.json();
-    const cataloguePayload = await cataloguePromise;
-    const invoice = enrichInvoiceProducts(
-      mapInvoiceFromApi(payload),
-      cataloguePayload,
-    );
+    const loadInvoice = async () => {
+      try {
+        const cataloguePromise = fetchProductCatalogue(controller.signal);
+        const payload = await InvoiceServiceOperations.getInvoiceById(
+          id,
+          controller.signal,
+        );
+        const invoice = enrichInvoiceProducts(
+          mapInvoiceFromApi(payload),
+          await cataloguePromise,
+        );
 
-    if (!invoice) {
-      return { props: { invoice: null, statusCode: 502 } };
-    }
+        if (!controller.signal.aborted) {
+          setState({
+            invoice,
+            statusCode: invoice ? 200 : 502,
+            loading: false,
+          });
+        }
+      } catch (error) {
+        if (!controller.signal.aborted) {
+          setState({
+            invoice: null,
+            statusCode: error?.response?.status || 502,
+            loading: false,
+          });
+        }
+      }
+    };
 
-    return { props: { invoice, statusCode: 200 } };
-  } catch {
-    return { props: { invoice: null, statusCode: 502 } };
-  } finally {
-    clearTimeout(timeout);
-  }
+    void loadInvoice();
+    return () => controller.abort();
+  }, [router.isReady, router.query.id]);
+
+  if (state.loading) return null;
+  return <InvoicePage invoice={state.invoice} statusCode={state.statusCode} />;
 };
 
-export default InvoicePage;
+export default PublicInvoiceRoute;

--- a/src/services/invoice.js
+++ b/src/services/invoice.js
@@ -62,6 +62,21 @@ const exchangeInvoiceToken = async (token) => {
 export const directInvoiceLoginPath = (invoiceId) =>
   `/invoice-gateway/${encodeURIComponent(String(invoiceId || ""))}/login`;
 
+export const invoiceByIdPath = (invoiceId) =>
+  `/invoice-gateway/${encodeURIComponent(String(invoiceId || ""))}`;
+
+const getInvoiceById = async (invoiceId, signal) => {
+  if (!invoiceId) throw new Error("Invoice ID is required.");
+  const response = await invoiceRequest({
+    method: "get",
+    url: invoiceByIdPath(invoiceId),
+    params: { refresh: Date.now() },
+    headers: { "Cache-Control": "no-cache", Pragma: "no-cache" },
+    signal,
+  });
+  return response.data;
+};
+
 const loginDirectInvoiceAccess = async (invoiceId, firebaseIdToken) => {
   if (!invoiceId) throw new Error("Invoice ID is required.");
   const response = await invoiceRequest({
@@ -144,6 +159,7 @@ const InvoiceServiceOperations = {
   exchangeInvoiceToken,
   loginInvoiceAccess,
   loginDirectInvoiceAccess,
+  getInvoiceById,
   getAccessibleInvoices,
   emailInvoice,
   claimInvoice,

--- a/src/services/invoice.test.js
+++ b/src/services/invoice.test.js
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   directInvoiceLoginPath,
+  invoiceByIdPath,
   isValidInvoiceEmail,
   normalizeInvoiceEmail,
   normalizeInvoicePhone,
@@ -33,11 +34,18 @@ describe("invoice delivery email", () => {
   });
 });
 
-
 describe("direct invoice Google login", () => {
   it("builds an invoice-scoped BFF path safely", () => {
     expect(directInvoiceLoginPath("invoice/with spaces")).toBe(
       "/invoice-gateway/invoice%2Fwith%20spaces/login",
+    );
+  });
+});
+
+describe("fresh invoice loading", () => {
+  it("builds an invoice-scoped client fetch path safely", () => {
+    expect(invoiceByIdPath("invoice/with spaces")).toBe(
+      "/invoice-gateway/invoice%2Fwith%20spaces",
     );
   });
 });


### PR DESCRIPTION
## What changed

- Removed `getServerSideProps` from `/invoice/[id]` and fetches the secured invoice in the browser on every page open or refresh.
- Adds cache-busting request parameters and explicit `no-store`/`no-cache` headers on the invoice gateway response.
- Keeps the existing invoice normalization, catalogue enrichment, Google access flow, and invoice layout unchanged.
- Removed the server redirect from `/find-invoice`.
- Added `/fetch-invoice` as a client-only alias; `/page/find-invoice` remains client-only too.

## Why

Server-rendered page props could remain stale during client navigation and made recently updated invoice data unreliable. The page now requests the current invoice after mount and after route-ID changes.

## Validation

- Focused invoice tests: 14/14 passed.
- Next.js production build passed; route output confirms `/invoice/[id]`, `/fetch-invoice`, `/find-invoice`, and `/page/find-invoice` are static/client pages.
- `git diff --check` passed.
- Focused ESLint could not run because the repository's installed ESLint stack crashes internally with `scopeManager.addGlobals is not a function` before linting files.