### PR TITLE
Streamline shop filters and product image loading

### DIFF
--- a/src/components/cards/ProductCardTwo.js
+++ b/src/components/cards/ProductCardTwo.js
@@ -9,7 +9,17 @@ import LazyImage from "../image/LazyImage";
 import { useRouter } from "next/router";
 import { getProductReviewStats } from "@/utils/reviewStats";
 
-const ReusableProductCard = ({ product, viewMode = "grid", padded = true }) => {
+const getPhotoUrl = (photo) =>
+  typeof photo === "string"
+    ? photo
+    : photo?.delivery_url || photo?.secure_url || photo?.url || "";
+
+const ReusableProductCard = ({
+  product,
+  viewMode = "grid",
+  padded = true,
+  imagePriority = false,
+}) => {
   const [fav, setAddFav] = useState(false);
   const [cart, setAddCart] = useState(false);
 
@@ -213,13 +223,20 @@ const ReusableProductCard = ({ product, viewMode = "grid", padded = true }) => {
                   }}
                   transition={{ duration: 0.5, ease: "easeInOut" }}
                 >
-                  <LazyImage
-                    src={photo?.delivery_url}
-                    alt={title}
-                    width={500}
-                    height={500}
-                    imgClassName="h-full w-full object-cover object-center"
-                  />
+                  {index === activeIndex ? (
+                    <LazyImage
+                      src={getPhotoUrl(photo)}
+                      alt={title}
+                      width={480}
+                      height={480}
+                      sizes="192px"
+                      priority={imagePriority && index === 0}
+                      quality={68}
+                      imgClassName="h-full w-full object-cover object-center"
+                    />
+                  ) : (
+                    <div className="h-full w-full bg-slate-100" />
+                  )}
                 </motion.div>
               ))}
             </div>
@@ -351,13 +368,20 @@ const ReusableProductCard = ({ product, viewMode = "grid", padded = true }) => {
                   animate={{ opacity: activeIndex === i ? 1 : 0.6 }}
                   transition={{ duration: 0.4 }}
                 >
-                  <LazyImage
-                    src={p.delivery_url}
-                    alt={title}
-                    width={900}
-                    height={900}
-                    imgClassName="h-full w-full object-cover rounded-3xl p-1"
-                  />
+                  {i === activeIndex ? (
+                    <LazyImage
+                      src={getPhotoUrl(p)}
+                      alt={title}
+                      width={720}
+                      height={720}
+                      sizes="(max-width: 639px) calc(100vw - 24px), (max-width: 1023px) 50vw, (max-width: 1535px) 33vw, 25vw"
+                      priority={imagePriority && i === 0}
+                      quality={68}
+                      imgClassName="h-full w-full object-cover rounded-3xl p-1"
+                    />
+                  ) : (
+                    <div className="h-full w-full bg-slate-100" />
+                  )}
                 </motion.div>
               ))}
             </div>
@@ -488,13 +512,20 @@ const ReusableProductCard = ({ product, viewMode = "grid", padded = true }) => {
                     }}
                     transition={{ duration: 0.5, ease: "easeInOut" }}
                   >
-                    <LazyImage
-                      src={photo?.delivery_url}
-                      alt={title}
-                      width={500}
-                      height={500}
-                      imgClassName="h-full w-full object-cover object-center rounded-3xl p-3"
-                    />
+                    {index === activeIndex ? (
+                      <LazyImage
+                        src={getPhotoUrl(photo)}
+                        alt={title}
+                        width={640}
+                        height={640}
+                        sizes="(max-width: 639px) calc(100vw - 24px), (max-width: 1023px) 50vw, 33vw"
+                        priority={imagePriority && index === 0}
+                        quality={68}
+                        imgClassName="h-full w-full object-cover object-center rounded-3xl p-3"
+                      />
+                    ) : (
+                      <div className="h-full w-full bg-slate-100" />
+                    )}
                   </motion.div>
                 ))}
               </div>

--- a/src/pageComponents/shop/index.js
+++ b/src/pageComponents/shop/index.js
@@ -1,26 +1,17 @@
 "use client";
 
 import { useDeferredValue, useMemo, useState } from "react";
-import Link from "next/link";
 import { AnimatePresence, motion } from "framer-motion";
 import {
-  ArrowRight,
   BadgeCheck,
-  BadgePercent,
   ChevronDown,
   Droplets,
   Funnel,
   Grid2X2,
-  Headphones,
   List,
-  PackageCheck,
   RotateCcw,
   Search,
-  ShieldCheck,
   SlidersHorizontal,
-  Sparkles,
-  Star,
-  WandSparkles,
   X,
 } from "lucide-react";
 import AquaLayout from "@/components/Layout/Layout";
@@ -435,397 +426,244 @@ const AquaShopPageComponent = ({
           <div className="pointer-events-none absolute right-[-12rem] top-[36rem] h-[30rem] w-[30rem] rounded-full bg-sky-200/20 blur-[120px]" />
 
           <div className="relative mx-auto max-w-[1480px]">
-            <motion.section
-              initial={{ opacity: 0, y: 18 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.55, ease: [0.22, 1, 0.36, 1] }}
-              className="relative overflow-hidden rounded-[2rem] border border-white/10 bg-slate-950 px-5 py-8 text-white shadow-[0_32px_90px_rgba(2,6,23,0.24)] sm:rounded-[2.75rem] sm:px-9 sm:py-11 lg:px-14 lg:py-14"
-            >
-              <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_80%_10%,rgba(45,212,191,0.22),transparent_30%),radial-gradient(circle_at_8%_100%,rgba(14,165,233,0.14),transparent_35%)]" />
-              <div className="pointer-events-none absolute -right-16 -top-28 h-80 w-80 rounded-full border border-white/10 shadow-[0_0_0_50px_rgba(255,255,255,0.025),0_0_0_100px_rgba(255,255,255,0.015)]" />
-
-              <div className="relative z-10 grid items-end gap-10 lg:grid-cols-[1.25fr_0.75fr]">
-                <div>
-                  <div className="inline-flex items-center gap-2 rounded-full border border-emerald-300/20 bg-emerald-400/10 px-3 py-2 text-[10px] font-black uppercase tracking-[0.16em] text-emerald-200">
-                    <Sparkles size={14} /> Curated water solutions
-                  </div>
-                  <h1 className="mt-6 max-w-4xl text-[clamp(2.45rem,7vw,6.4rem)] font-black leading-[0.87] tracking-[-0.085em]">
-                    Water,
-                    <br /> thoughtfully solved.
-                  </h1>
-                  <p className="mt-6 max-w-2xl text-sm leading-7 text-slate-300 sm:text-base">
-                    Explore reliable softeners, purifiers and filtration systems
-                    selected for Indian homes—with clear pricing and expert help
-                    before you buy.
-                  </p>
-                  <div className="mt-7 flex flex-wrap gap-3">
-                    <button
-                      type="button"
-                      onClick={() =>
-                        document
-                          .getElementById("shop-products")
-                          ?.scrollIntoView({ behavior: "smooth" })
-                      }
-                      className="inline-flex min-h-12 items-center gap-2 rounded-full bg-emerald-400 px-5 text-xs font-black text-slate-950 shadow-[0_14px_30px_rgba(16,185,129,0.25)] transition hover:-translate-y-0.5 hover:bg-emerald-300"
-                    >
-                      Shop the collection <ArrowRight size={16} />
-                    </button>
-                    <Link
-                      href="/softener-planner"
-                      className="inline-flex min-h-12 items-center gap-2 rounded-full border border-white/15 bg-white/8 px-5 text-xs font-black text-white backdrop-blur transition hover:bg-white/14"
-                    >
-                      <WandSparkles size={16} /> Find my solution
-                    </Link>
-                  </div>
-                </div>
-
-                <div className="grid grid-cols-2 gap-2.5 sm:grid-cols-3 lg:grid-cols-1">
-                  {[
-                    [BadgeCheck, `${products.length}+`, "curated products"],
-                    [
-                      ShieldCheck,
-                      `${derivedMeta.brands.length}`,
-                      "trusted brands",
-                    ],
-                    [Headphones, "Human", "pre-buy guidance"],
-                  ].map(([Icon, value, label]) => (
-                    <div
-                      key={label}
-                      className="flex min-h-[88px] items-center gap-3 rounded-2xl border border-white/10 bg-white/[0.065] p-4 backdrop-blur-xl last:col-span-2 sm:last:col-span-1"
-                    >
-                      <span className="grid h-10 w-10 shrink-0 place-items-center rounded-xl bg-emerald-400/12 text-emerald-300">
-                        <Icon size={19} />
-                      </span>
-                      <span>
-                        <strong className="block text-lg font-black tracking-[-0.04em]">
-                          {value}
-                        </strong>
-                        <small className="mt-0.5 block text-[9px] uppercase tracking-[0.13em] text-slate-400">
-                          {label}
-                        </small>
-                      </span>
+            <section id="shop-products" className="scroll-mt-28">
+              <div className="grid items-start gap-5 lg:grid-cols-[280px_minmax(0,1fr)] xl:grid-cols-[310px_minmax(0,1fr)]">
+                <aside className="hidden lg:block">
+                  <div className="sticky top-[96px] max-h-[calc(100vh-112px)] overflow-y-auto rounded-[1.75rem] border border-white/80 bg-white/78 p-4 shadow-[0_18px_55px_rgba(15,23,42,0.08)] backdrop-blur-2xl">
+                    <div className="mb-4 flex items-center justify-between border-b border-slate-200/70 pb-4">
+                      <div>
+                        <span className="text-[9px] font-black uppercase tracking-[0.18em] text-emerald-700">
+                          Refine products
+                        </span>
+                        <h1 className="mt-1 text-xl font-black tracking-[-0.05em] text-slate-950">
+                          Filters
+                        </h1>
+                      </div>
+                      {activeFilterChips.length ? (
+                        <button
+                          type="button"
+                          onClick={clearAllFilters}
+                          className="inline-flex h-9 items-center gap-1.5 rounded-full bg-slate-100 px-3 text-[10px] font-black text-slate-600 transition hover:bg-rose-50 hover:text-rose-600"
+                        >
+                          <RotateCcw size={12} /> Reset
+                        </button>
+                      ) : null}
                     </div>
-                  ))}
-                </div>
-              </div>
-            </motion.section>
-
-            <section className="mt-5 overflow-hidden rounded-[1.75rem] border border-white/80 bg-white/70 p-3 shadow-[0_20px_60px_rgba(15,23,42,0.07)] backdrop-blur-2xl sm:p-4">
-              <div className="mb-3 flex items-center justify-between px-1 sm:px-2">
-                <div>
-                  <span className="text-[9px] font-black uppercase tracking-[0.18em] text-emerald-700">
-                    Start with your need
-                  </span>
-                  <h2 className="mt-1 text-sm font-black tracking-[-0.03em] text-slate-950 sm:text-base">
-                    Quick solution lanes
-                  </h2>
-                </div>
-                {filters.category !== "All" ? (
-                  <button
-                    type="button"
-                    onClick={() => handleFilterChange("category", "All")}
-                    className="text-[10px] font-black text-slate-500 transition hover:text-emerald-700"
-                  >
-                    Show everything
-                  </button>
-                ) : null}
-              </div>
-
-              <div className="no-scrollbar flex gap-2 overflow-x-auto pb-1">
-                <button
-                  type="button"
-                  onClick={() => handleFilterChange("category", "All")}
-                  className={`flex min-w-[145px] items-center gap-3 rounded-2xl border p-3 text-left transition ${
-                    filters.category === "All"
-                      ? "border-slate-950 bg-slate-950 text-white shadow-lg"
-                      : "border-slate-200/80 bg-white/80 text-slate-700 hover:border-emerald-200"
-                  }`}
-                >
-                  <span className="grid h-9 w-9 shrink-0 place-items-center rounded-xl bg-emerald-400/15 text-emerald-500">
-                    <Droplets size={18} />
-                  </span>
-                  <span>
-                    <strong className="block text-[11px] font-black">
-                      All solutions
-                    </strong>
-                    <small className="mt-0.5 block text-[9px] opacity-60">
-                      {products.length} products
-                    </small>
-                  </span>
-                </button>
-
-                {derivedMeta.categories.slice(0, 9).map((category, index) => (
-                  <button
-                    type="button"
-                    key={category}
-                    onClick={() => handleFilterChange("category", category)}
-                    className={`flex min-w-[170px] items-center gap-3 rounded-2xl border p-3 text-left transition ${
-                      filters.category === category
-                        ? "border-emerald-600 bg-emerald-600 text-white shadow-lg"
-                        : "border-slate-200/80 bg-white/80 text-slate-700 hover:-translate-y-0.5 hover:border-emerald-200 hover:shadow-md"
-                    }`}
-                  >
-                    <span
-                      className={`grid h-9 w-9 shrink-0 place-items-center rounded-xl ${
-                        filters.category === category
-                          ? "bg-white/15 text-white"
-                          : "bg-slate-100 text-emerald-700"
-                      }`}
-                    >
-                      {index % 2 ? (
-                        <PackageCheck size={18} />
-                      ) : (
-                        <Droplets size={18} />
-                      )}
-                    </span>
-                    <span className="min-w-0">
-                      <strong className="block truncate text-[11px] font-black">
-                        {category}
-                      </strong>
-                      <small className="mt-0.5 block text-[9px] opacity-60">
-                        {derivedMeta.categoryCounts.get(category) || 0} products
-                      </small>
-                    </span>
-                  </button>
-                ))}
-              </div>
-            </section>
-
-            <section id="shop-products" className="scroll-mt-28 pt-7">
-              <div className="sticky top-[76px] z-30 mb-5 rounded-[1.65rem] border border-white/80 bg-[rgba(248,252,251,0.88)] p-2.5 shadow-[0_18px_55px_rgba(15,23,42,0.09)] backdrop-blur-2xl sm:top-[92px] sm:p-3">
-                <div className="flex items-center gap-2.5">
-                  <button
-                    type="button"
-                    onClick={() => setShowFilters(true)}
-                    className="relative inline-flex h-12 shrink-0 items-center gap-2 rounded-2xl bg-slate-950 px-4 text-xs font-black text-white shadow-lg transition hover:bg-emerald-700"
-                  >
-                    <SlidersHorizontal size={17} />
-                    <span className="hidden sm:inline">Tune filters</span>
-                    {activeFilterChips.length ? (
-                      <span className="grid h-5 min-w-5 place-items-center rounded-full bg-emerald-400 px-1 text-[9px] text-slate-950">
-                        {activeFilterChips.length}
-                      </span>
-                    ) : null}
-                  </button>
-
-                  <label className="relative min-w-0 flex-1">
-                    <Search
-                      size={17}
-                      className="pointer-events-none absolute left-3.5 top-1/2 -translate-y-1/2 text-slate-400"
+                    <ShopFiltersPanel
+                      filters={filters}
+                      onFilterChange={handleFilterChange}
+                      categoryOptions={derivedMeta.categories}
+                      subcategoryOptions={derivedMeta.subcategories}
+                      brandOptions={derivedMeta.brands}
+                      priceRange={{
+                        min: derivedMeta.priceRange.min,
+                        max: derivedMeta.priceRange.max,
+                        value: priceValue,
+                      }}
                     />
-                    <input
-                      type="search"
-                      value={filters.query}
-                      onChange={(event) =>
-                        handleFilterChange("query", event.target.value)
-                      }
-                      placeholder="Search water solutions…"
-                      className="h-12 w-full rounded-2xl border border-slate-200/80 bg-white/90 pl-10 pr-9 text-xs font-semibold text-slate-900 outline-none transition placeholder:text-slate-400 focus:border-emerald-300 focus:ring-4 focus:ring-emerald-100"
-                    />
-                    {filters.query ? (
+                  </div>
+                </aside>
+
+                <div className="min-w-0">
+                  <div className="sticky top-[76px] z-30 mb-5 rounded-[1.65rem] border border-white/80 bg-[rgba(248,252,251,0.92)] p-2.5 shadow-[0_18px_55px_rgba(15,23,42,0.09)] backdrop-blur-2xl sm:top-[92px] sm:p-3">
+                    <div className="flex items-center gap-2.5">
                       <button
                         type="button"
-                        onClick={() => handleFilterChange("query", "")}
-                        className="absolute right-2.5 top-1/2 grid h-7 w-7 -translate-y-1/2 place-items-center rounded-full bg-slate-100 text-slate-500"
-                        aria-label="Clear search"
+                        onClick={() => setShowFilters(true)}
+                        className="relative inline-flex h-12 shrink-0 items-center gap-2 rounded-2xl bg-slate-950 px-4 text-xs font-black text-white shadow-lg transition hover:bg-emerald-700 lg:hidden"
                       >
-                        <X size={13} />
+                        <SlidersHorizontal size={17} />
+                        <span className="hidden sm:inline">Tune filters</span>
+                        {activeFilterChips.length ? (
+                          <span className="grid h-5 min-w-5 place-items-center rounded-full bg-emerald-400 px-1 text-[9px] text-slate-950">
+                            {activeFilterChips.length}
+                          </span>
+                        ) : null}
                       </button>
-                    ) : null}
-                  </label>
 
-                  <div className="relative hidden sm:block">
-                    <select
-                      value={sortBy}
-                      onChange={(event) => setSortBy(event.target.value)}
-                      aria-label="Sort products"
-                      className="h-12 appearance-none rounded-2xl border border-slate-200/80 bg-white/90 pl-4 pr-10 text-xs font-black text-slate-700 outline-none transition hover:border-slate-300 focus:border-emerald-300 focus:ring-4 focus:ring-emerald-100"
-                    >
-                      <option value="recommended">Recommended</option>
-                      <option value="price-low">Price: low to high</option>
-                      <option value="price-high">Price: high to low</option>
-                      <option value="rating">Top rated</option>
-                      <option value="saving">Biggest saving</option>
-                      <option value="name">Name: A to Z</option>
-                    </select>
-                    <ChevronDown
-                      size={14}
-                      className="pointer-events-none absolute right-3.5 top-1/2 -translate-y-1/2 text-slate-500"
-                    />
-                  </div>
-
-                  <div className="hidden h-12 items-center rounded-2xl border border-slate-200/80 bg-white/90 p-1 sm:flex">
-                    <button
-                      type="button"
-                      onClick={() => setViewMode("grid")}
-                      className={`grid h-10 w-10 place-items-center rounded-xl transition ${
-                        viewMode === "grid"
-                          ? "bg-slate-950 text-white"
-                          : "text-slate-500 hover:bg-slate-100"
-                      }`}
-                      aria-label="Grid view"
-                    >
-                      <Grid2X2 size={16} />
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => setViewMode("list")}
-                      className={`grid h-10 w-10 place-items-center rounded-xl transition ${
-                        viewMode === "list"
-                          ? "bg-slate-950 text-white"
-                          : "text-slate-500 hover:bg-slate-100"
-                      }`}
-                      aria-label="List view"
-                    >
-                      <List size={17} />
-                    </button>
-                  </div>
-                </div>
-
-                <div className="mt-2 flex items-center justify-between gap-3 border-t border-slate-200/70 px-1 pt-2 sm:hidden">
-                  <div className="relative min-w-0 flex-1">
-                    <select
-                      value={sortBy}
-                      onChange={(event) => setSortBy(event.target.value)}
-                      aria-label="Sort products"
-                      className="h-9 w-full appearance-none rounded-xl border-0 bg-slate-100 pl-3 pr-8 text-[10px] font-black text-slate-700 outline-none"
-                    >
-                      <option value="recommended">Recommended</option>
-                      <option value="price-low">Price: low to high</option>
-                      <option value="price-high">Price: high to low</option>
-                      <option value="rating">Top rated</option>
-                      <option value="saving">Biggest saving</option>
-                    </select>
-                    <ChevronDown
-                      size={13}
-                      className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-slate-500"
-                    />
-                  </div>
-                  <span className="shrink-0 text-[10px] font-black text-slate-500">
-                    {filteredAndSortedProducts.length} results
-                  </span>
-                </div>
-              </div>
-
-              <AnimatePresence mode="popLayout">
-                {activeFilterChips.length ? (
-                  <motion.div
-                    layout
-                    initial={{ opacity: 0, height: 0 }}
-                    animate={{ opacity: 1, height: "auto" }}
-                    exit={{ opacity: 0, height: 0 }}
-                    className="mb-5 overflow-hidden"
-                  >
-                    <div className="flex flex-wrap items-center gap-2 px-1">
-                      {activeFilterChips.map((chip) => (
-                        <FilterChip
-                          key={chip.key}
-                          label={chip.label}
-                          onRemove={() =>
-                            handleFilterChange(chip.key, chip.value)
-                          }
+                      <label className="relative min-w-0 flex-1">
+                        <Search
+                          size={17}
+                          className="pointer-events-none absolute left-3.5 top-1/2 -translate-y-1/2 text-slate-400"
                         />
-                      ))}
+                        <input
+                          type="search"
+                          value={filters.query}
+                          onChange={(event) =>
+                            handleFilterChange("query", event.target.value)
+                          }
+                          placeholder="Search water solutions…"
+                          className="h-12 w-full rounded-2xl border border-slate-200/80 bg-white/90 pl-10 pr-9 text-xs font-semibold text-slate-900 outline-none transition placeholder:text-slate-400 focus:border-emerald-300 focus:ring-4 focus:ring-emerald-100"
+                        />
+                        {filters.query ? (
+                          <button
+                            type="button"
+                            onClick={() => handleFilterChange("query", "")}
+                            className="absolute right-2.5 top-1/2 grid h-7 w-7 -translate-y-1/2 place-items-center rounded-full bg-slate-100 text-slate-500"
+                            aria-label="Clear search"
+                          >
+                            <X size={13} />
+                          </button>
+                        ) : null}
+                      </label>
+
+                      <div className="relative hidden sm:block">
+                        <select
+                          value={sortBy}
+                          onChange={(event) => setSortBy(event.target.value)}
+                          aria-label="Sort products"
+                          className="h-12 appearance-none rounded-2xl border border-slate-200/80 bg-white/90 pl-4 pr-10 text-xs font-black text-slate-700 outline-none transition hover:border-slate-300 focus:border-emerald-300 focus:ring-4 focus:ring-emerald-100"
+                        >
+                          <option value="recommended">Recommended</option>
+                          <option value="price-low">Price: low to high</option>
+                          <option value="price-high">Price: high to low</option>
+                          <option value="rating">Top rated</option>
+                          <option value="saving">Biggest saving</option>
+                          <option value="name">Name: A to Z</option>
+                        </select>
+                        <ChevronDown
+                          size={14}
+                          className="pointer-events-none absolute right-3.5 top-1/2 -translate-y-1/2 text-slate-500"
+                        />
+                      </div>
+
+                      <div className="hidden h-12 items-center rounded-2xl border border-slate-200/80 bg-white/90 p-1 sm:flex">
+                        <button
+                          type="button"
+                          onClick={() => setViewMode("grid")}
+                          className={`grid h-10 w-10 place-items-center rounded-xl transition ${
+                            viewMode === "grid"
+                              ? "bg-slate-950 text-white"
+                              : "text-slate-500 hover:bg-slate-100"
+                          }`}
+                          aria-label="Grid view"
+                        >
+                          <Grid2X2 size={16} />
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => setViewMode("list")}
+                          className={`grid h-10 w-10 place-items-center rounded-xl transition ${
+                            viewMode === "list"
+                              ? "bg-slate-950 text-white"
+                              : "text-slate-500 hover:bg-slate-100"
+                          }`}
+                          aria-label="List view"
+                        >
+                          <List size={17} />
+                        </button>
+                      </div>
+                    </div>
+
+                    <div className="mt-2 flex items-center justify-between gap-3 border-t border-slate-200/70 px-1 pt-2 sm:hidden">
+                      <div className="relative min-w-0 flex-1">
+                        <select
+                          value={sortBy}
+                          onChange={(event) => setSortBy(event.target.value)}
+                          aria-label="Sort products"
+                          className="h-9 w-full appearance-none rounded-xl border-0 bg-slate-100 pl-3 pr-8 text-[10px] font-black text-slate-700 outline-none"
+                        >
+                          <option value="recommended">Recommended</option>
+                          <option value="price-low">Price: low to high</option>
+                          <option value="price-high">Price: high to low</option>
+                          <option value="rating">Top rated</option>
+                          <option value="saving">Biggest saving</option>
+                        </select>
+                        <ChevronDown
+                          size={13}
+                          className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-slate-500"
+                        />
+                      </div>
+                      <span className="shrink-0 text-[10px] font-black text-slate-500">
+                        {filteredAndSortedProducts.length} results
+                      </span>
+                    </div>
+                  </div>
+
+                  <AnimatePresence mode="popLayout">
+                    {activeFilterChips.length ? (
+                      <motion.div
+                        layout
+                        initial={{ opacity: 0, height: 0 }}
+                        animate={{ opacity: 1, height: "auto" }}
+                        exit={{ opacity: 0, height: 0 }}
+                        className="mb-5 overflow-hidden"
+                      >
+                        <div className="flex flex-wrap items-center gap-2 px-1">
+                          {activeFilterChips.map((chip) => (
+                            <FilterChip
+                              key={chip.key}
+                              label={chip.label}
+                              onRemove={() =>
+                                handleFilterChange(chip.key, chip.value)
+                              }
+                            />
+                          ))}
+                          <button
+                            type="button"
+                            onClick={clearAllFilters}
+                            className="inline-flex h-9 items-center gap-1.5 px-2 text-[10px] font-black text-slate-500 transition hover:text-rose-600"
+                          >
+                            <RotateCcw size={13} /> Clear all
+                          </button>
+                        </div>
+                      </motion.div>
+                    ) : null}
+                  </AnimatePresence>
+
+                  <div className="mb-5 flex items-end justify-between gap-6 px-1 sm:px-2">
+                    <div>
+                      <span className="text-[9px] font-black uppercase tracking-[0.18em] text-emerald-700">
+                        Shop with clarity
+                      </span>
+                      <h2 className="mt-1 text-2xl font-black tracking-[-0.06em] text-slate-950 sm:text-4xl">
+                        {filters.category === "All"
+                          ? "The complete collection"
+                          : filters.category}
+                      </h2>
+                    </div>
+                    <div className="hidden items-center gap-2 rounded-full border border-slate-200 bg-white/75 px-3 py-2 text-[10px] font-bold text-slate-500 sm:flex">
+                      <BadgeCheck size={14} className="text-emerald-600" />
+                      {filteredAndSortedProducts.length} carefully matched
+                    </div>
+                  </div>
+
+                  {hasAnyProducts && hasFilteredProducts ? (
+                    <ProductGrid
+                      products={filteredAndSortedProducts}
+                      viewMode={viewMode}
+                    />
+                  ) : hasAnyProducts ? (
+                    <motion.div
+                      initial={{ opacity: 0, y: 10 }}
+                      animate={{ opacity: 1, y: 0 }}
+                      className="flex min-h-[44vh] flex-col items-center justify-center rounded-[2.25rem] border border-dashed border-slate-300 bg-white/65 p-8 text-center backdrop-blur-xl"
+                    >
+                      <span className="grid h-16 w-16 place-items-center rounded-2xl bg-emerald-50 text-emerald-700">
+                        <Funnel size={26} />
+                      </span>
+                      <h3 className="mt-5 text-xl font-black tracking-[-0.04em] text-slate-950">
+                        No exact match yet
+                      </h3>
+                      <p className="mt-2 max-w-md text-xs leading-6 text-slate-500">
+                        Widen the budget or remove a filter. Your full Aquakart
+                        collection is one tap away.
+                      </p>
                       <button
                         type="button"
                         onClick={clearAllFilters}
-                        className="inline-flex h-9 items-center gap-1.5 px-2 text-[10px] font-black text-slate-500 transition hover:text-rose-600"
+                        className="mt-6 inline-flex min-h-11 items-center gap-2 rounded-full bg-slate-950 px-5 text-xs font-black text-white transition hover:bg-emerald-700"
                       >
-                        <RotateCcw size={13} /> Clear all
+                        <RotateCcw size={15} /> Reset filters
                       </button>
+                    </motion.div>
+                  ) : (
+                    <div className="flex min-h-[42vh] items-center justify-center rounded-[2.25rem] border border-dashed border-slate-300 bg-white/65 text-xs font-semibold text-slate-500">
+                      No products are available right now.
                     </div>
-                  </motion.div>
-                ) : null}
-              </AnimatePresence>
-
-              <div className="mb-5 flex items-end justify-between gap-6 px-1 sm:px-2">
-                <div>
-                  <span className="text-[9px] font-black uppercase tracking-[0.18em] text-emerald-700">
-                    Shop with clarity
-                  </span>
-                  <h2 className="mt-1 text-2xl font-black tracking-[-0.06em] text-slate-950 sm:text-4xl">
-                    {filters.category === "All"
-                      ? "The complete collection"
-                      : filters.category}
-                  </h2>
-                </div>
-                <div className="hidden items-center gap-2 rounded-full border border-slate-200 bg-white/75 px-3 py-2 text-[10px] font-bold text-slate-500 sm:flex">
-                  <BadgeCheck size={14} className="text-emerald-600" />
-                  {filteredAndSortedProducts.length} carefully matched
+                  )}
                 </div>
               </div>
-
-              {hasAnyProducts && hasFilteredProducts ? (
-                <ProductGrid
-                  products={filteredAndSortedProducts}
-                  viewMode={viewMode}
-                />
-              ) : hasAnyProducts ? (
-                <motion.div
-                  initial={{ opacity: 0, y: 10 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  className="flex min-h-[44vh] flex-col items-center justify-center rounded-[2.25rem] border border-dashed border-slate-300 bg-white/65 p-8 text-center backdrop-blur-xl"
-                >
-                  <span className="grid h-16 w-16 place-items-center rounded-2xl bg-emerald-50 text-emerald-700">
-                    <Funnel size={26} />
-                  </span>
-                  <h3 className="mt-5 text-xl font-black tracking-[-0.04em] text-slate-950">
-                    No exact match yet
-                  </h3>
-                  <p className="mt-2 max-w-md text-xs leading-6 text-slate-500">
-                    Widen the budget or remove a filter. Your full Aquakart
-                    collection is one tap away.
-                  </p>
-                  <button
-                    type="button"
-                    onClick={clearAllFilters}
-                    className="mt-6 inline-flex min-h-11 items-center gap-2 rounded-full bg-slate-950 px-5 text-xs font-black text-white transition hover:bg-emerald-700"
-                  >
-                    <RotateCcw size={15} /> Reset filters
-                  </button>
-                </motion.div>
-              ) : (
-                <div className="flex min-h-[42vh] items-center justify-center rounded-[2.25rem] border border-dashed border-slate-300 bg-white/65 text-xs font-semibold text-slate-500">
-                  No products are available right now.
-                </div>
-              )}
-            </section>
-
-            <section className="mt-10 grid gap-3 sm:grid-cols-3">
-              {[
-                [
-                  ShieldCheck,
-                  "Confident purchase",
-                  "Clear specifications and transparent prices.",
-                ],
-                [
-                  Headphones,
-                  "Human guidance",
-                  "Talk to our team before choosing a system.",
-                ],
-                [
-                  BadgePercent,
-                  "Value that lasts",
-                  "Compare offers without losing product context.",
-                ],
-              ].map(([Icon, title, description]) => (
-                <div
-                  key={title}
-                  className="flex items-start gap-3 rounded-2xl border border-white/80 bg-white/65 p-4 shadow-sm backdrop-blur"
-                >
-                  <span className="grid h-10 w-10 shrink-0 place-items-center rounded-xl bg-emerald-50 text-emerald-700">
-                    <Icon size={18} />
-                  </span>
-                  <div>
-                    <strong className="text-xs font-black text-slate-900">
-                      {title}
-                    </strong>
-                    <p className="mt-1 text-[10px] leading-5 text-slate-500">
-                      {description}
-                    </p>
-                  </div>
-                </div>
-              ))}
             </section>
           </div>
 

--- a/src/pageComponents/shop/productGrid.js
+++ b/src/pageComponents/shop/productGrid.js
@@ -11,7 +11,7 @@ const ProductGrid = ({ products = [], viewMode = "grid" }) => {
     visible: {
       opacity: 1,
       transition: {
-        staggerChildren: 0.05,
+        staggerChildren: 0.025,
       },
     },
   };
@@ -44,8 +44,13 @@ const ProductGrid = ({ products = [], viewMode = "grid" }) => {
           key={product?._id || index}
           variants={itemVariants}
           className="min-w-0"
+          style={{ contentVisibility: "auto", containIntrinsicSize: "420px" }}
         >
-          <ReusableProductCard product={product} viewMode={viewMode} />
+          <ReusableProductCard
+            product={product}
+            viewMode={viewMode}
+            imagePriority={index < 4}
+          />
         </motion.div>
       ))}
     </motion.div>


### PR DESCRIPTION
## What changed

- Removed the large shop hero, quick-solution lanes, and bottom promotional cards so customers reach products immediately.
- Added a persistent left-side filter panel on desktop with search, availability, offers, category, solution type, brand, budget, and rating controls.
- Kept the compact filter drawer on mobile and retained the sticky search/sort controls.
- Reduced product-grid animation delay and enabled browser rendering containment for off-screen cards.
- Prioritizes the first four visible product images, uses responsive lower-weight image requests, and loads only the active carousel image.
- Supports `delivery_url`, `secure_url`, `url`, and direct string photo formats so valid backend images do not render as empty cards.

## Customer impact

Customers see the catalogue immediately, can refine it without opening a separate desktop drawer, and download fewer image bytes during initial page load. No unrelated layout or business logic was changed.

## Validation

- Shop filter tests: 3/3 passed.
- Next.js production build passed.
- `git diff --check` passed.