### PR TITLE
Complete the direct invoice access flow

### DIFF
--- a/src/features/invoiceAccess/directInvoice.js
+++ b/src/features/invoiceAccess/directInvoice.js
@@ -1,0 +1,14 @@
+export const openDirectInvoiceAccess = async ({
+  invoiceId,
+  firebaseIdToken,
+  loginDirectInvoiceAccess,
+}) => {
+  if (!invoiceId) throw new Error("Invoice ID is required.");
+  if (!firebaseIdToken) throw new Error("Google verification is required.");
+  if (typeof loginDirectInvoiceAccess !== "function") {
+    throw new Error("Invoice access is unavailable.");
+  }
+
+  await loginDirectInvoiceAccess(invoiceId, firebaseIdToken);
+  return true;
+};

--- a/src/features/invoiceAccess/directInvoice.test.js
+++ b/src/features/invoiceAccess/directInvoice.test.js
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { openDirectInvoiceAccess } from "./directInvoice";
+
+describe("direct invoice access", () => {
+  it("exchanges only the invoice ID and Firebase token", async () => {
+    const loginDirectInvoiceAccess = vi.fn().mockResolvedValue({
+      success: true,
+    });
+
+    await expect(
+      openDirectInvoiceAccess({
+        invoiceId: "invoice-123",
+        firebaseIdToken: "firebase-token",
+        loginDirectInvoiceAccess,
+      }),
+    ).resolves.toBe(true);
+
+    expect(loginDirectInvoiceAccess).toHaveBeenCalledWith(
+      "invoice-123",
+      "firebase-token",
+    );
+  });
+
+  it("does not attempt access without Google verification", async () => {
+    const loginDirectInvoiceAccess = vi.fn();
+
+    await expect(
+      openDirectInvoiceAccess({
+        invoiceId: "invoice-123",
+        firebaseIdToken: "",
+        loginDirectInvoiceAccess,
+      }),
+    ).rejects.toThrow("Google verification is required");
+    expect(loginDirectInvoiceAccess).not.toHaveBeenCalled();
+  });
+});

--- a/src/pageComponents/invoice/InvoicePage.js
+++ b/src/pageComponents/invoice/InvoicePage.js
@@ -32,9 +32,12 @@ import {
 import { toast } from "sonner";
 import logo from "@/assests/logo.png";
 import GoogleMark from "@/components/auth/GoogleMark";
-import { useAuth } from "@/context/AuthContext";
-import { getCurrentFirebaseIdToken } from "@/services/googleAuth";
+import {
+  getCurrentFirebaseIdToken,
+  loginWithGoogleForInvoice,
+} from "@/services/googleAuth";
 import InvoiceServiceOperations from "@/services/invoice";
+import { openDirectInvoiceAccess } from "@/features/invoiceAccess/directInvoice";
 import {
   bankCopyDetails,
   bankPaymentMethods,
@@ -92,15 +95,10 @@ const StatusPill = ({ status }) => {
   );
 };
 
-const InvoiceError = ({ statusCode }) => {
+const InvoiceError = ({ statusCode, onAccessGranted }) => {
   const router = useRouter();
-  const {
-    authenticated,
-    authReady,
-    loading: authLoading,
-    session,
-    signInWithGoogle,
-  } = useAuth();
+  const [checkingSession, setCheckingSession] = useState(true);
+  const [hasGoogleSession, setHasGoogleSession] = useState(false);
   const [signingIn, setSigningIn] = useState(false);
   const [openingInvoice, setOpeningInvoice] = useState(false);
   const [accessError, setAccessError] = useState("");
@@ -111,14 +109,14 @@ const InvoiceError = ({ statusCode }) => {
   const routeId = Array.isArray(router.query.id)
     ? router.query.id[0]
     : router.query.id;
-  const authBusy = authLoading || signingIn || openingInvoice;
+  const authBusy = checkingSession || signingIn || openingInvoice;
   const clientAccessMessage = accessError
     ? "We could not open the invoice just now. Please try again."
     : "";
 
   const requestDirectAccess = useCallback(
-    async () => {
-      if (!routeId || directAccessInFlight.current) {
+    async (firebaseIdToken) => {
+      if (!routeId || !firebaseIdToken || directAccessInFlight.current) {
         return;
       }
 
@@ -128,12 +126,13 @@ const InvoiceError = ({ statusCode }) => {
       setAccessError("");
 
       try {
-        const firebaseIdToken = await getCurrentFirebaseIdToken();
-        await InvoiceServiceOperations.loginDirectInvoiceAccess(
-          routeId,
+        await openDirectInvoiceAccess({
+          invoiceId: routeId,
           firebaseIdToken,
-        );
-        window.location.replace(router.asPath);
+          loginDirectInvoiceAccess:
+            InvoiceServiceOperations.loginDirectInvoiceAccess,
+        });
+        await onAccessGranted?.();
         return true;
       } catch (error) {
         setAccessError(
@@ -147,47 +146,61 @@ const InvoiceError = ({ statusCode }) => {
         setOpeningInvoice(false);
       }
     },
-    [routeId, router.asPath],
+    [onAccessGranted, routeId],
   );
 
   useEffect(() => {
-    if (
-      unauthorized &&
-      authReady &&
-      authenticated &&
-      session?.token &&
-      !authLoading &&
-      !attemptedDirectAccess.current
-    ) {
-      void requestDirectAccess();
+    if (!unauthorized || !routeId || attemptedDirectAccess.current) {
+      setCheckingSession(false);
+      return undefined;
     }
-  }, [
-    authLoading,
-    authReady,
-    authenticated,
-    requestDirectAccess,
-    session?.token,
-    unauthorized,
-  ]);
+
+    let active = true;
+    setCheckingSession(true);
+
+    const openWithExistingGoogleSession = async () => {
+      try {
+        const firebaseIdToken = await getCurrentFirebaseIdToken();
+        if (!active) return;
+        setHasGoogleSession(true);
+        await requestDirectAccess(firebaseIdToken);
+      } catch (error) {
+        if (!active) return;
+        setHasGoogleSession(false);
+        if (error?.code !== "auth/no-current-user") {
+          setAccessError(
+            error?.message || "We could not verify your Google session.",
+          );
+        }
+      } finally {
+        if (active) setCheckingSession(false);
+      }
+    };
+
+    void openWithExistingGoogleSession();
+    return () => {
+      active = false;
+    };
+  }, [requestDirectAccess, routeId, unauthorized]);
 
   const continueWithGoogle = async () => {
     if (authBusy) return;
 
-    if (authenticated && session?.token) {
-      attemptedDirectAccess.current = false;
-      const opened = await requestDirectAccess();
-      if (opened) return;
-    }
-
     setSigningIn(true);
     setAccessError("");
     try {
-      const result = await signInWithGoogle();
+      const result = await loginWithGoogleForInvoice();
       if (!result?.redirecting) {
-        await requestDirectAccess();
+        setHasGoogleSession(true);
+        attemptedDirectAccess.current = false;
+        await requestDirectAccess(result.firebaseIdToken);
       }
-    } catch {
-      // AuthContext shows the user-facing authentication error.
+    } catch (error) {
+      setAccessError(
+        error?.response?.data?.message ||
+          error?.message ||
+          "We could not verify your Google account.",
+      );
     } finally {
       setSigningIn(false);
     }
@@ -195,11 +208,13 @@ const InvoiceError = ({ statusCode }) => {
 
   const primaryActionLabel = openingInvoice
     ? "Opening invoice…"
-    : signingIn || authLoading
+    : checkingSession
       ? "Checking Google session…"
-      : authenticated
-        ? "Open invoice"
-        : "Continue with Google";
+      : signingIn
+        ? "Continuing with Google…"
+        : hasGoogleSession
+          ? "Open invoice"
+          : "Continue with Google";
 
   return (
     <div className={styles.errorPage}>
@@ -229,18 +244,17 @@ const InvoiceError = ({ statusCode }) => {
         </h1>
         <p>
           {unauthorized
-            ? authenticated
-              ? "You are signed in. We are securely opening this invoice with your verified email."
-              : "Continue with Google once to securely view and download your invoice."
+            ? checkingSession
+              ? "We are checking your existing Google session and will open the invoice automatically."
+              : hasGoogleSession
+                ? "You are signed in. We are securely opening this invoice with your verified email."
+                : "Continue with Google once to securely view and download your invoice."
             : notFound
               ? "Check the invoice link and try again. The ID may be incomplete or no longer available."
               : "We could not reach the invoice service. Please wait a moment and try again."}
         </p>
         {clientAccessMessage ? (
-          <p
-            className={styles.accessError}
-            role="alert"
-          >
+          <p className={styles.accessError} role="alert">
             {clientAccessMessage}
           </p>
         ) : null}
@@ -519,13 +533,15 @@ const BankMethodCard = ({ method, copied, onCopy }) => {
   );
 };
 
-const InvoicePage = ({ invoice, statusCode = 200 }) => {
+const InvoicePage = ({ invoice, statusCode = 200, onAccessGranted }) => {
   const [isDownloading, setIsDownloading] = useState(false);
   const [copied, setCopied] = useState(false);
   const [copiedPayment, setCopiedPayment] = useState("");
 
   if (!invoice || statusCode !== 200) {
-    return <InvoiceError statusCode={statusCode} />;
+    return (
+      <InvoiceError statusCode={statusCode} onAccessGranted={onAccessGranted} />
+    );
   }
 
   const amounts = priceUtils.getInvoiceAmounts(invoice);

--- a/src/pages/api/invoice-access/[id]/login.js
+++ b/src/pages/api/invoice-access/[id]/login.js
@@ -50,6 +50,12 @@ export default async function handler(req, res) {
     );
     const payload = await response.json().catch(() => ({}));
     if (!response.ok) return res.status(response.status).json(payload);
+    if (!payload.accessToken) {
+      return res.status(502).json({
+        success: false,
+        message: "Invoice access could not be created. Please try again.",
+      });
+    }
 
     res.setHeader(
       "Set-Cookie",

--- a/src/pages/invoice/[id].js
+++ b/src/pages/invoice/[id].js
@@ -43,6 +43,7 @@ const fetchProductCatalogue = async (signal) => {
 
 const PublicInvoiceRoute = () => {
   const router = useRouter();
+  const [refreshKey, setRefreshKey] = useState(0);
   const [state, setState] = useState({
     invoice: null,
     statusCode: 0,
@@ -63,15 +64,11 @@ const PublicInvoiceRoute = () => {
 
     const loadInvoice = async () => {
       try {
-        const cataloguePromise = fetchProductCatalogue(controller.signal);
         const payload = await InvoiceServiceOperations.getInvoiceById(
           id,
           controller.signal,
         );
-        const invoice = enrichInvoiceProducts(
-          mapInvoiceFromApi(payload),
-          await cataloguePromise,
-        );
+        const invoice = mapInvoiceFromApi(payload);
 
         if (!controller.signal.aborted) {
           setState({
@@ -79,6 +76,17 @@ const PublicInvoiceRoute = () => {
             statusCode: invoice ? 200 : 502,
             loading: false,
           });
+        }
+
+        if (invoice) {
+          const catalogue = await fetchProductCatalogue(controller.signal);
+          if (!controller.signal.aborted) {
+            setState({
+              invoice: enrichInvoiceProducts(invoice, catalogue),
+              statusCode: 200,
+              loading: false,
+            });
+          }
         }
       } catch (error) {
         if (!controller.signal.aborted) {
@@ -93,10 +101,16 @@ const PublicInvoiceRoute = () => {
 
     void loadInvoice();
     return () => controller.abort();
-  }, [router.isReady, router.query.id]);
+  }, [refreshKey, router.isReady, router.query.id]);
 
   if (state.loading) return null;
-  return <InvoicePage invoice={state.invoice} statusCode={state.statusCode} />;
+  return (
+    <InvoicePage
+      invoice={state.invoice}
+      statusCode={state.statusCode}
+      onAccessGranted={() => setRefreshKey((current) => current + 1)}
+    />
+  );
 };
 
 export default PublicInvoiceRoute;

--- a/src/services/googleAuth.js
+++ b/src/services/googleAuth.js
@@ -93,6 +93,25 @@ export const loginWithGoogle = async () => {
   }
 };
 
+export const loginWithGoogleForInvoice = async () => {
+  const firebaseAuth = getFirebaseAuth();
+  try {
+    const credential = await signInWithPopup(firebaseAuth, getGoogleProvider());
+    return {
+      firebaseIdToken: await withTimeout(
+        credential.user.getIdToken(true),
+        FIREBASE_OPERATION_TIMEOUT_MS,
+        "Google verification took too long. Please try again.",
+      ),
+      redirecting: false,
+    };
+  } catch (error) {
+    if (!shouldUseRedirectFallback(error)) throw error;
+    await signInWithRedirect(firebaseAuth, getGoogleProvider());
+    return { redirecting: true };
+  }
+};
+
 export const completeGoogleRedirectLogin = async () => {
   const credential = await getRedirectResult(getFirebaseAuth());
   return credential ? exchangeGoogleUser(credential.user) : null;
@@ -123,7 +142,9 @@ export const getCurrentFirebaseIdToken = async () => {
   );
   const currentUser = firebaseAuth.currentUser;
   if (!currentUser) {
-    throw new Error("Please continue with Google first");
+    const error = new Error("Please continue with Google first");
+    error.code = "auth/no-current-user";
+    throw error;
   }
   return withTimeout(
     currentUser.getIdToken(true),


### PR DESCRIPTION
## Root cause

The direct invoice page correctly received `401` when its scoped cookie was missing, but recovery was incorrectly gated by the normal AquaKart backend session (`session.token`) and the global auth restore lifecycle. Direct invoice access only requires a verified Firebase Google token, so valid signed-in customers could remain stuck on **Checking Google session…** without the required `POST /invoice-gateway/:id/login` ever running.

## Complete flow fixed

1. `/invoice/:id` requests the current invoice without cache.
2. A valid scoped cookie renders the invoice immediately.
3. On `401/403`, the invoice module checks Firebase directly—independent of the normal backend login session.
4. If a Firebase session exists, it automatically exchanges that ID token for the invoice-scoped cookie.
5. If no Firebase session exists, the customer gets one **Continue with Google** action with popup-to-redirect fallback.
6. After cookie creation, the invoice is retried in place; there is no full-page reload.
7. Invoice data renders before optional catalogue enrichment, and the catalogue is no longer fetched before invoice authorization.
8. The BFF rejects incomplete backend login responses instead of setting an unusable cookie.

## Existing backend contract verified

No backend patch is required. The deployed contract already:

- verifies Firebase for direct invoice login;
- issues an invoice-scoped `direct` grant;
- preserves an existing invoice email;
- fills the verified Google email only when invoice email is missing;
- accepts scoped invoice tokens for retrieval.

## Validation

- Frontend focused invoice/auth tests: **22/22 passed**.
- Backend invoice/session/security tests: **17/17 passed**.
- Next.js production build passed.
- `git diff --check` passed.

No invoice layout or invoice business data presentation was redesigned.