### PR TITLE
Connect invoice login to the AquaKart storefront session

### DIFF
--- a/src/context/AuthContext.js
+++ b/src/context/AuthContext.js
@@ -109,6 +109,11 @@ export const AuthProvider = ({ children }) => {
     }
   }, [applyLoginResult, router]);
 
+  const adoptGoogleSession = useCallback(
+    (result) => applyLoginResult(result, router.asPath, false),
+    [applyLoginResult, router.asPath],
+  );
+
   const signOut = useCallback(async () => {
     setLoading(true);
     try {
@@ -129,9 +134,17 @@ export const AuthProvider = ({ children }) => {
       session,
       signInWithGoogle,
       switchGoogleAccount: signInWithGoogle,
+      adoptGoogleSession,
       signOut,
     }),
-    [authReady, loading, session, signInWithGoogle, signOut],
+    [
+      adoptGoogleSession,
+      authReady,
+      loading,
+      session,
+      signInWithGoogle,
+      signOut,
+    ],
   );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/src/features/invoiceAccess/directInvoice.js
+++ b/src/features/invoiceAccess/directInvoice.js
@@ -2,13 +2,20 @@ export const openDirectInvoiceAccess = async ({
   invoiceId,
   firebaseIdToken,
   loginDirectInvoiceAccess,
+  exchangeFirebaseIdToken,
+  onStorefrontSession,
 }) => {
   if (!invoiceId) throw new Error("Invoice ID is required.");
   if (!firebaseIdToken) throw new Error("Google verification is required.");
   if (typeof loginDirectInvoiceAccess !== "function") {
     throw new Error("Invoice access is unavailable.");
   }
+  if (typeof exchangeFirebaseIdToken !== "function") {
+    throw new Error("Aquakart sign-in is unavailable.");
+  }
 
   await loginDirectInvoiceAccess(invoiceId, firebaseIdToken);
-  return true;
+  const storefrontSession = await exchangeFirebaseIdToken(firebaseIdToken);
+  await onStorefrontSession?.(storefrontSession);
+  return storefrontSession;
 };

--- a/src/features/invoiceAccess/directInvoice.test.js
+++ b/src/features/invoiceAccess/directInvoice.test.js
@@ -3,22 +3,37 @@ import { describe, expect, it, vi } from "vitest";
 import { openDirectInvoiceAccess } from "./directInvoice";
 
 describe("direct invoice access", () => {
-  it("exchanges only the invoice ID and Firebase token", async () => {
+  it("opens the invoice, refreshes the enriched user, and adopts the storefront session", async () => {
     const loginDirectInvoiceAccess = vi.fn().mockResolvedValue({
       success: true,
     });
+    const storefrontSession = {
+      token: "aquakart-token",
+      user: { phone: "9876543210", addresses: [{ street: "Hyderabad" }] },
+    };
+    const exchangeFirebaseIdToken = vi
+      .fn()
+      .mockResolvedValue(storefrontSession);
+    const onStorefrontSession = vi.fn();
 
     await expect(
       openDirectInvoiceAccess({
         invoiceId: "invoice-123",
         firebaseIdToken: "firebase-token",
         loginDirectInvoiceAccess,
+        exchangeFirebaseIdToken,
+        onStorefrontSession,
       }),
-    ).resolves.toBe(true);
+    ).resolves.toEqual(storefrontSession);
 
     expect(loginDirectInvoiceAccess).toHaveBeenCalledWith(
       "invoice-123",
       "firebase-token",
+    );
+    expect(exchangeFirebaseIdToken).toHaveBeenCalledWith("firebase-token");
+    expect(onStorefrontSession).toHaveBeenCalledWith(storefrontSession);
+    expect(loginDirectInvoiceAccess.mock.invocationCallOrder[0]).toBeLessThan(
+      exchangeFirebaseIdToken.mock.invocationCallOrder[0],
     );
   });
 
@@ -30,6 +45,7 @@ describe("direct invoice access", () => {
         invoiceId: "invoice-123",
         firebaseIdToken: "",
         loginDirectInvoiceAccess,
+        exchangeFirebaseIdToken: vi.fn(),
       }),
     ).rejects.toThrow("Google verification is required");
     expect(loginDirectInvoiceAccess).not.toHaveBeenCalled();

--- a/src/pageComponents/invoice/InvoicePage.js
+++ b/src/pageComponents/invoice/InvoicePage.js
@@ -33,9 +33,11 @@ import { toast } from "sonner";
 import logo from "@/assests/logo.png";
 import GoogleMark from "@/components/auth/GoogleMark";
 import {
+  exchangeFirebaseIdToken,
   getCurrentFirebaseIdToken,
   loginWithGoogleForInvoice,
 } from "@/services/googleAuth";
+import { useAuth } from "@/context/AuthContext";
 import InvoiceServiceOperations from "@/services/invoice";
 import { openDirectInvoiceAccess } from "@/features/invoiceAccess/directInvoice";
 import {
@@ -97,6 +99,7 @@ const StatusPill = ({ status }) => {
 
 const InvoiceError = ({ statusCode, onAccessGranted }) => {
   const router = useRouter();
+  const { adoptGoogleSession } = useAuth();
   const [checkingSession, setCheckingSession] = useState(true);
   const [hasGoogleSession, setHasGoogleSession] = useState(false);
   const [signingIn, setSigningIn] = useState(false);
@@ -131,6 +134,8 @@ const InvoiceError = ({ statusCode, onAccessGranted }) => {
           firebaseIdToken,
           loginDirectInvoiceAccess:
             InvoiceServiceOperations.loginDirectInvoiceAccess,
+          exchangeFirebaseIdToken,
+          onStorefrontSession: adoptGoogleSession,
         });
         await onAccessGranted?.();
         return true;
@@ -146,7 +151,7 @@ const InvoiceError = ({ statusCode, onAccessGranted }) => {
         setOpeningInvoice(false);
       }
     },
-    [onAccessGranted, routeId],
+    [adoptGoogleSession, onAccessGranted, routeId],
   );
 
   useEffect(() => {

--- a/src/services/googleAuth.js
+++ b/src/services/googleAuth.js
@@ -38,13 +38,21 @@ const withTimeout = (promise, timeoutMs, message) =>
   });
 
 const exchangeGoogleUser = async (user) => {
-  const firebaseAuth = getFirebaseAuth();
   const firebaseIdToken = await withTimeout(
     user.getIdToken(),
     FIREBASE_OPERATION_TIMEOUT_MS,
     "Google verification took too long. Please try again.",
   );
 
+  return exchangeFirebaseIdToken(firebaseIdToken);
+};
+
+export const exchangeFirebaseIdToken = async (firebaseIdToken) => {
+  if (!firebaseIdToken) {
+    throw new Error("Google verification is required.");
+  }
+
+  const firebaseAuth = getFirebaseAuth();
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), AUTH_REQUEST_TIMEOUT_MS);
   let response;


### PR DESCRIPTION
## What changed

- Keeps the direct invoice-link Gmail verification flow intact.
- After backend invoice access enriches the AquaKart user, exchanges the same verified Firebase token through the standard `/v1/auth/google` flow.
- Adopts the refreshed backend session in the global frontend auth context.
- Makes enriched phone and address data immediately available to the existing profile and checkout prefill logic.
- Covers the required ordering with a focused unit test: invoice enrichment first, storefront session refresh second.

## Why

Previously, invoice-link Google verification opened the invoice but did not establish the normal e-commerce login state. The backend could create/enrich the customer record, while the frontend still behaved as signed out and could not reuse the enriched profile during shopping.

## Validation

- `npm test` — 22 files, 77 tests passed
- `npm run build` — production Next.js build passed
- Prettier check passed for all changed files
- Targeted ESLint is blocked by the repository's existing ESLint/plugin incompatibility: `scopeManager.addGlobals is not a function`