### PR TITLE
Fix shop category filters and layout alignment

### DIFF
--- a/src/pageComponents/shop/index.js
+++ b/src/pageComponents/shop/index.js
@@ -43,30 +43,59 @@ const formatCurrency = (value) =>
 
 const normalizeText = (value) => {
   if (value && typeof value === "object") {
-    return String(value.title || value.name || "").trim();
+    return String(
+      value.title ||
+        value.name ||
+        value.categoryTitle ||
+        value.subCategoryTitle ||
+        "",
+    ).trim();
   }
   return String(value || "").trim();
 };
 
-const extractCategory = (product) =>
-  normalizeText(
-    product?.category?.title ||
-      product?.categoryTitle ||
-      product?.categoryName ||
-      product?.category ||
-      product?.mainCategory ||
-      product?.productCategory,
-  ) || "Others";
+const isMongoObjectId = (value) => /^[a-f\d]{24}$/i.test(String(value || ""));
 
-const extractSubcategory = (product) =>
-  normalizeText(
+const buildTitleLookup = (items) =>
+  new Map(
+    items
+      .map((item) => [String(item?._id || item?.id || ""), normalizeText(item)])
+      .filter(([id, title]) => id && title),
+  );
+
+const extractCategory = (product, titleLookup = new Map()) => {
+  const value =
+    product?.category?.title ||
+    product?.categoryTitle ||
+    product?.categoryName ||
+    product?.category ||
+    product?.mainCategory ||
+    product?.productCategory;
+  const rawValue = normalizeText(value);
+  const id = String(value?._id || value?.id || rawValue);
+  return (
+    titleLookup.get(id) ||
+    (isMongoObjectId(rawValue) ? "" : rawValue) ||
+    "Others"
+  );
+};
+
+const extractSubcategory = (product, titleLookup = new Map()) => {
+  const value =
     product?.subcategory?.title ||
-      product?.subCategory?.title ||
-      product?.subCategoryName ||
-      product?.subCategory ||
-      product?.subcategory ||
-      product?.productSubCategory,
-  ) || "Others";
+    product?.subCategory?.title ||
+    product?.subCategoryName ||
+    product?.subCategory ||
+    product?.subcategory ||
+    product?.productSubCategory;
+  const rawValue = normalizeText(value);
+  const id = String(value?._id || value?.id || rawValue);
+  return (
+    titleLookup.get(id) ||
+    (isMongoObjectId(rawValue) ? "" : rawValue) ||
+    "Others"
+  );
+};
 
 const extractBrand = (product) =>
   normalizeText(
@@ -110,13 +139,13 @@ const isProductInStock = (product) => {
   return Number.isFinite(stock) ? stock > 0 : true;
 };
 
-const productSearchText = (product) =>
+const productSearchText = (product, categoryLookup, subcategoryLookup) =>
   [
     product?.title,
     product?.name,
     extractBrand(product),
-    extractCategory(product),
-    extractSubcategory(product),
+    extractCategory(product, categoryLookup),
+    extractSubcategory(product, subcategoryLookup),
     product?.application,
     product?.coverage,
     product?.capacity,
@@ -161,6 +190,15 @@ const AquaShopPageComponent = ({
   const [filters, setFilters] = useState(defaultFilters);
   const deferredQuery = useDeferredValue(filters.query.trim().toLowerCase());
 
+  const categoryTitleLookup = useMemo(
+    () => buildTitleLookup(initialCategories),
+    [initialCategories],
+  );
+  const subcategoryTitleLookup = useMemo(
+    () => buildTitleLookup(initialSubcategories),
+    [initialSubcategories],
+  );
+
   const fetchProducts = async () => {
     setLoading(true);
     setError("");
@@ -204,8 +242,8 @@ const AquaShopPageComponent = ({
     let maxPrice = 0;
 
     products.forEach((product) => {
-      const category = extractCategory(product);
-      const subcategory = extractSubcategory(product);
+      const category = extractCategory(product, categoryTitleLookup);
+      const subcategory = extractSubcategory(product, subcategoryTitleLookup);
       const brand = extractBrand(product);
       const price = extractPrice(product);
 
@@ -235,7 +273,13 @@ const AquaShopPageComponent = ({
         max: maxPrice,
       },
     };
-  }, [products, categoryTitlesFromProps, subcategoryTitlesFromProps]);
+  }, [
+    products,
+    categoryTitlesFromProps,
+    subcategoryTitlesFromProps,
+    categoryTitleLookup,
+    subcategoryTitleLookup,
+  ]);
 
   const filteredAndSortedProducts = useMemo(() => {
     const priceLimit =
@@ -244,19 +288,24 @@ const AquaShopPageComponent = ({
     const filtered = products.filter((product) => {
       if (
         deferredQuery &&
-        !productSearchText(product).includes(deferredQuery)
+        !productSearchText(
+          product,
+          categoryTitleLookup,
+          subcategoryTitleLookup,
+        ).includes(deferredQuery)
       ) {
         return false;
       }
       if (
         filters.category !== "All" &&
-        extractCategory(product) !== filters.category
+        extractCategory(product, categoryTitleLookup) !== filters.category
       ) {
         return false;
       }
       if (
         filters.subcategory !== "All" &&
-        extractSubcategory(product) !== filters.subcategory
+        extractSubcategory(product, subcategoryTitleLookup) !==
+          filters.subcategory
       ) {
         return false;
       }
@@ -303,7 +352,15 @@ const AquaShopPageComponent = ({
           return 0;
       }
     });
-  }, [products, filters, deferredQuery, derivedMeta.priceRange.max, sortBy]);
+  }, [
+    products,
+    filters,
+    deferredQuery,
+    derivedMeta.priceRange.max,
+    sortBy,
+    categoryTitleLookup,
+    subcategoryTitleLookup,
+  ]);
 
   const activeFilterChips = useMemo(() => {
     const chips = [];
@@ -466,7 +523,7 @@ const AquaShopPageComponent = ({
                 </aside>
 
                 <div className="min-w-0">
-                  <div className="sticky top-[76px] z-30 mb-5 rounded-[1.65rem] border border-white/80 bg-[rgba(248,252,251,0.92)] p-2.5 shadow-[0_18px_55px_rgba(15,23,42,0.09)] backdrop-blur-2xl sm:top-[92px] sm:p-3">
+                  <div className="sticky top-[76px] z-30 mb-10 rounded-[1.65rem] border border-white/80 bg-[rgba(248,252,251,0.96)] p-2.5 shadow-[0_18px_55px_rgba(15,23,42,0.09)] backdrop-blur-2xl sm:top-[92px] sm:p-3">
                     <div className="flex items-center gap-2.5">
                       <button
                         type="button"

--- a/src/pageComponents/shop/shopFilter.jsx
+++ b/src/pageComponents/shop/shopFilter.jsx
@@ -104,21 +104,21 @@ const ToggleRow = ({ checked, onChange, icon: Icon, title, description }) => (
     role="switch"
     aria-checked={checked}
     onClick={() => onChange(!checked)}
-    className={`flex w-full items-center gap-3 rounded-2xl border p-3 text-left transition ${
+    className={`grid min-h-[72px] w-full grid-cols-[36px_minmax(0,1fr)_44px] items-center gap-3 rounded-2xl border p-3 text-left transition ${
       checked
         ? "border-emerald-200 bg-emerald-50/90"
         : "border-slate-200/80 bg-white/70 hover:bg-white"
     }`}
   >
     <span
-      className={`grid h-9 w-9 shrink-0 place-items-center rounded-xl ${
+      className={`grid h-9 w-9 place-items-center rounded-xl ${
         checked ? "bg-emerald-500 text-white" : "bg-slate-100 text-slate-500"
       }`}
     >
       <Icon size={17} />
     </span>
-    <span className="min-w-0 flex-1">
-      <strong className="block text-xs font-black text-slate-900">
+    <span className="min-w-0 self-center">
+      <strong className="block text-xs font-black leading-4 text-slate-900">
         {title}
       </strong>
       <small className="mt-0.5 block text-[10px] leading-4 text-slate-500">
@@ -126,7 +126,7 @@ const ToggleRow = ({ checked, onChange, icon: Icon, title, description }) => (
       </small>
     </span>
     <span
-      className={`relative h-6 w-11 shrink-0 rounded-full transition ${
+      className={`relative h-6 w-11 justify-self-end rounded-full transition ${
         checked ? "bg-emerald-500" : "bg-slate-200"
       }`}
     >
@@ -217,7 +217,7 @@ const ShopFiltersPanel = ({
         ) : null}
       </div>
 
-      <div className="grid grid-cols-2 gap-2">
+      <div className="grid grid-cols-1 gap-2">
         <ToggleRow
           checked={filters.inStockOnly}
           onChange={(value) => onFilterChange("inStockOnly", value)}


### PR DESCRIPTION
## What changed

- Added category and subcategory lookup maps so product ObjectIds resolve to API-provided titles.
- Prevented unresolved MongoDB ObjectIds from appearing in filter labels.
- Increased clearance below the sticky search/sort toolbar so it does not overlap the collection heading.
- Reworked the stock and offers switches into consistently aligned full-width rows.

## Root causes

- Product records contain category references as ObjectIds, while the category APIs return `{ _id, title }`; both values were previously inserted directly into the filter set.
- Two complete toggle cards were forced into two narrow columns inside the desktop filter sidebar.
- The sticky toolbar needed additional visual spacing from the following catalogue heading.

## Validation

- Focused shop-filter tests: 3 passed.
- Next.js production build: passed, including `/shop` SSR compilation.
- `git diff --check`: passed.
- Repository-wide ESLint remains blocked by the existing ESLint/parser mismatch: `scopeManager.addGlobals is not a function`.