### PR TITLE
feat: render centrally managed SEO metadata

### DIFF
--- a/src/components/Layout/Layout.js
+++ b/src/components/Layout/Layout.js
@@ -13,6 +13,8 @@ import useNetworkStatus from "@/utils/connectivity";
 
 import CategoryServiceOperations from "@/services/category";
 import SubCategoryServiceOperations from "@/services/subcategory";
+import useManagedSeo from "@/hooks/useManagedSeo";
+import { getManagedSeoPageKey } from "@/utils/managedSeo";
 
 // Lazy client-only overlays (don’t hurt SSR/LCP)
 const AquaCartDrawer = dynamic(
@@ -69,6 +71,10 @@ const AquaLayout = (props) => {
 
     return next;
   }, [router.pathname]);
+  const managedSeo = useManagedSeo(
+    getManagedSeoPageKey(router.pathname),
+    props.managedSeo,
+  );
 
   // Mount overlays on first interaction OR after a short delay
   useEffect(() => {
@@ -197,6 +203,7 @@ const AquaLayout = (props) => {
   return (
     <>
       <AquaSeoRevamp
+        data={managedSeo || props.seo}
         path={seo.path}
         category={seo.category}
         categoryData={props?.categoryData}

--- a/src/components/Layout/seo/RefactoredSeo.js
+++ b/src/components/Layout/seo/RefactoredSeo.js
@@ -51,7 +51,7 @@ const AquaSeoRevamp = ({
   const baseUrl = process.env.NEXT_PUBLIC_URL || "https://aquakart.co.in";
 
   let metaData = data;
-  if (path && config[path]) {
+  if (!metaData && path && config[path]) {
     metaData = config[path];
   }
   if (product) {
@@ -121,6 +121,14 @@ const AquaSeoRevamp = ({
     description = "",
     follow = true,
     photos,
+    robots,
+    ogTitle,
+    ogDescription,
+    ogImage,
+    twitterTitle,
+    twitterDescription,
+    twitterImage,
+    schemaJson,
   } = metaData || {};
 
   const canonicalUrl = toAbsoluteUrl(
@@ -129,6 +137,9 @@ const AquaSeoRevamp = ({
   );
   const photoCandidates = collectImages(photos);
   const primaryImage = photoCandidates[0] || DEFAULT_LOGO;
+  const socialImage = ogImage || primaryImage;
+  const twitterSocialImage = twitterImage || socialImage;
+  const safeJson = (value) => JSON.stringify(value).replace(/</g, "\\u003c");
 
   // Determine og:type based on page context
   const ogType = blogPage ? "article" : product ? "product" : "website";
@@ -519,28 +530,40 @@ const AquaSeoRevamp = ({
             <meta name="keyphrases" content={keyphrases} />
             <meta
               name="robots"
-              content={`index, ${follow ? "follow" : "nofollow"}, max-image-preview:large, max-snippet:-1, max-video-preview:-1`}
+              content={
+                robots ||
+                `index, ${follow ? "follow" : "nofollow"}, max-image-preview:large, max-snippet:-1, max-video-preview:-1`
+              }
             />
             <meta property="og:type" content={ogType} />
             <meta property="og:site_name" content="Aquakart" />
             <meta property="og:locale" content="en_IN" />
             <meta property="og:url" content={canonicalUrl} />
-            <meta property="og:title" content={title} />
-            <meta property="og:description" content={description} />
-            {primaryImage && (
-              <meta property="og:image" content={primaryImage} />
-            )}
+            <meta property="og:title" content={ogTitle || title} />
+            <meta
+              property="og:description"
+              content={ogDescription || description}
+            />
+            {socialImage && <meta property="og:image" content={socialImage} />}
             <meta property="og:image:width" content="1200" />
             <meta property="og:image:height" content="630" />
-            {primaryImage && <meta property="og:image:alt" content={title} />}
+            {socialImage && (
+              <meta property="og:image:alt" content={ogTitle || title} />
+            )}
             <meta name="twitter:card" content="summary_large_image" />
             <meta name="twitter:site" content="@aquakart8" />
             <meta name="twitter:creator" content="@aquakart8" />
             <meta name="twitter:url" content={canonicalUrl} />
-            <meta name="twitter:title" content={title} />
-            <meta name="twitter:description" content={description} />
-            {primaryImage && (
-              <meta name="twitter:image" content={primaryImage} />
+            <meta
+              name="twitter:title"
+              content={twitterTitle || ogTitle || title}
+            />
+            <meta
+              name="twitter:description"
+              content={twitterDescription || ogDescription || description}
+            />
+            {twitterSocialImage && (
+              <meta name="twitter:image" content={twitterSocialImage} />
             )}
             <meta name="author" content="Aquakart" />
             <meta httpEquiv="content-language" content="en" />
@@ -551,11 +574,17 @@ const AquaSeoRevamp = ({
           <script
             type="application/ld+json"
             dangerouslySetInnerHTML={{
-              __html: JSON.stringify({
+              __html: safeJson({
                 "@context": "https://schema.org",
                 "@graph": graphNodes,
               }),
             }}
+          />
+        )}
+        {schemaJson && (
+          <script
+            type="application/ld+json"
+            dangerouslySetInnerHTML={{ __html: safeJson(schemaJson) }}
           />
         )}
       </Head>

--- a/src/hooks/useManagedSeo.js
+++ b/src/hooks/useManagedSeo.js
@@ -1,0 +1,21 @@
+import { useEffect, useState } from "react";
+
+import { getManagedSeo } from "@/services/seo";
+
+export default function useManagedSeo(pageKey, initialValue = null) {
+  const [seo, setSeo] = useState(initialValue);
+
+  useEffect(() => {
+    setSeo(initialValue);
+    if (!pageKey || initialValue) return undefined;
+
+    const controller = new AbortController();
+    getManagedSeo(pageKey, { signal: controller.signal })
+      .then((value) => value && setSeo(value))
+      .catch(() => undefined);
+
+    return () => controller.abort();
+  }, [initialValue, pageKey]);
+
+  return seo;
+}

--- a/src/pageComponents/blogs/index.js
+++ b/src/pageComponents/blogs/index.js
@@ -122,7 +122,11 @@ const ArticleCard = ({ post }) => (
   </Link>
 );
 
-const AquaBlogComponent = ({ initialBlogs = [], initialError = "" }) => {
+const AquaBlogComponent = ({
+  initialBlogs = [],
+  initialError = "",
+  managedSeo = null,
+}) => {
   const router = useRouter();
   const [blogs, setBlogs] = useState(initialBlogs);
   const [query, setQuery] = useState("");
@@ -190,7 +194,7 @@ const AquaBlogComponent = ({ initialBlogs = [], initialError = "" }) => {
   };
 
   return (
-    <AquaLayout seo={seoData} blogListData={blogs}>
+    <AquaLayout seo={seoData} blogListData={blogs} managedSeo={managedSeo}>
       <main className={styles.page}>
         <div className={styles.shell}>
           <header className={styles.hero}>

--- a/src/pageComponents/home/index.js
+++ b/src/pageComponents/home/index.js
@@ -78,6 +78,7 @@ const needCards = [
 const AquaHomeComponent = ({
   initialCategories = [],
   initialProducts = [],
+  managedSeo = null,
 }) => {
   const router = useRouter();
   const seoData = {
@@ -94,7 +95,7 @@ const AquaHomeComponent = ({
   };
 
   return (
-    <AquaLayout seo={seoData}>
+    <AquaLayout seo={seoData} managedSeo={managedSeo}>
       <div className={styles.page}>
         <div className={styles.shell}>
           <AquaHomeHero data={initialCategories} />

--- a/src/pageComponents/shop/index.js
+++ b/src/pageComponents/shop/index.js
@@ -180,6 +180,7 @@ const AquaShopPageComponent = ({
   initialError = "",
   initialCategories = [],
   initialSubcategories = [],
+  managedSeo = null,
 }) => {
   const [products, setProducts] = useState(initialProducts);
   const [loading, setLoading] = useState(false);
@@ -446,7 +447,11 @@ const AquaShopPageComponent = ({
   );
 
   return (
-    <AquaLayout path="shop" productListData={schemaProducts}>
+    <AquaLayout
+      path="shop"
+      productListData={schemaProducts}
+      managedSeo={managedSeo}
+    >
       {loading ? (
         <AquaAppLoader
           variant="screen"

--- a/src/pages/blogs.js
+++ b/src/pages/blogs.js
@@ -1,24 +1,30 @@
 import AquaBlogComponnet from "@/pageComponents/blogs";
 import BlogServiceOperations from "@/services/blog";
+import { getManagedSeoServerSide } from "@/services/seo";
 
-const AquaBlogIndex = ({ initialBlogs, initialError }) => {
+const AquaBlogIndex = ({ initialBlogs, initialError, managedSeo }) => {
   return (
     <AquaBlogComponnet
       initialBlogs={initialBlogs}
       initialError={initialError}
+      managedSeo={managedSeo}
     />
   );
 };
 
 export const getServerSideProps = async () => {
   try {
-    const response = await BlogServiceOperations.AllBlogs();
+    const [response, managedSeo] = await Promise.all([
+      BlogServiceOperations.AllBlogs(),
+      getManagedSeoServerSide("blogs"),
+    ]);
     const blogs = Array.isArray(response?.data?.data) ? response.data.data : [];
 
     return {
       props: {
         initialBlogs: blogs,
         initialError: "",
+        managedSeo,
       },
     };
   } catch (error) {
@@ -28,6 +34,7 @@ export const getServerSideProps = async () => {
       props: {
         initialBlogs: [],
         initialError: "Unable to load blogs at the moment. Please try again.",
+        managedSeo: await getManagedSeoServerSide("blogs"),
       },
     };
   }

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,6 +1,7 @@
 import AquaHomeComponent from "@/pageComponents/home";
 import CategoryServiceOperations from "@/services/category";
 import ProductServiceOperations from "@/services/products";
+import { getManagedSeoServerSide } from "@/services/seo";
 
 const AquaHomePage = (props) => {
   return (
@@ -17,15 +18,17 @@ export async function getServerSideProps({ res }) {
   );
 
   try {
-    const [categoriesRes, productsRes] = await Promise.all([
+    const [categoriesRes, productsRes, managedSeo] = await Promise.all([
       CategoryServiceOperations.Allcategories(),
       ProductServiceOperations.AllProducts(),
+      getManagedSeoServerSide("home"),
     ]);
 
     return {
       props: {
         initialCategories: categoriesRes.data?.data || [],
         initialProducts: productsRes.data?.data || [],
+        managedSeo,
       },
     };
   } catch (error) {
@@ -34,6 +37,7 @@ export async function getServerSideProps({ res }) {
       props: {
         initialCategories: [],
         initialProducts: [],
+        managedSeo: await getManagedSeoServerSide("home"),
       },
     };
   }

--- a/src/pages/shop.js
+++ b/src/pages/shop.js
@@ -2,12 +2,14 @@ import AquaShopComponent from "@/pageComponents/shop";
 import ProductServiceOperations from "@/services/products";
 import CategoryServiceOperations from "@/services/category";
 import SubCategoryServiceOperations from "@/services/subcategory";
+import { getManagedSeoServerSide } from "@/services/seo";
 
 const AquaShop = ({
   products = [],
   error = "",
   categories = [],
   subcategories = [],
+  managedSeo = null,
 }) => {
   return (
     <AquaShopComponent
@@ -15,6 +17,7 @@ const AquaShop = ({
       initialError={error}
       initialCategories={categories}
       initialSubcategories={subcategories}
+      managedSeo={managedSeo}
     />
   );
 };
@@ -26,18 +29,26 @@ export const getServerSideProps = async () => {
       return {
         props: {
           products: [],
+          categories: [],
+          subcategories: [],
+          managedSeo: await getManagedSeoServerSide("shop"),
           error:
             "Shop catalogue is temporarily unavailable. Please try again soon.",
         },
       };
     }
 
-    const [productsResponse, categoriesResponse, subcategoriesResponse] =
-      await Promise.all([
-        ProductServiceOperations.AllProducts(),
-        CategoryServiceOperations.Allcategories().catch(() => null),
-        SubCategoryServiceOperations.AllSubcategories().catch(() => null),
-      ]);
+    const [
+      productsResponse,
+      categoriesResponse,
+      subcategoriesResponse,
+      managedSeo,
+    ] = await Promise.all([
+      ProductServiceOperations.AllProducts(),
+      CategoryServiceOperations.Allcategories().catch(() => null),
+      SubCategoryServiceOperations.AllSubcategories().catch(() => null),
+      getManagedSeoServerSide("shop"),
+    ]);
 
     const products = Array.isArray(productsResponse?.data?.data)
       ? productsResponse.data.data
@@ -54,6 +65,7 @@ export const getServerSideProps = async () => {
         products,
         categories,
         subcategories,
+        managedSeo,
         error:
           products.length === 0 ? "No products available at the moment." : "",
       },
@@ -65,6 +77,7 @@ export const getServerSideProps = async () => {
         products: [],
         categories: [],
         subcategories: [],
+        managedSeo: await getManagedSeoServerSide("shop"),
         error:
           "We couldn’t load the catalogue. Please refresh the page or visit later.",
       },

--- a/src/services/seo.js
+++ b/src/services/seo.js
@@ -1,0 +1,23 @@
+import axios from "axios";
+
+import { normalizeManagedSeo } from "@/utils/managedSeo";
+
+const API_BASE =
+  process.env.NEXT_PUBLIC_API_URL || "https://api.aquakart.co.in/v1";
+
+export const getManagedSeo = async (pageKey, config = {}) => {
+  if (!pageKey) return null;
+  const response = await axios.get(
+    `${API_BASE}/seo/public/${encodeURIComponent(pageKey)}`,
+    config,
+  );
+  return normalizeManagedSeo(response?.data?.data);
+};
+
+export const getManagedSeoServerSide = async (pageKey) => {
+  try {
+    return await getManagedSeo(pageKey, { timeout: 3000 });
+  } catch {
+    return null;
+  }
+};

--- a/src/utils/managedSeo.js
+++ b/src/utils/managedSeo.js
@@ -1,0 +1,40 @@
+const STATIC_PAGE_KEYS = {
+  "/": "home",
+  "/shop": "shop",
+  "/blogs": "blogs",
+  "/categories": "categories",
+  "/about": "about",
+  "/contact-us": "contact-us",
+  "/compare": "compare",
+  "/privacy-policy": "privacy-policy",
+  "/terms-and-conditions": "terms-and-conditions",
+  "/shipping-policy": "shipping-policy",
+  "/softener-planner": "softener-planner",
+  "/softeners-hyderabad": "softeners-hyderabad",
+};
+
+export const getManagedSeoPageKey = (pathname = "") =>
+  STATIC_PAGE_KEYS[pathname] || null;
+
+export const normalizeManagedSeo = (record) => {
+  if (!record || record.active === false) return null;
+
+  return {
+    title: record.title,
+    description: record.description,
+    keywords: Array.isArray(record.keywords)
+      ? record.keywords.join(", ")
+      : record.keywords || "",
+    url: record.canonicalUrl || record.route,
+    photos: record.ogImage || record.twitterImage,
+    robots: record.robots,
+    ogTitle: record.ogTitle,
+    ogDescription: record.ogDescription,
+    ogImage: record.ogImage,
+    twitterTitle: record.twitterTitle,
+    twitterDescription: record.twitterDescription,
+    twitterImage: record.twitterImage,
+    schemaJson: record.schemaJson,
+    follow: !String(record.robots || "").includes("nofollow"),
+  };
+};

--- a/src/utils/managedSeo.test.js
+++ b/src/utils/managedSeo.test.js
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import { getManagedSeoPageKey, normalizeManagedSeo } from "./managedSeo";
+
+describe("managed SEO", () => {
+  it("maps only supported static routes", () => {
+    expect(getManagedSeoPageKey("/")).toBe("home");
+    expect(getManagedSeoPageKey("/shop")).toBe("shop");
+    expect(getManagedSeoPageKey("/product/[slug]")).toBeNull();
+  });
+
+  it("normalizes the backend contract for the SEO renderer", () => {
+    expect(
+      normalizeManagedSeo({
+        active: true,
+        title: "Aquakart",
+        keywords: ["water", "softener"],
+        canonicalUrl: "https://aquakart.co.in/shop",
+        ogImage: "https://example.com/social.jpg",
+      }),
+    ).toMatchObject({
+      title: "Aquakart",
+      keywords: "water, softener",
+      url: "https://aquakart.co.in/shop",
+      photos: "https://example.com/social.jpg",
+    });
+  });
+
+  it("ignores inactive records", () => {
+    expect(normalizeManagedSeo({ active: false })).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- consume the public centralized SEO endpoint with hardcoded metadata fallback
- server-render managed SEO for home, shop, and blogs
- client-load managed SEO for supported static routes
- preserve product, category, subcategory, and blog-detail metadata precedence
- render robots, canonical, Open Graph, Twitter, and safely escaped custom JSON-LD
- add route mapping and normalization tests

## Dependency
Depends on backend API in SVSKHD/AQUAKARTBACKEND#29.

## Validation
- targeted Vitest — 3/3 passed
- production `next build --turbopack` — passed
- ESLint is blocked by the repository's current ESLint/parser version mismatch (`scopeManager.addGlobals is not a function`)