### PR TITLE
Stop find-invoice from hanging during session checks

### DIFF
--- a/src/features/invoiceDiscovery/flow.js
+++ b/src/features/invoiceDiscovery/flow.js
@@ -183,3 +183,11 @@ export const validateDeliveryEmail = (value) =>
   isValidInvoiceEmail(value)
     ? ""
     : "Enter a valid email address for this delivery.";
+
+export const shouldShowInvoiceAuthLoader = ({
+  authReady,
+  authGateExpired,
+  phase,
+}) =>
+  phase === INVOICE_FLOW_PHASE.AUTHENTICATING ||
+  (!authReady && !authGateExpired);

--- a/src/features/invoiceDiscovery/flow.test.js
+++ b/src/features/invoiceDiscovery/flow.test.js
@@ -5,6 +5,7 @@ import {
   getInvoiceEmailScenario,
   INVOICE_FLOW_PHASE,
   invoiceFlowReducer,
+  shouldShowInvoiceAuthLoader,
   validateDeliveryEmail,
 } from "./flow";
 
@@ -85,5 +86,29 @@ describe("invoice discovery state model", () => {
       { type: "SEND_START" },
     );
     expect(state.phase).toBe(INVOICE_FLOW_PHASE.SENDING);
+  });
+
+  it("stops blocking the invoice page when session restoration is slow", () => {
+    expect(
+      shouldShowInvoiceAuthLoader({
+        authReady: false,
+        authGateExpired: false,
+        phase: INVOICE_FLOW_PHASE.AUTH_REQUIRED,
+      }),
+    ).toBe(true);
+    expect(
+      shouldShowInvoiceAuthLoader({
+        authReady: false,
+        authGateExpired: true,
+        phase: INVOICE_FLOW_PHASE.AUTH_REQUIRED,
+      }),
+    ).toBe(false);
+    expect(
+      shouldShowInvoiceAuthLoader({
+        authReady: true,
+        authGateExpired: true,
+        phase: INVOICE_FLOW_PHASE.AUTHENTICATING,
+      }),
+    ).toBe(true);
   });
 });

--- a/src/pages/find-invoice.js
+++ b/src/pages/find-invoice.js
@@ -1,7 +1,7 @@
 import Head from "next/head";
 import Link from "next/link";
 import { useRouter } from "next/router";
-import { useCallback, useEffect, useReducer, useRef } from "react";
+import { useCallback, useEffect, useReducer, useRef, useState } from "react";
 import {
   ArrowLeft,
   ArrowRight,
@@ -28,6 +28,7 @@ import {
   findRequestedInvoice,
   INVOICE_FLOW_PHASE,
   invoiceFlowReducer,
+  shouldShowInvoiceAuthLoader,
   validateDeliveryEmail,
 } from "@/features/invoiceDiscovery/flow";
 import { getCurrentFirebaseIdToken } from "@/services/googleAuth";
@@ -38,6 +39,7 @@ import styles from "@/styles/find-invoice.module.css";
 
 const LOOKUP_STORAGE_KEY = "aquakart_invoice_lookup_phone";
 const AUTH_UI_TIMEOUT_MS = 8_000;
+const AUTH_GATE_TIMEOUT_MS = 1_500;
 
 const isValidLookupPhone = (phone) => /^[6-9]\d{9}$/.test(phone);
 
@@ -127,12 +129,26 @@ const FindInvoicePage = () => {
     invoiceFlowReducer,
     createInitialInvoiceFlow(),
   );
+  const [authGateExpired, setAuthGateExpired] = useState(false);
   const mutationInFlight = useRef(false);
   const sendInFlight = useRef(false);
   const lookupInFlight = useRef(false);
   const lookupHydrated = useRef(false);
   const pendingPrefilledLookup = useRef(false);
   const lastAutoLookupKey = useRef("");
+
+  useEffect(() => {
+    if (authReady) {
+      setAuthGateExpired(false);
+      return undefined;
+    }
+
+    const timeout = window.setTimeout(
+      () => setAuthGateExpired(true),
+      AUTH_GATE_TIMEOUT_MS,
+    );
+    return () => window.clearTimeout(timeout);
+  }, [authReady]);
 
   useEffect(() => {
     if (!router.isReady || lookupHydrated.current) return;
@@ -288,7 +304,6 @@ const FindInvoicePage = () => {
 
   const authenticate = async (accountSwitch = false) => {
     if (
-      authLoading ||
       lookupInFlight.current ||
       flow.phase === INVOICE_FLOW_PHASE.AUTHENTICATING
     ) {
@@ -461,8 +476,11 @@ const FindInvoicePage = () => {
 
   const isSearching = flow.phase === INVOICE_FLOW_PHASE.SEARCHING;
   const phoneIsValid = isValidLookupPhone(flow.phone);
-  const isAuthenticating =
-    flow.phase === INVOICE_FLOW_PHASE.AUTHENTICATING || !authReady;
+  const isAuthenticating = shouldShowInvoiceAuthLoader({
+    authReady,
+    authGateExpired,
+    phase: flow.phase,
+  });
   const showLookup = [
     INVOICE_FLOW_PHASE.LOOKUP,
     INVOICE_FLOW_PHASE.SEARCHING,
@@ -532,6 +550,12 @@ const FindInvoicePage = () => {
                     Continue with Google before searching. This prevents invoice
                     details from being exposed through phone-number guesses.
                   </p>
+                  {!authReady && authGateExpired ? (
+                    <p className={styles.formNotice} role="status">
+                      The saved-session check is taking longer than expected.
+                      You can still continue with Google now.
+                    </p>
+                  ) : null}
                   {flow.error ? (
                     <p className={styles.formError} role="alert">
                       {flow.error}

--- a/src/styles/find-invoice.module.css
+++ b/src/styles/find-invoice.module.css
@@ -365,6 +365,18 @@
   line-height: 1.5;
 }
 
+.formNotice {
+  margin: 14px 0 0;
+  padding: 11px 13px;
+  border: 1px solid #cde1db;
+  border-radius: 11px;
+  background: rgba(235, 249, 244, 0.72);
+  color: #36645a;
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 1.5;
+}
+
 .spinner {
   animation: spin 750ms linear infinite;
 }


### PR DESCRIPTION
## What changed

- Limited the blocking saved-session check on the Find Invoice page to 1.5 seconds.
- Shows the Google sign-in screen when background Firebase restoration is slow instead of leaving the page on an indefinite loader.
- Allows users to begin Google authentication without waiting for the global restore process to time out.
- Keeps the existing phone number and authenticated auto-lookup flow intact.
- Added a clear slow-session notice and regression coverage for the auth gate.

## Root cause

The page treated `!authReady` as an active authentication operation. The global auth provider can spend up to 12 seconds restoring Firebase/backend state, so signed-out visitors saw only the account-check loader and could not access the sign-in action.

## Security

This changes only the UI gate. Invoice lookup remains protected by the Firebase ID token and backend session token.

## Validation

- `npm test` — 23 files / 85 tests passed
- `npm run build` — production build passed
- Prettier and `git diff --check` passed