### PR TITLE
Fix authenticated invoice lookup timeouts

### DIFF
--- a/src/pages/api/invoice-access/login.js
+++ b/src/pages/api/invoice-access/login.js
@@ -1,6 +1,7 @@
 import {
   backendInvoiceRequest,
   invoiceAccessCookie,
+  isInvoiceBackendTimeout,
   isSameOriginRequest,
 } from "@/utils/server/invoiceAccess";
 
@@ -54,7 +55,13 @@ export default async function handler(req, res) {
       user: payload.user,
       message: payload.message,
     });
-  } catch {
+  } catch (error) {
+    if (isInvoiceBackendTimeout(error)) {
+      return res.status(504).json({
+        success: false,
+        message: "Invoice lookup took too long. Please retry in a few seconds.",
+      });
+    }
     return res
       .status(502)
       .json({ success: false, message: "Invoice service is unavailable" });

--- a/src/pages/find-invoice.js
+++ b/src/pages/find-invoice.js
@@ -102,6 +102,10 @@ const friendlyAuthError = (error) => {
 };
 
 const lookupFailureMessage = (error) => {
+  if (error?.code === "ECONNABORTED") {
+    return "Invoice lookup took too long. Please retry in a few seconds.";
+  }
+
   if (error?.response?.status === 401) {
     return (
       error?.response?.data?.message ||
@@ -111,6 +115,9 @@ const lookupFailureMessage = (error) => {
 
   return (
     error?.response?.data?.message ||
+    (error?.response?.status === 429
+      ? "Too many invoice searches. Please wait a few minutes and retry."
+      : "") ||
     "We could not check your invoices right now. Please try again."
   );
 };

--- a/src/services/invoice.js
+++ b/src/services/invoice.js
@@ -1,6 +1,6 @@
 import axios from "axios";
 
-export const INVOICE_REQUEST_TIMEOUT_MS = 6_000;
+export const INVOICE_REQUEST_TIMEOUT_MS = 15_000;
 
 const invoiceRequest = (config) =>
   axios({ timeout: INVOICE_REQUEST_TIMEOUT_MS, ...config });

--- a/src/services/invoice.test.js
+++ b/src/services/invoice.test.js
@@ -2,11 +2,18 @@ import { describe, expect, it } from "vitest";
 
 import {
   directInvoiceLoginPath,
+  INVOICE_REQUEST_TIMEOUT_MS,
   invoiceByIdPath,
   isValidInvoiceEmail,
   normalizeInvoiceEmail,
   normalizeInvoicePhone,
 } from "./invoice";
+
+describe("invoice request timing", () => {
+  it("allows the authenticated backend lookup enough time to finish", () => {
+    expect(INVOICE_REQUEST_TIMEOUT_MS).toBeGreaterThanOrEqual(12_000);
+  });
+});
 
 describe("normalizeInvoicePhone", () => {
   it("normalizes Indian country codes and formatting", () => {

--- a/src/utils/server/invoiceAccess.js
+++ b/src/utils/server/invoiceAccess.js
@@ -1,4 +1,5 @@
 export const INVOICE_ACCESS_COOKIE = "aquakart_invoice_access";
+export const INVOICE_BACKEND_TIMEOUT_MS = 12_000;
 
 export const getInvoiceApiBase = () =>
   (
@@ -7,15 +8,30 @@ export const getInvoiceApiBase = () =>
     "https://api.aquakart.co.in/v1"
   ).replace(/\/$/, "");
 
-export const backendInvoiceRequest = async (path, options = {}) =>
-  fetch(`${getInvoiceApiBase()}/invoices/public${path}`, {
-    ...options,
-    headers: {
-      Accept: "application/json",
-      ...(options.body ? { "Content-Type": "application/json" } : {}),
-      ...options.headers,
-    },
-  });
+export const backendInvoiceRequest = async (path, options = {}) => {
+  const controller = new AbortController();
+  const timeout = setTimeout(
+    () => controller.abort(),
+    INVOICE_BACKEND_TIMEOUT_MS,
+  );
+
+  try {
+    return await fetch(`${getInvoiceApiBase()}/invoices/public${path}`, {
+      ...options,
+      signal: options.signal || controller.signal,
+      headers: {
+        Accept: "application/json",
+        ...(options.body ? { "Content-Type": "application/json" } : {}),
+        ...options.headers,
+      },
+    });
+  } finally {
+    clearTimeout(timeout);
+  }
+};
+
+export const isInvoiceBackendTimeout = (error) =>
+  error?.name === "AbortError" || error?.name === "TimeoutError";
 
 export const pipeJsonResponse = async (response, res) => {
   res.setHeader("Cache-Control", "private, no-store, max-age=0");

--- a/src/utils/server/invoiceAccess.test.js
+++ b/src/utils/server/invoiceAccess.test.js
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it } from "vitest";
 
-import { invoiceAccessCookie } from "./invoiceAccess";
+import { invoiceAccessCookie, isInvoiceBackendTimeout } from "./invoiceAccess";
 
 const originalEnvironment = process.env.NODE_ENV;
 
@@ -20,5 +20,13 @@ describe("invoiceAccessCookie", () => {
   it("adds Secure in production", () => {
     process.env.NODE_ENV = "production";
     expect(invoiceAccessCookie("token")).toContain("Secure");
+  });
+});
+
+describe("invoice backend timeout detection", () => {
+  it("recognizes aborted and platform timeout requests", () => {
+    expect(isInvoiceBackendTimeout({ name: "AbortError" })).toBe(true);
+    expect(isInvoiceBackendTimeout({ name: "TimeoutError" })).toBe(true);
+    expect(isInvoiceBackendTimeout(new Error("network error"))).toBe(false);
   });
 });


### PR DESCRIPTION
## What changed

- Increased the browser-side invoice request budget from 6 seconds to 15 seconds.
- Added a 12-second abort boundary to the Next.js invoice BFF backend call.
- Returns a clear 504 timeout response instead of leaving the lookup unresolved.
- Distinguishes lookup timeout, backend unavailability, authentication expiry, and rate limiting in the Find Invoice UI.
- Added regression tests for the client request budget and backend timeout detection.

## Root cause

The authenticated lookup performs Firebase revocation verification, backend-session validation, user lookup, invoice lookup (including a legacy phone-field fallback), and ownership processing. The browser aborted the same-origin request after 6 seconds, before the complete chain could reliably finish, producing the generic error shown in the UI.

A true no-match is not an error: the backend returns HTTP 200 with `found: false`. The screenshot therefore represents a request failure/timeout, not a missing invoice.

## Validation

- `npm test` — 24 files / 90 tests passed
- `npm run build` — production build passed
- Prettier and `git diff --check` passed