### PR TITLE
Display stored total_price on Find Invoice

### DIFF
--- a/src/pages/find-invoice.js
+++ b/src/pages/find-invoice.js
@@ -73,11 +73,13 @@ const clearStoredLookupPhone = () => {
 };
 
 const money = (value) =>
-  new Intl.NumberFormat("en-IN", {
-    style: "currency",
-    currency: "INR",
-    maximumFractionDigits: 0,
-  }).format(Number(value) || 0);
+  value === null || value === undefined || !Number.isFinite(Number(value))
+    ? "Amount unavailable"
+    : new Intl.NumberFormat("en-IN", {
+        style: "currency",
+        currency: "INR",
+        maximumFractionDigits: 0,
+      }).format(Number(value));
 
 const date = (value) => {
   const parsed = new Date(value);
@@ -691,7 +693,7 @@ const FindInvoicePage = () => {
                           </span>
                         </div>
                         <strong className={styles.invoiceTotal}>
-                          {money(invoice.total)}
+                          {money(invoice.total_price)}
                         </strong>
                         <div className={styles.purchaseMeta}>
                           <span>


### PR DESCRIPTION
## What changed

- Find Invoice now displays `invoice.total_price` from the backend response directly.
- Removed use of the previous generic `invoice.total` summary field.
- A missing or invalid `total_price` displays “Amount unavailable” instead of calculating a value or silently showing ₹0.

## Dependency

Merge and deploy backend PR `SVSKHD/AQUAKARTBACKEND#30` first so invoice summaries provide the new `total_price` contract.

## Validation

- `npm test` — 24 files / 90 tests passed
- Prettier and `git diff --check` passed