### PR TITLE
Make invoice email and WhatsApp delivery functional

### DIFF
--- a/src/components/invoice/InvoiceShareDialog.jsx
+++ b/src/components/invoice/InvoiceShareDialog.jsx
@@ -33,6 +33,7 @@ const InvoiceShareDialog = ({
   onDeliveryEmailChange,
   onSend,
   onWhatsApp,
+  whatsappSending,
 }) => {
   const scenario = getInvoiceEmailScenario(invoice);
   const busy = [
@@ -234,10 +235,14 @@ const InvoiceShareDialog = ({
                         type="button"
                         className={styles.whatsappButton}
                         onClick={onWhatsApp}
-                        disabled={busy}
+                        disabled={busy || whatsappSending}
                       >
-                        <MessageCircle /> WhatsApp
-                        <small>Coming soon</small>
+                        {whatsappSending ? (
+                          <Loader2 className={styles.spinner} />
+                        ) : (
+                          <MessageCircle />
+                        )}
+                        {whatsappSending ? "Sending…" : "Send on WhatsApp"}
                       </button>
                     </div>
 

--- a/src/components/invoice/InvoiceShareDialog.test.jsx
+++ b/src/components/invoice/InvoiceShareDialog.test.jsx
@@ -24,6 +24,7 @@ const baseProps = {
   onDeliveryEmailChange: vi.fn(),
   onSend: vi.fn(),
   onWhatsApp: vi.fn(),
+  whatsappSending: false,
 };
 
 describe("InvoiceShareDialog", () => {
@@ -90,7 +91,9 @@ describe("InvoiceShareDialog", () => {
     expect(
       screen.getByRole("button", { name: /whatsapp/i }),
     ).toBeInTheDocument();
-    expect(screen.getByText(/coming soon/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /send on whatsapp/i }),
+    ).toBeEnabled();
   });
 
   it("disables sharing while an email request is active", () => {
@@ -110,5 +113,23 @@ describe("InvoiceShareDialog", () => {
     expect(
       screen.getByRole("button", { name: /sending invoice/i }),
     ).toBeDisabled();
+  });
+
+  it("shows a dedicated WhatsApp sending state", () => {
+    render(
+      <InvoiceShareDialog
+        {...baseProps}
+        phase={INVOICE_FLOW_PHASE.READY}
+        whatsappSending
+        invoice={{
+          ...baseProps.invoice,
+          emailStatus: "matches",
+          claimRequired: false,
+          canView: true,
+        }}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: /sending/i })).toBeDisabled();
   });
 });

--- a/src/pages/api/invoice-access/[id]/share/whatsapp.js
+++ b/src/pages/api/invoice-access/[id]/share/whatsapp.js
@@ -5,8 +5,8 @@ import {
 } from "@/utils/server/invoiceAccess";
 
 export default async function handler(req, res) {
-  if (req.method !== "GET") {
-    res.setHeader("Allow", "GET");
+  if (!["GET", "POST"].includes(req.method)) {
+    res.setHeader("Allow", "GET, POST");
     return res
       .status(405)
       .json({ success: false, message: "Method not allowed" });
@@ -20,13 +20,19 @@ export default async function handler(req, res) {
   try {
     const response = await backendInvoiceRequest(
       `/${encodeURIComponent(String(req.query.id || ""))}/share/whatsapp`,
-      { headers: { Authorization: `Bearer ${token}` } },
+      {
+        method: req.method,
+        headers: { Authorization: `Bearer ${token}` },
+      },
     );
     return pipeJsonResponse(response, res);
   } catch {
     return res.status(502).json({
       success: false,
-      message: "WhatsApp sharing status is unavailable",
+      message:
+        req.method === "POST"
+          ? "WhatsApp delivery is unavailable"
+          : "WhatsApp sharing status is unavailable",
     });
   }
 }

--- a/src/pages/find-invoice.js
+++ b/src/pages/find-invoice.js
@@ -139,6 +139,7 @@ const FindInvoicePage = () => {
     createInitialInvoiceFlow(),
   );
   const [authGateExpired, setAuthGateExpired] = useState(false);
+  const [whatsappSending, setWhatsappSending] = useState(false);
   const mutationInFlight = useRef(false);
   const sendInFlight = useRef(false);
   const lookupInFlight = useRef(false);
@@ -440,6 +441,7 @@ const FindInvoicePage = () => {
         type: "SEND_SUCCESS",
         message: payload.message || "Invoice emailed successfully.",
       });
+      toast.success(payload.message || "Invoice emailed successfully.");
     } catch (error) {
       dispatch({
         type: "FAILURE",
@@ -454,18 +456,23 @@ const FindInvoicePage = () => {
     }
   };
 
-  const showWhatsAppStatus = async () => {
-    if (!flow.selectedInvoice) return;
+  const sendInvoiceOnWhatsApp = async () => {
+    if (!flow.selectedInvoice || whatsappSending) return;
+    setWhatsappSending(true);
     try {
-      const payload = await InvoiceServiceOperations.getWhatsAppSharingStatus(
+      const payload = await InvoiceServiceOperations.shareInvoiceByWhatsApp(
         flow.selectedInvoice.id,
       );
-      toast.info(
-        payload.whatsapp?.message ||
-          "WhatsApp invoice sharing will be available soon.",
+      toast.success(
+        payload.message || "Invoice sent on WhatsApp successfully.",
       );
-    } catch {
-      toast.info("WhatsApp invoice sharing will be available soon.");
+    } catch (error) {
+      toast.error(
+        error?.response?.data?.message ||
+          "We could not send the invoice on WhatsApp right now.",
+      );
+    } finally {
+      setWhatsappSending(false);
     }
   };
 
@@ -739,7 +746,8 @@ const FindInvoicePage = () => {
           dispatch({ type: "DELIVERY_EMAIL_CHANGE", email })
         }
         onSend={sendInvoice}
-        onWhatsApp={showWhatsAppStatus}
+        onWhatsApp={sendInvoiceOnWhatsApp}
+        whatsappSending={whatsappSending}
       />
     </AquaLayout>
   );

--- a/src/services/invoice.js
+++ b/src/services/invoice.js
@@ -153,6 +153,14 @@ const getWhatsAppSharingStatus = async (invoiceId) => {
   return response.data;
 };
 
+const shareInvoiceByWhatsApp = async (invoiceId) => {
+  const response = await invoiceRequest({
+    method: "post",
+    url: `/invoice-gateway/${encodeURIComponent(invoiceId)}/share/whatsapp`,
+  });
+  return response.data;
+};
+
 const InvoiceServiceOperations = {
   lookupInvoices,
   requestInvoiceAccess,
@@ -166,6 +174,7 @@ const InvoiceServiceOperations = {
   updateInvoiceEmail,
   shareInvoiceByEmail,
   getWhatsAppSharingStatus,
+  shareInvoiceByWhatsApp,
 };
 
 export default InvoiceServiceOperations;


### PR DESCRIPTION
## What changed

- Email Invoice now shows a success toast after confirmed SMTP delivery and retains the existing error state on failure.
- Replaced the WhatsApp “Coming soon” status check with a real authenticated send request.
- Added WhatsApp sending spinner, disabled state, and duplicate-click guard.
- Shows clear success and failure toasts for WhatsApp delivery.
- Updated the same-origin invoice gateway to proxy both WhatsApp status GET and delivery POST requests.
- Added UI regression coverage for the functional WhatsApp button and sending state.

## Dependencies

- Backend PR #32 provides the WhatsApp POST delivery endpoint.
- Backend PR #31 corrects invoice totals used by the email template.
- E-commerce PR #86 provides the `total_price` display contract and should be merged if not already included elsewhere.

## Validation

- `npm test` — 24 files / 91 tests passed
- `npm run build` — production build passed
- Prettier and `git diff --check` passed