### PR TITLE
Refactor the e-commerce user dashboard

### DIFF
--- a/src/pageComponents/userDasboard/dashboard.js
+++ b/src/pageComponents/userDasboard/dashboard.js
@@ -7,11 +7,10 @@ import {
   ShoppingCart,
   PackageCheck,
   Clock3,
-  CalendarCheck,
+  ArrowUpRight,
 } from "lucide-react";
 import AquaUserDashbordLayout from "./layout/layout";
 import DashboardProductCard from "./layout/cards/cartCard";
-import { getUserDisplayName } from "@/utils/user";
 
 const AquaUserDashbordPageComponent = () => {
   const router = useRouter();
@@ -78,56 +77,31 @@ const AquaUserDashbordPageComponent = () => {
     ];
   }, [safeCart.length, safeFav.length, recentOrders]);
 
-  const firstName = useMemo(
-    () => getUserDisplayName(userData?.user, "there").split(" ")[0],
-    [userData?.user],
-  );
-
-  const featuredCart = useMemo(() => safeCart.slice(0, 4), [safeCart]);
-  const featuredFav = useMemo(() => safeFav.slice(0, 4), [safeFav]);
+  const featuredCart = useMemo(() => safeCart.slice(0, 3), [safeCart]);
+  const featuredFav = useMemo(() => safeFav.slice(0, 3), [safeFav]);
 
   return (
     <AquaUserDashbordLayout>
-      <div className="space-y-10">
-        <section className="glass-tint-emerald rounded-3xl p-6 sm:p-8">
-          <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-            <div>
-              <p className="text-sm font-bold uppercase tracking-wide text-emerald-600">
-                Welcome back
-              </p>
-              <h1 className="mt-1 text-2xl font-bold text-slate-900 sm:text-3xl">
-                Hi {firstName}, your water essentials are ready.
-              </h1>
-              <p className="mt-2 max-w-xl text-sm text-slate-600">
-                Track your orders, manage saved products, and keep your profile
-                up to date for lightning-fast deliveries.
-              </p>
-            </div>
-            <Link
-              href="/dashboard/profile"
-              className="btn-glass btn-glass-primary self-start"
-            >
-              <CalendarCheck className="h-4 w-4" />
-              Update profile
-            </Link>
-          </div>
-        </section>
-
-        <section className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+      <div className="space-y-8">
+        <section className="grid grid-cols-2 gap-3 xl:grid-cols-4">
           {highlightCards.map(
             ({ title, value, icon: Icon, iconTone, cardClass }) => (
               <div
                 key={title}
-                className={`flex items-center gap-3 rounded-2xl p-4 transition-all duration-300 hover:-translate-y-0.5 hover:shadow-lg ${cardClass}`}
+                className={`flex min-w-0 items-center gap-3 rounded-2xl border border-slate-100 p-3 sm:p-4 ${cardClass}`}
               >
                 <span
-                  className={`flex h-12 w-12 items-center justify-center rounded-2xl ${iconTone}`}
+                  className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-xl sm:h-11 sm:w-11 ${iconTone}`}
                 >
-                  <Icon className="h-6 w-6" aria-hidden="true" />
+                  <Icon className="h-5 w-5" aria-hidden="true" />
                 </span>
-                <div>
-                  <p className="text-sm text-slate-500">{title}</p>
-                  <p className="text-2xl font-bold text-slate-900">{value}</p>
+                <div className="min-w-0">
+                  <p className="truncate text-xs font-semibold text-slate-500 sm:text-sm">
+                    {title}
+                  </p>
+                  <p className="text-xl font-black text-slate-950 sm:text-2xl">
+                    {value}
+                  </p>
                 </div>
               </div>
             ),
@@ -135,7 +109,7 @@ const AquaUserDashbordPageComponent = () => {
         </section>
 
         <section className="space-y-4">
-          <div className="flex items-center justify-between">
+          <div className="flex items-end justify-between gap-4">
             <div>
               <h2 className="text-lg font-semibold text-slate-900">
                 Quick cart picks
@@ -146,19 +120,20 @@ const AquaUserDashbordPageComponent = () => {
             </div>
             <Link
               href="/dashboard/cart"
-              className="text-sm font-semibold text-emerald-600 transition hover:text-emerald-500"
+              className="inline-flex items-center gap-1 text-sm font-bold text-emerald-700 transition hover:text-emerald-600"
             >
-              View cart
+              View cart <ArrowUpRight className="h-4 w-4" />
             </Link>
           </div>
 
           {featuredCart.length > 0 ? (
-            <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4">
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
               {featuredCart.map((item) => (
                 <DashboardProductCard
                   key={item?._id}
                   product={item}
                   variant="cart"
+                  compact
                 />
               ))}
             </div>
@@ -170,7 +145,7 @@ const AquaUserDashbordPageComponent = () => {
         </section>
 
         <section className="space-y-4">
-          <div className="flex items-center justify-between">
+          <div className="flex items-end justify-between gap-4">
             <div>
               <h2 className="text-lg font-semibold text-slate-900">
                 Saved favourites
@@ -181,19 +156,20 @@ const AquaUserDashbordPageComponent = () => {
             </div>
             <Link
               href="/dashboard/fav"
-              className="text-sm font-semibold text-emerald-600 transition hover:text-emerald-500"
+              className="inline-flex items-center gap-1 text-sm font-bold text-emerald-700 transition hover:text-emerald-600"
             >
-              View favourites
+              View favourites <ArrowUpRight className="h-4 w-4" />
             </Link>
           </div>
 
           {featuredFav.length > 0 ? (
-            <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4">
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
               {featuredFav.map((item) => (
                 <DashboardProductCard
                   key={item?._id}
                   product={item}
                   variant="fav"
+                  compact
                 />
               ))}
             </div>

--- a/src/pageComponents/userDasboard/layout/cards/cartCard.js
+++ b/src/pageComponents/userDasboard/layout/cards/cartCard.js
@@ -97,7 +97,11 @@ const getStockBadge = (product) => {
   };
 };
 
-const DashboardProductCard = ({ product = {}, variant = "default" }) => {
+const DashboardProductCard = ({
+  product = {},
+  variant = "default",
+  compact = false,
+}) => {
   const [photoIndex, setPhotoIndex] = useState(0);
   const { favData = [], cartData = [] } = useSelector((state) => ({
     favData: ensureArray(state.favData),
@@ -219,8 +223,12 @@ const DashboardProductCard = ({ product = {}, variant = "default" }) => {
   };
 
   return (
-    <div className="flex h-full flex-col overflow-hidden rounded-3xl glass-card transition-all duration-300 hover:-translate-y-1 hover:shadow-[0_16px_48px_rgba(0,0,0,0.1)]">
-      <div className="relative aspect-[4/3] overflow-hidden bg-slate-50">
+    <article className="flex h-full flex-col overflow-hidden rounded-[22px] border border-slate-200/80 bg-white shadow-[0_8px_24px_rgba(15,23,42,0.05)] transition-shadow hover:shadow-[0_14px_34px_rgba(15,23,42,0.09)]">
+      <div
+        className={`relative overflow-hidden bg-slate-50 ${
+          compact ? "aspect-[16/10]" : "aspect-[4/3]"
+        }`}
+      >
         <Image
           src={normalized.photos[photoIndex]?.url || FALLBACK_IMAGE}
           alt={normalized.title}
@@ -230,7 +238,7 @@ const DashboardProductCard = ({ product = {}, variant = "default" }) => {
           priority={false}
         />
 
-        {normalized.photos.length > 1 && (
+        {!compact && normalized.photos.length > 1 && (
           <>
             <button
               type="button"
@@ -268,7 +276,11 @@ const DashboardProductCard = ({ product = {}, variant = "default" }) => {
         ) : null}
       </div>
 
-      <div className="flex flex-1 flex-col gap-2 p-3 sm:gap-4 sm:p-5">
+      <div
+        className={`flex flex-1 flex-col p-4 ${
+          compact ? "gap-2" : "gap-2 sm:gap-4 sm:p-5"
+        }`}
+      >
         <div className="flex flex-col gap-1">
           <span className="text-xs font-semibold uppercase tracking-wide text-emerald-600">
             {normalized.brand}
@@ -279,9 +291,11 @@ const DashboardProductCard = ({ product = {}, variant = "default" }) => {
           >
             {normalized.title}
           </Link>
-          <p className="line-clamp-2 text-xs text-slate-500">
-            {normalized.description}
-          </p>
+          {!compact && (
+            <p className="line-clamp-2 text-xs text-slate-500">
+              {normalized.description}
+            </p>
+          )}
         </div>
 
         <div className="flex items-baseline gap-3">
@@ -322,7 +336,14 @@ const DashboardProductCard = ({ product = {}, variant = "default" }) => {
         </div>
 
         <div className="mt-auto flex flex-col gap-2">
-          {variant === "cart" ? (
+          {compact ? (
+            <Link
+              href={normalized.href}
+              className="inline-flex items-center justify-center rounded-xl bg-slate-950 px-4 py-2.5 text-sm font-bold text-white transition-colors hover:bg-emerald-700"
+            >
+              View product
+            </Link>
+          ) : variant === "cart" ? (
             <>
               <button
                 type="button"
@@ -385,7 +406,7 @@ const DashboardProductCard = ({ product = {}, variant = "default" }) => {
           )}
         </div>
       </div>
-    </div>
+    </article>
   );
 };
 

--- a/src/pageComponents/userDasboard/layout/greet.js
+++ b/src/pageComponents/userDasboard/layout/greet.js
@@ -1,107 +1,47 @@
-import Image from "next/image";
-import { useEffect, useMemo, useState } from "react";
-import AquaLogo from "@/assests/logo-white.png";
+import { useMemo, useState } from "react";
+import { ArrowRight, Droplets, Sparkles } from "lucide-react";
 
-const MOTIVATION_SNIPPETS = [
-  "Monitor your water softener stats to keep scale off every fixture.",
-  "RO filters thrive on timely swaps—check when your membrane is due.",
-  "Sand filters that run clear mean sparkling tanks and happier showers.",
-  "Top up softener salt before hardness creeps back into the lines.",
-  "Log today's TDS readings to keep your RO system dialed in.",
-  "Cartridge life matters—track replacements so every glass tastes better.",
+const TIPS = [
+  "Track cartridge replacements so every glass tastes better.",
+  "Check your active orders and delivery updates in one place.",
+  "Save products now and return when you are ready to compare.",
 ];
 
 const AquaUserGreet = ({ userName = "there" }) => {
   const [tipIndex, setTipIndex] = useState(0);
-
   const greeting = useMemo(() => {
     const currentHour = new Date().getHours();
-
     if (currentHour < 12) return "Good morning";
     if (currentHour < 17) return "Good afternoon";
     if (currentHour < 21) return "Good evening";
     return "Good night";
   }, []);
 
-  useEffect(() => {
-    const interval = setInterval(() => {
-      setTipIndex((prev) => (prev + 1) % MOTIVATION_SNIPPETS.length);
-    }, 7000);
-
-    return () => clearInterval(interval);
-  }, []);
-
-  const handleNextTip = () => {
-    setTipIndex((prev) => (prev + 1) % MOTIVATION_SNIPPETS.length);
-  };
-
   return (
-    <>
-      <div className="relative mt-4 w-full overflow-hidden rounded-3xl glass-tint-emerald p-6 text-left">
-        <div className="pointer-events-none absolute -right-8 -top-8 h-32 w-32 rounded-full bg-emerald-200/40 blur-2xl" />
-        <div className="pointer-events-none absolute -bottom-12 left-6 h-28 w-28 rounded-full bg-indigo-200/50 blur-2xl" />
-        <div className="pointer-events-none absolute inset-0 z-0 opacity-85">
-          <Image
-            src={AquaLogo}
-            alt="Aquakart logo"
-            fill
-            className="object-contain object-right opacity-95"
-            style={{ filter: "brightness(0.7) contrast(1.05)" }}
-            sizes="(max-width: 768px) 100vw, 400px"
-            priority
-          />
+    <section className="mx-auto flex w-full max-w-5xl items-center justify-between gap-5 overflow-hidden rounded-[28px] border border-emerald-100 bg-gradient-to-br from-emerald-50 via-white to-sky-50 p-5 sm:p-6">
+      <div className="min-w-0">
+        <div className="mb-2 flex items-center gap-2 text-xs font-bold uppercase tracking-[0.16em] text-emerald-700">
+          <Sparkles className="h-4 w-4" /> Your Aquakart
         </div>
-
-        <div className="relative z-10">
-          <h2 className="text-3xl font-semibold text-gray-900">
-            <span className="text-gray-500">{greeting}, </span>
-            <span className="text-gray-900">{userName}</span>
-            <span className="wave-hand ml-2 inline-block">👋</span>
-          </h2>
-          <p className="mt-2 max-w-xl text-sm text-gray-600 transition-opacity duration-500 ease-in-out">
-            {MOTIVATION_SNIPPETS[tipIndex]}
-          </p>
-          <button
-            type="button"
-            onClick={handleNextTip}
-            className="mt-4 inline-flex items-center gap-2 rounded-full bg-white/70 px-4 py-1 text-xs font-medium text-indigo-600 shadow-sm ring-1 ring-indigo-100 transition hover:translate-y-0.5 hover:bg-indigo-50"
-          >
-            <span className="inline-flex h-2 w-2 rounded-full bg-emerald-400 shadow" />
-            Show me something else
-          </button>
-        </div>
+        <h2 className="truncate text-2xl font-black tracking-tight text-slate-950 sm:text-3xl">
+          {greeting}, {userName}
+        </h2>
+        <p className="mt-2 max-w-xl text-sm leading-6 text-slate-600">
+          {TIPS[tipIndex]}
+        </p>
+        <button
+          type="button"
+          onClick={() => setTipIndex((current) => (current + 1) % TIPS.length)}
+          className="mt-3 inline-flex items-center gap-1.5 text-xs font-bold text-emerald-700 transition hover:text-emerald-600"
+        >
+          Another tip <ArrowRight className="h-3.5 w-3.5" />
+        </button>
       </div>
-      <style jsx>{`
-        @keyframes wave {
-          0% {
-            transform: rotate(0deg);
-          }
-          15% {
-            transform: rotate(14deg);
-          }
-          30% {
-            transform: rotate(-8deg);
-          }
-          45% {
-            transform: rotate(14deg);
-          }
-          60% {
-            transform: rotate(-4deg);
-          }
-          75% {
-            transform: rotate(10deg);
-          }
-          100% {
-            transform: rotate(0deg);
-          }
-        }
 
-        .wave-hand {
-          animation: wave 1.8s ease-in-out infinite;
-          transform-origin: 70% 70%;
-        }
-      `}</style>
-    </>
+      <div className="hidden h-20 w-20 shrink-0 place-items-center rounded-[26px] bg-slate-950 text-emerald-400 shadow-lg shadow-emerald-900/10 sm:grid">
+        <Droplets className="h-9 w-9" />
+      </div>
+    </section>
   );
 };
 

--- a/src/pageComponents/userDasboard/layout/header.js
+++ b/src/pageComponents/userDasboard/layout/header.js
@@ -6,110 +6,104 @@ import {
   ShoppingCart,
   Heart,
   ShoppingBag,
-  ShoppingBagIcon,
+  Store,
+  Droplets,
 } from "lucide-react";
 
-const AquaUserDashboardHeader = () => {
-  const router = useRouter();
+const navItems = [
+  { id: "dashboard", label: "Dashboard", href: "/dashboard", icon: Home },
+  {
+    id: "orders",
+    label: "Orders",
+    href: "/dashboard/orders",
+    icon: ShoppingBag,
+  },
+  { id: "cart", label: "Cart", href: "/dashboard/cart", icon: ShoppingCart },
+  {
+    id: "favourites",
+    label: "Favourites",
+    href: "/dashboard/fav",
+    icon: Heart,
+  },
+  { id: "profile", label: "Profile", href: "/dashboard/profile", icon: User },
+];
 
-  const navItems = [
-    {
-      id: "home",
-      label: "Shop",
-      href: "/",
-      icon: ShoppingBagIcon,
-    },
-    {
-      id: "dashboard",
-      label: "Dashboard",
-      href: "/dashboard",
-      icon: Home,
-    },
-    {
-      id: "profile",
-      label: "Profile",
-      href: "/dashboard/profile",
-      icon: User,
-    },
-    {
-      id: "orders",
-      label: "Orders",
-      href: "/dashboard/orders",
-      icon: ShoppingBag,
-    },
-    // {
-    //   id: "settings",
-    //   label: "Settings",
-    //   href: "/dashboard/settings",
-    //   icon: Settings,
-    // },
-    {
-      id: "cart",
-      label: "Cart",
-      href: "/dashboard/cart",
-      icon: ShoppingCart,
-    },
-    {
-      id: "favourites",
-      label: "Favourites",
-      href: "/dashboard/fav",
-      icon: Heart,
-    },
-  ];
+const isCurrentRoute = (pathname, href) =>
+  href === "/dashboard" ? pathname === href : pathname.startsWith(href);
+
+const NavigationItem = ({ item, pathname, compact = false }) => {
+  const active = isCurrentRoute(pathname, item.href);
+  const Icon = item.icon;
 
   return (
-    <div className="mx-auto mt-6 w-full">
-      <div className="hidden justify-center px-4 sm:flex">
-        <div className="flex items-center gap-1.5 rounded-full border border-slate-200 bg-white px-3 py-2.5 shadow-[0_8px_26px_rgba(15,23,42,0.06)]">
-          {navItems.map((item) => {
-            const isActive = router.pathname === item.href;
-            const Icon = item.icon;
+    <Link
+      href={item.href}
+      aria-current={active ? "page" : undefined}
+      className={`group flex items-center rounded-2xl font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 ${
+        compact
+          ? "min-w-[64px] flex-col justify-center gap-1 px-2 py-2 text-[11px]"
+          : "gap-3 px-3 py-3 text-sm xl:px-4"
+      } ${
+        active
+          ? "bg-emerald-600 text-white shadow-sm"
+          : "text-slate-500 hover:bg-emerald-50 hover:text-emerald-700"
+      }`}
+    >
+      <Icon className="h-5 w-5 shrink-0" strokeWidth={active ? 2.3 : 1.8} />
+      <span className={compact ? "leading-none" : "hidden xl:block"}>
+        {item.label}
+      </span>
+    </Link>
+  );
+};
 
-            return (
-              <Link key={item.id} href={item.href} className="relative">
-                <span
-                  className={`inline-flex items-center gap-2 rounded-full px-4 py-2 text-sm font-semibold transition-all duration-200 ${
-                    isActive
-                      ? "bg-gradient-to-r from-emerald-500 to-teal-500 text-white shadow-lg shadow-emerald-500/25"
-                      : "text-slate-500 hover:bg-white/60 hover:text-slate-800"
-                  }`}
-                >
-                  <Icon
-                    size={18}
-                    strokeWidth={isActive ? 2.4 : 1.6}
-                    className={isActive ? "text-white" : "text-slate-400"}
-                  />
-                  {item.label}
-                </span>
-              </Link>
-            );
-          })}
-        </div>
-      </div>
+const AquaUserDashboardHeader = () => {
+  const { pathname } = useRouter();
 
-      <div className="px-4 sm:hidden">
-        <div className="no-scrollbar flex items-center gap-1.5 overflow-x-auto rounded-2xl border border-slate-200 bg-white px-3 py-2 shadow-[0_4px_16px_rgba(15,23,42,0.05)]">
-          {navItems.map((item) => {
-            const isActive = router.pathname === item.href;
-            const Icon = item.icon;
-            return (
-              <Link
-                key={item.id}
-                href={item.href}
-                className={`inline-flex flex-shrink-0 items-center gap-1.5 rounded-full px-3 py-1.5 text-sm font-semibold transition ${
-                  isActive
-                    ? "bg-gradient-to-r from-emerald-500 to-teal-500 text-white shadow-md shadow-emerald-500/20"
-                    : "text-slate-500 hover:bg-white/60 hover:text-slate-800"
-                }`}
-              >
-                <Icon size={16} strokeWidth={isActive ? 2.4 : 1.6} />
-                {item.label}
-              </Link>
-            );
-          })}
-        </div>
-      </div>
-    </div>
+  return (
+    <>
+      <aside className="sticky top-6 hidden h-[calc(100vh-3rem)] w-20 shrink-0 flex-col rounded-[28px] border border-slate-200/80 bg-white p-3 shadow-[0_16px_45px_rgba(15,23,42,0.06)] lg:flex xl:w-60 xl:p-4">
+        <Link
+          href="/"
+          aria-label="Open Aquakart shop"
+          className="mb-5 flex items-center justify-center gap-3 rounded-2xl bg-slate-950 px-3 py-3 text-white xl:justify-start"
+        >
+          <Droplets className="h-6 w-6 text-emerald-400" />
+          <span className="hidden text-base font-black xl:block">Aquakart</span>
+        </Link>
+
+        <p className="mb-2 hidden px-4 text-[10px] font-bold uppercase tracking-[0.18em] text-slate-400 xl:block">
+          Your account
+        </p>
+        <nav className="space-y-2" aria-label="User dashboard">
+          {navItems.map((item) => (
+            <NavigationItem key={item.id} item={item} pathname={pathname} />
+          ))}
+        </nav>
+
+        <Link
+          href="/"
+          className="mt-auto flex items-center justify-center gap-3 rounded-2xl border border-slate-200 px-3 py-3 text-sm font-semibold text-slate-600 transition hover:border-emerald-200 hover:bg-emerald-50 hover:text-emerald-700 xl:justify-start xl:px-4"
+        >
+          <Store className="h-5 w-5" />
+          <span className="hidden xl:block">Back to shop</span>
+        </Link>
+      </aside>
+
+      <nav
+        className="fixed inset-x-3 bottom-3 z-50 flex items-center justify-around rounded-[22px] border border-slate-200/80 bg-white/95 px-1 py-1.5 shadow-[0_18px_50px_rgba(15,23,42,0.18)] backdrop-blur lg:hidden"
+        aria-label="User dashboard"
+      >
+        {navItems.map((item) => (
+          <NavigationItem
+            key={item.id}
+            item={item}
+            pathname={pathname}
+            compact
+          />
+        ))}
+      </nav>
+    </>
   );
 };
 

--- a/src/pageComponents/userDasboard/layout/layout.js
+++ b/src/pageComponents/userDasboard/layout/layout.js
@@ -60,39 +60,52 @@ const AquaUserDashbordLayout = ({
     return username;
   };
   return (
-    <div className="relative min-h-screen flex flex-col items-center justify-start bg-slate-50">
-      <AquaUserDashboardHeader />
+    <div className="relative min-h-screen bg-slate-50">
       <AquaCartAddressDialog />
-      {!focused && (
-        <div className="w-full max-w-5xl px-4">
-          <AquaUserGreet
-            userName={getFirstLettersFromEmail(userData?.user?.email)}
-          />
-        </div>
-      )}
-      <div
-        className={`w-full px-4 py-6 sm:py-8 ${
-          focused ? "max-w-6xl" : "max-w-5xl"
-        }`}
-      >
-        <div
-          className={
-            focused ? "w-full" : "glass-card w-full rounded-3xl p-5 sm:p-8"
-          }
-        >
-          <div className="mb-6 border-b border-white/30 pb-4">
-            <h1 className="text-xl font-bold text-gray-900 sm:text-2xl">
-              {resolvedTitle}
-            </h1>
-            {resolvedSubtitle && (
-              <p className="mt-1 text-sm text-slate-500">{resolvedSubtitle}</p>
-            )}
-          </div>
-          <div className={focused ? "" : "min-h-[60vh]"}>{children}</div>
-        </div>
+      <div className="mx-auto flex w-full max-w-[1440px] items-start gap-5 px-3 py-4 sm:px-5 sm:py-6 lg:gap-7">
+        <AquaUserDashboardHeader />
+
+        <main className="min-w-0 flex-1 pb-24 lg:pb-0">
+          {!focused && (
+            <AquaUserGreet
+              userName={getFirstLettersFromEmail(userData?.user?.email)}
+            />
+          )}
+
+          <section
+            className={`mx-auto mt-4 w-full ${
+              focused ? "max-w-6xl" : "max-w-5xl"
+            }`}
+          >
+            <div
+              className={
+                focused
+                  ? "w-full"
+                  : "w-full rounded-[28px] border border-slate-200/80 bg-white p-4 shadow-[0_16px_45px_rgba(15,23,42,0.05)] sm:p-6 lg:p-7"
+              }
+            >
+              <header className="mb-6 flex items-end justify-between gap-4 border-b border-slate-100 pb-4">
+                <div>
+                  <h1 className="text-xl font-black text-slate-950 sm:text-2xl">
+                    {resolvedTitle}
+                  </h1>
+                  {resolvedSubtitle && (
+                    <p className="mt-1 text-sm text-slate-500">
+                      {resolvedSubtitle}
+                    </p>
+                  )}
+                </div>
+              </header>
+              <div className={focused ? "" : "min-h-[55vh]"}>{children}</div>
+            </div>
+          </section>
+        </main>
       </div>
-      <div className="w-full mt-auto">
-        <AquaFooter categories={categories} subcategories={subcategories} />
+
+      <div className="w-full lg:pl-20 xl:pl-60">
+        <div className="mx-auto max-w-6xl">
+          <AquaFooter categories={categories} subcategories={subcategories} />
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## What changed

- Replaces the wide top tab bar with a sticky left navigation rail on desktop.
- Keeps navigation labels visible on wide screens and uses an icon rail on medium desktop widths.
- Adds a compact bottom navigation on mobile so account actions remain thumb-friendly.
- Centers the working content in a stable responsive column.
- Removes the repeated welcome card and replaces the animated/image-heavy greeting with a lightweight account header.
- Cleans the four account metric cards and improves small-screen density.
- Limits home dashboard cart/favourite previews to three products.
- Uses a single lazy product image and one clear action in dashboard previews; full cart and favourite pages retain their existing controls.
- Preserves the existing Redux data, authentication redirect, URLs, product actions, footer, and address dialog.

## Performance impact

- Removed the continuously running seven-second greeting timer.
- Removed the priority full-card logo image from the greeting.
- Avoided rendering image carousel controls and dots in dashboard preview cards.
- Reduced dashboard preview products from four to three per section.
- Uses color transitions instead of layout-moving hover animation.

## Validation

- Prettier completed on all five changed files.
- `git diff --check` passed.
- Production Next.js webpack build compiled successfully and generated all 31 routes, including all dashboard pages.
- ESLint is currently blocked before source evaluation by the repository's ESLint/parser incompatibility: `scopeManager.addGlobals is not a function`.
