### PR TITLE
Polish dashboard tab transitions and layout consistency

### DIFF
--- a/src/pageComponents/userDasboard/layout/header.js
+++ b/src/pageComponents/userDasboard/layout/header.js
@@ -12,19 +12,9 @@ import {
 
 const navItems = [
   { id: "dashboard", label: "Dashboard", href: "/dashboard", icon: Home },
-  {
-    id: "orders",
-    label: "Orders",
-    href: "/dashboard/orders",
-    icon: ShoppingBag,
-  },
+  { id: "orders", label: "Orders", href: "/dashboard/orders", icon: ShoppingBag },
   { id: "cart", label: "Cart", href: "/dashboard/cart", icon: ShoppingCart },
-  {
-    id: "favourites",
-    label: "Favourites",
-    href: "/dashboard/fav",
-    icon: Heart,
-  },
+  { id: "favourites", label: "Favourites", href: "/dashboard/fav", icon: Heart },
   { id: "profile", label: "Profile", href: "/dashboard/profile", icon: User },
 ];
 
@@ -38,19 +28,19 @@ const NavigationItem = ({ item, pathname, mobile = false }) => {
   return (
     <Link
       href={item.href}
+      prefetch
+      scroll={false}
       aria-label={item.label}
       aria-current={active ? "page" : undefined}
-      className={`group relative grid place-items-center rounded-2xl transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 ${
-        mobile ? "h-11 w-11" : "h-12 w-12"
-      } ${
+      className={`group relative grid h-11 w-11 place-items-center rounded-[14px] transition-[background-color,color,box-shadow,transform] duration-200 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950 ${
         active
-          ? "bg-emerald-500 text-slate-950 shadow-[0_8px_20px_rgba(16,185,129,0.28)]"
-          : "text-slate-400 hover:bg-white/10 hover:text-emerald-300"
+          ? "bg-emerald-500 text-slate-950 shadow-[0_8px_22px_rgba(16,185,129,0.3)]"
+          : "text-slate-400 hover:-translate-y-0.5 hover:bg-white/10 hover:text-emerald-300"
       }`}
     >
-      <Icon className="h-5 w-5" strokeWidth={active ? 2.4 : 1.8} />
+      <Icon className="h-5 w-5" strokeWidth={2} aria-hidden="true" />
       {!mobile && (
-        <span className="pointer-events-none absolute left-full z-50 ml-3 whitespace-nowrap rounded-xl bg-slate-950 px-3 py-2 text-xs font-bold text-white opacity-0 shadow-xl transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100">
+        <span className="pointer-events-none absolute left-full z-50 ml-3 whitespace-nowrap rounded-lg bg-slate-900 px-2.5 py-1.5 text-[11px] font-bold text-white opacity-0 shadow-xl transition-opacity duration-150 group-hover:opacity-100 group-focus-visible:opacity-100">
           {item.label}
         </span>
       )}
@@ -66,26 +56,23 @@ const AquaUserDashboardHeader = () => {
 
   return (
     <>
-      <aside className="sticky top-6 hidden h-[calc(100vh-3rem)] w-[76px] shrink-0 flex-col items-center rounded-[30px] border border-white/10 bg-slate-950 px-3 py-4 shadow-[0_24px_60px_rgba(15,23,42,0.22)] lg:flex">
+      <aside className="sticky top-4 hidden h-[calc(100vh-2rem)] w-[72px] shrink-0 flex-col items-center rounded-[26px] border border-white/10 bg-slate-950 px-3 py-3 shadow-[0_20px_55px_rgba(15,23,42,0.2)] lg:flex">
         <Link
           href="/"
           aria-label="Open Aquakart shop"
-          className="grid h-12 w-12 place-items-center rounded-2xl bg-white/10 ring-1 ring-white/10 transition hover:bg-white/15"
+          className="grid h-11 w-11 place-items-center rounded-[14px] bg-white/10 ring-1 ring-white/10 transition-colors duration-200 hover:bg-white/15 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400"
         >
           <Image
             src="/aquakart-logo-white.png"
             alt="Aquakart"
-            width={32}
-            height={32}
-            className="h-8 w-8 object-contain"
+            width={28}
+            height={28}
+            className="h-7 w-7 object-contain"
             priority
           />
         </Link>
 
-        <nav
-          className="my-auto flex flex-col items-center gap-2"
-          aria-label="User dashboard"
-        >
+        <nav className="my-auto flex flex-col items-center gap-2" aria-label="User dashboard tabs">
           {navItems.map((item) => (
             <NavigationItem key={item.id} item={item} pathname={pathname} />
           ))}
@@ -94,26 +81,18 @@ const AquaUserDashboardHeader = () => {
         <Link
           href="/"
           aria-label="Back to shop"
-          className="group relative grid h-12 w-12 place-items-center rounded-2xl text-slate-400 transition-colors hover:bg-white/10 hover:text-emerald-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500"
+          className="group relative grid h-11 w-11 place-items-center rounded-[14px] text-slate-400 transition-colors duration-200 hover:bg-white/10 hover:text-emerald-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400"
         >
-          <Store className="h-5 w-5" />
-          <span className="pointer-events-none absolute left-full z-50 ml-3 whitespace-nowrap rounded-xl bg-slate-950 px-3 py-2 text-xs font-bold text-white opacity-0 shadow-xl transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100">
+          <Store className="h-5 w-5" strokeWidth={2} aria-hidden="true" />
+          <span className="pointer-events-none absolute left-full z-50 ml-3 whitespace-nowrap rounded-lg bg-slate-900 px-2.5 py-1.5 text-[11px] font-bold text-white opacity-0 shadow-xl transition-opacity duration-150 group-hover:opacity-100 group-focus-visible:opacity-100">
             Back to shop
           </span>
         </Link>
       </aside>
 
-      <nav
-        className="fixed bottom-3 left-1/2 z-50 flex -translate-x-1/2 items-center gap-1 rounded-[22px] border border-white/10 bg-slate-950/95 px-2 py-2 shadow-[0_18px_50px_rgba(15,23,42,0.28)] backdrop-blur lg:hidden"
-        aria-label="User dashboard"
-      >
+      <nav className="fixed bottom-3 left-1/2 z-50 flex -translate-x-1/2 items-center gap-1 rounded-[20px] border border-white/10 bg-slate-950/95 px-2 py-2 shadow-[0_18px_50px_rgba(15,23,42,0.28)] backdrop-blur lg:hidden" aria-label="User dashboard tabs">
         {navItems.map((item) => (
-          <NavigationItem
-            key={item.id}
-            item={item}
-            pathname={pathname}
-            mobile
-          />
+          <NavigationItem key={item.id} item={item} pathname={pathname} mobile />
         ))}
       </nav>
     </>

--- a/src/pageComponents/userDasboard/layout/layout.js
+++ b/src/pageComponents/userDasboard/layout/layout.js
@@ -5,99 +5,59 @@ import { useSelector } from "react-redux";
 import { useRouter } from "next/router";
 
 const ROUTE_COPY = {
-  "/dashboard": {
-    title: "Dashboard",
-    subtitle: "Your Aquakart snapshot at a glance.",
-  },
-  "/dashboard/profile": {
-    title: "Profile",
-    subtitle: "Review and update your personal details.",
-  },
-  "/dashboard/settings": {
-    title: "Settings",
-    subtitle: "Fine-tune how you experience Aquakart.",
-  },
-  "/dashboard/orders": {
-    title: "Orders",
-    subtitle: "Track every purchase and its delivery status.",
-  },
-  "/dashboard/cart": {
-    title: "Cart",
-    subtitle: "Quick access to items waiting for checkout.",
-  },
-  "/dashboard/fav": {
-    title: "Favourites",
-    subtitle: "All the products you've saved for later.",
-  },
+  "/dashboard": { title: "Dashboard", subtitle: "Your Aquakart snapshot at a glance." },
+  "/dashboard/profile": { title: "Profile", subtitle: "Review and update your personal details." },
+  "/dashboard/settings": { title: "Settings", subtitle: "Fine-tune how you experience Aquakart." },
+  "/dashboard/orders": { title: "Orders", subtitle: "Track every purchase and its delivery status." },
+  "/dashboard/cart": { title: "Cart", subtitle: "Quick access to items waiting for checkout." },
+  "/dashboard/fav": { title: "Favourites", subtitle: "All the products you've saved for later." },
 };
 
-const AquaUserDashbordLayout = ({
-  children,
-  title,
-  subtitle,
-  focused = false,
-}) => {
+const AquaUserDashbordLayout = ({ children, title, subtitle }) => {
   const { userData } = useSelector((state) => ({ ...state }));
   const router = useRouter();
-
   const routeMeta = ROUTE_COPY[router.pathname] || ROUTE_COPY["/dashboard"];
   const resolvedTitle = title || routeMeta.title;
   const resolvedSubtitle = subtitle || routeMeta.subtitle;
 
   const getFirstLettersFromEmail = (email) => {
-    if (!email || typeof email !== "string") {
-      return "there";
-    }
-
-    const [username] = email.split("@");
-    if (!username) {
-      return "there";
-    }
-
-    return username;
+    if (!email || typeof email !== "string") return "there";
+    return email.split("@")[0] || "there";
   };
+
   return (
     <div className="relative min-h-screen bg-slate-50">
       <AquaCartAddressDialog />
-      <div className="mx-auto flex w-full max-w-[1380px] items-start gap-4 px-3 py-4 sm:px-5 sm:py-6 lg:gap-6">
+      <div className="mx-auto flex w-full max-w-[1320px] items-start gap-4 px-3 py-4 sm:px-5 lg:gap-5">
         <AquaUserDashboardHeader />
 
-        <main className="min-w-0 flex-1 pb-24 lg:pb-0">
-          {!focused && (
-            <AquaUserGreet
-              userName={getFirstLettersFromEmail(userData?.user?.email)}
-            />
-          )}
+        <main className="min-h-[calc(100vh-2rem)] min-w-0 flex-1 pb-24 lg:pb-0">
+          <AquaUserGreet userName={getFirstLettersFromEmail(userData?.user?.email)} />
 
-          <section
-            className={`mx-auto mt-4 w-full ${
-              focused ? "max-w-6xl" : "max-w-5xl"
-            }`}
-          >
-            <div
-              className={
-                focused
-                  ? "w-full"
-                  : "w-full rounded-[28px] border border-slate-200/80 bg-white p-4 shadow-[0_16px_45px_rgba(15,23,42,0.05)] sm:p-6 lg:p-7"
-              }
-            >
+          <section className="mx-auto mt-4 w-full max-w-5xl">
+            <div className="min-h-[calc(100vh-14rem)] w-full rounded-[28px] border border-slate-200/80 bg-white p-4 shadow-[0_16px_45px_rgba(15,23,42,0.05)] sm:p-6 lg:p-7">
               <header className="mb-6 flex items-end justify-between gap-4 border-b border-slate-100 pb-4">
                 <div>
-                  <h1 className="text-xl font-black text-slate-950 sm:text-2xl">
-                    {resolvedTitle}
-                  </h1>
-                  {resolvedSubtitle && (
-                    <p className="mt-1 text-sm text-slate-500">
-                      {resolvedSubtitle}
-                    </p>
-                  )}
+                  <h1 className="text-xl font-black text-slate-950 sm:text-2xl">{resolvedTitle}</h1>
+                  {resolvedSubtitle && <p className="mt-1 text-sm text-slate-500">{resolvedSubtitle}</p>}
                 </div>
               </header>
-              <div className={focused ? "" : "min-h-[55vh]"}>{children}</div>
+              <div key={router.pathname} className="animate-[dashboard-tab-in_180ms_cubic-bezier(0.22,1,0.36,1)]">
+                {children}
+              </div>
             </div>
           </section>
         </main>
       </div>
+      <style jsx global>{`
+        @keyframes dashboard-tab-in {
+          from { opacity: 0; transform: translateY(5px); }
+          to { opacity: 1; transform: translateY(0); }
+        }
+        @media (prefers-reduced-motion: reduce) {
+          [class*="dashboard-tab-in"] { animation: none !important; }
+        }
+      `}</style>
     </div>
   );
 };

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -16,63 +16,36 @@ import { Roboto_Mono, Montserrat } from "next/font/google";
 import AquaAppLoader from "@/components/common/AquaAppLoader";
 import { AuthProvider } from "@/context/AuthContext";
 
-const robotoMono = Roboto_Mono({
-  subsets: ["latin"],
-  display: "swap",
-  variable: "--font-roboto-mono",
-});
-
-const montserrat = Montserrat({
-  subsets: ["latin"],
-  display: "swap",
-  variable: "--font-montserrat",
-});
-
-const Toaster = dynamic(() => import("sonner").then((mod) => mod.Toaster), {
-  ssr: false,
-});
+const robotoMono = Roboto_Mono({ subsets: ["latin"], display: "swap", variable: "--font-roboto-mono" });
+const montserrat = Montserrat({ subsets: ["latin"], display: "swap", variable: "--font-montserrat" });
+const Toaster = dynamic(() => import("sonner").then((mod) => mod.Toaster), { ssr: false });
 
 const GA_ID = "G-FS41RRVRD4";
 const APP_BOOT_MIN_MS = 1300;
 const APP_BOOT_MAX_MS = 2600;
 const ROUTE_LOADER_DELAY_MS = 0;
 const ROUTE_LOADER_MIN_MS = 520;
-
-const persistConfig = {
-  key: "root",
-  storage,
-};
-
+const persistConfig = { key: "root", storage };
 const persistedReducer = persistReducer(persistConfig, rootReducer);
 const store = createStore(persistedReducer);
 const persistor = persistStore(store);
-
-const wait = (duration) =>
-  new Promise((resolve) => {
-    window.setTimeout(resolve, duration);
-  });
+const wait = (duration) => new Promise((resolve) => window.setTimeout(resolve, duration));
 
 const waitForWindowLoad = () =>
   new Promise((resolve) => {
-    if (typeof window === "undefined") {
+    if (typeof window === "undefined" || document.readyState === "complete") {
       resolve();
       return;
     }
-
-    if (document.readyState === "complete") {
-      resolve();
-      return;
-    }
-
     window.addEventListener("load", resolve, { once: true });
   });
 
+const routePathname = (url = "") => url.split("?")[0].split("#")[0];
+const isDashboardTabChange = (from, to) =>
+  from.startsWith("/dashboard") && routePathname(to).startsWith("/dashboard");
+
 const PersistLoader = () => (
-  <AquaAppLoader
-    variant="screen"
-    message="Preparing Aquakart"
-    subtext="Syncing your cart, profile and order experience."
-  />
+  <AquaAppLoader variant="screen" message="Preparing Aquakart" subtext="Syncing your cart, profile and order experience." />
 );
 
 export default function App({ Component, pageProps }) {
@@ -82,39 +55,31 @@ export default function App({ Component, pageProps }) {
   const loaderTimerRef = useRef(null);
   const loaderStartedAtRef = useRef(0);
   const routeHideTimerRef = useRef(null);
+  const skipRouteLoaderRef = useRef(false);
 
   useEffect(() => {
-    const handleRouteChange = (url) => {
-      window.gtag?.("config", GA_ID, { page_path: url });
-    };
-
+    const handleRouteChange = (url) => window.gtag?.("config", GA_ID, { page_path: url });
     router.events.on("routeChangeComplete", handleRouteChange);
     return () => router.events.off("routeChangeComplete", handleRouteChange);
   }, [router.events]);
 
   useEffect(() => {
     let isMounted = true;
-
     const prepareFirstPaint = async () => {
-      await Promise.race([
-        Promise.all([wait(APP_BOOT_MIN_MS), waitForWindowLoad()]),
-        wait(APP_BOOT_MAX_MS),
-      ]);
-
-      if (isMounted) {
-        setAppReady(true);
-      }
+      await Promise.race([Promise.all([wait(APP_BOOT_MIN_MS), waitForWindowLoad()]), wait(APP_BOOT_MAX_MS)]);
+      if (isMounted) setAppReady(true);
     };
-
     prepareFirstPaint();
-
-    return () => {
-      isMounted = false;
-    };
+    return () => { isMounted = false; };
   }, []);
 
   useEffect(() => {
-    const showRouteLoader = () => {
+    const showRouteLoader = (url) => {
+      skipRouteLoaderRef.current = isDashboardTabChange(router.asPath, url);
+      if (skipRouteLoaderRef.current) {
+        setRouteLoading(false);
+        return;
+      }
       window.clearTimeout(loaderTimerRef.current);
       window.clearTimeout(routeHideTimerRef.current);
       loaderTimerRef.current = window.setTimeout(() => {
@@ -124,19 +89,20 @@ export default function App({ Component, pageProps }) {
     };
 
     const hideRouteLoader = () => {
+      if (skipRouteLoaderRef.current) {
+        skipRouteLoaderRef.current = false;
+        setRouteLoading(false);
+        return;
+      }
       window.clearTimeout(loaderTimerRef.current);
       const elapsed = Date.now() - loaderStartedAtRef.current;
       const remaining = Math.max(ROUTE_LOADER_MIN_MS - elapsed, 0);
-
-      routeHideTimerRef.current = window.setTimeout(() => {
-        setRouteLoading(false);
-      }, remaining);
+      routeHideTimerRef.current = window.setTimeout(() => setRouteLoading(false), remaining);
     };
 
     router.events.on("routeChangeStart", showRouteLoader);
     router.events.on("routeChangeComplete", hideRouteLoader);
     router.events.on("routeChangeError", hideRouteLoader);
-
     return () => {
       window.clearTimeout(loaderTimerRef.current);
       window.clearTimeout(routeHideTimerRef.current);
@@ -144,14 +110,9 @@ export default function App({ Component, pageProps }) {
       router.events.off("routeChangeComplete", hideRouteLoader);
       router.events.off("routeChangeError", hideRouteLoader);
     };
-  }, [router.events]);
+  }, [router.asPath, router.events]);
 
-  useEffect(() => {
-    if (typeof window !== "undefined") {
-      persistor.persist();
-    }
-  }, []);
-
+  useEffect(() => { if (typeof window !== "undefined") persistor.persist(); }, []);
   const shouldShowLoader = !appReady || routeLoading;
 
   return (
@@ -162,40 +123,21 @@ export default function App({ Component, pageProps }) {
           --font-montserrat: ${montserrat.style.fontFamily};
         }
       `}</style>
-
-      <Script
-        src={`https://www.googletagmanager.com/gtag/js?id=${GA_ID}`}
-        strategy="afterInteractive"
-      />
-      <Script id="ga-init" strategy="afterInteractive">
-        {`
-          window.dataLayer = window.dataLayer || [];
-          function gtag(){dataLayer.push(arguments);}
-          window.gtag = gtag;
-          gtag('js', new Date());
-          gtag('config', '${GA_ID}');
-        `}
-      </Script>
-
+      <Script src={`https://www.googletagmanager.com/gtag/js?id=${GA_ID}`} strategy="afterInteractive" />
+      <Script id="ga-init" strategy="afterInteractive">{`
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        window.gtag = gtag;
+        gtag('js', new Date());
+        gtag('config', '${GA_ID}');
+      `}</Script>
       <PersistGate persistor={persistor} loading={<PersistLoader />}>
         <AuthProvider>
           <div className={`${robotoMono.variable} ${montserrat.variable}`}>
-            {!appReady ? (
-              <AquaAppLoader
-                variant="screen"
-                message="Welcome to Aquakart"
-                subtext="Getting the page ready for you."
-              />
-            ) : null}
-            {routeLoading ? (
-              <AquaAppLoader
-                variant="route"
-                message="Opening Aquakart"
-                subtext="Preparing the next page smoothly."
-              />
-            ) : null}
+            {!appReady ? <AquaAppLoader variant="screen" message="Welcome to Aquakart" subtext="Getting the page ready for you." /> : null}
+            {routeLoading ? <AquaAppLoader variant="route" message="Opening Aquakart" subtext="Preparing the next page smoothly." /> : null}
             <main
-              key={router.asPath}
+              key={router.pathname.startsWith("/dashboard") ? "dashboard-shell" : router.asPath}
               className="aqua-page-shell aqua-page-enter"
               data-route={router.pathname}
               aria-hidden={shouldShowLoader}
@@ -203,10 +145,8 @@ export default function App({ Component, pageProps }) {
                 opacity: shouldShowLoader ? 0 : 1,
                 visibility: shouldShowLoader ? "hidden" : "visible",
                 pointerEvents: shouldShowLoader ? "none" : "auto",
-                transform: shouldShowLoader ? "none" : "none",
-                transition: shouldShowLoader
-                  ? "none"
-                  : "opacity 420ms ease, transform 420ms cubic-bezier(0.22, 1, 0.36, 1)",
+                transform: "none",
+                transition: shouldShowLoader ? "none" : "opacity 420ms ease, transform 420ms cubic-bezier(0.22, 1, 0.36, 1)",
               }}
             >
               <Component {...pageProps} />


### PR DESCRIPTION
## Summary
- make dashboard navigation feel like an in-place tab switch by skipping the global route loader only for dashboard-to-dashboard navigation
- keep the dashboard shell mounted while the selected tab changes and add a restrained 180ms content transition
- use the same greeting, content surface, width, border, radius and shadow on Dashboard, Profile, Orders, Cart and Favourites
- align the content column and icon rail to the same viewport-height baseline
- normalize every navigation, logo and shop icon to the same 44px control and 20px icon geometry
- retain accessible labels, current-page state, keyboard focus and reduced-motion behavior

## Client impact
The existing application loader remains unchanged for navigation outside the user dashboard. No animation dependency or additional data request was added.

## Validation
- inspected the final three-file commit diff against the merged dashboard navigation
- confirmed the route-loader condition is scoped to paths beginning with `/dashboard`
- full local build was unavailable because the transient e-commerce checkout was no longer present