### PR TITLE
Repair mobile navigation, categories, and footer overlays

### DIFF
--- a/src/components/Layout/Footer.js
+++ b/src/components/Layout/Footer.js
@@ -64,7 +64,7 @@ const AquaFooter = ({ categories = [], subcategories = [] }) => {
   return (
     <footer
       aria-labelledby="footer-heading"
-      className="aqua-site-footer-edge relative z-10 px-2 pb-2 pt-10 text-slate-300"
+      className="aqua-site-footer-edge relative z-10 px-2 pb-24 pt-10 text-slate-300 sm:pb-2"
     >
       <div className="relative overflow-hidden rounded-[2.5rem] bg-slate-950 px-6 pb-8 pt-16 sm:px-12 lg:px-16">
         {/* Ambient Background Effects */}

--- a/src/components/Layout/Layout.js
+++ b/src/components/Layout/Layout.js
@@ -28,12 +28,6 @@ const AquafavDrawer = dynamic(
   },
 );
 
-// Festival widget: also lazy-load (often non-critical for LCP)
-const FestivalCornerWidget = dynamic(
-  () => import("../reusables/FestivalCornerWidget"),
-  { ssr: false },
-);
-
 // Mobile bottom nav: client-only
 const MobileBottomNav = dynamic(() => import("./MobileBottomNav"), {
   ssr: false,
@@ -227,7 +221,6 @@ const AquaLayout = (props) => {
         <>
           <AquaCartDrawer />
           <AquafavDrawer />
-          <FestivalCornerWidget />
         </>
       )}
 

--- a/src/components/Layout/MobileBottomNav.js
+++ b/src/components/Layout/MobileBottomNav.js
@@ -83,7 +83,7 @@ const MobileBottomNav = () => {
 
   return (
     <nav
-      className="fixed bottom-0 inset-x-0 z-40 sm:hidden"
+      className="fixed inset-x-0 bottom-0 z-[70] sm:hidden"
       aria-label="Mobile navigation"
     >
       {/* iOS-style frosted glass bar */}

--- a/src/pageComponents/userDasboard/dashboard.js
+++ b/src/pageComponents/userDasboard/dashboard.js
@@ -82,7 +82,7 @@ const AquaUserDashbordPageComponent = () => {
 
   return (
     <AquaUserDashbordLayout>
-      <div className="space-y-8">
+      <div className="space-y-6 sm:space-y-8">
         <section className="grid grid-cols-2 gap-3 xl:grid-cols-4">
           {highlightCards.map(
             ({ title, value, icon: Icon, iconTone, cardClass }) => (
@@ -109,18 +109,18 @@ const AquaUserDashbordPageComponent = () => {
         </section>
 
         <section className="space-y-4">
-          <div className="flex items-end justify-between gap-4">
+          <div className="flex items-start justify-between gap-3">
             <div>
-              <h2 className="text-lg font-semibold text-slate-900">
+              <h2 className="text-base font-semibold text-slate-900 sm:text-lg">
                 Quick cart picks
               </h2>
-              <p className="text-sm text-slate-500">
+              <p className="text-xs leading-5 text-slate-500 sm:text-sm">
                 Review items currently waiting in your cart.
               </p>
             </div>
             <Link
               href="/dashboard/cart"
-              className="inline-flex items-center gap-1 text-sm font-bold text-emerald-700 transition hover:text-emerald-600"
+              className="inline-flex shrink-0 items-center gap-1 whitespace-nowrap text-xs font-bold text-emerald-700 transition hover:text-emerald-600 sm:text-sm"
             >
               View cart <ArrowUpRight className="h-4 w-4" />
             </Link>
@@ -138,25 +138,25 @@ const AquaUserDashbordPageComponent = () => {
               ))}
             </div>
           ) : (
-            <div className="glass-subtle rounded-2xl border border-dashed border-white/40 p-10 text-center text-sm text-slate-500">
+            <div className="glass-subtle rounded-2xl border border-dashed border-white/40 p-6 text-center text-xs leading-5 text-slate-500 sm:p-10 sm:text-sm">
               Your cart is currently empty. Browse products to add them here.
             </div>
           )}
         </section>
 
         <section className="space-y-4">
-          <div className="flex items-end justify-between gap-4">
+          <div className="flex items-start justify-between gap-3">
             <div>
-              <h2 className="text-lg font-semibold text-slate-900">
+              <h2 className="text-base font-semibold text-slate-900 sm:text-lg">
                 Saved favourites
               </h2>
-              <p className="text-sm text-slate-500">
+              <p className="text-xs leading-5 text-slate-500 sm:text-sm">
                 Keep an eye on the products you love.
               </p>
             </div>
             <Link
               href="/dashboard/fav"
-              className="inline-flex items-center gap-1 text-sm font-bold text-emerald-700 transition hover:text-emerald-600"
+              className="inline-flex shrink-0 items-center gap-1 whitespace-nowrap text-xs font-bold text-emerald-700 transition hover:text-emerald-600 sm:text-sm"
             >
               View favourites <ArrowUpRight className="h-4 w-4" />
             </Link>
@@ -174,7 +174,7 @@ const AquaUserDashbordPageComponent = () => {
               ))}
             </div>
           ) : (
-            <div className="glass-subtle rounded-2xl border border-dashed border-white/40 p-10 text-center text-sm text-slate-500">
+            <div className="glass-subtle rounded-2xl border border-dashed border-white/40 p-6 text-center text-xs leading-5 text-slate-500 sm:p-10 sm:text-sm">
               You have no saved favourites yet. Tap the heart icon on a product
               to keep it here.
             </div>

--- a/src/styles/aqua-loader.css
+++ b/src/styles/aqua-loader.css
@@ -259,11 +259,9 @@
 @keyframes aquaPageIn {
   from {
     opacity: 0;
-    transform: translateY(10px);
   }
   to {
     opacity: 1;
-    transform: translateY(0);
   }
 }
 @keyframes aquaCardIn {
@@ -289,13 +287,9 @@
 @keyframes aquaSoftReveal {
   from {
     opacity: 0;
-    filter: blur(8px);
-    transform: translateY(12px);
   }
   to {
     opacity: 1;
-    filter: blur(0);
-    transform: translateY(0);
   }
 }
 @keyframes aquaMediaIn {

--- a/src/styles/home.module.css
+++ b/src/styles/home.module.css
@@ -974,8 +974,24 @@
   }
 
   .collectionGrid {
-    grid-template-columns: 1fr 1fr;
-    gap: 9px;
+    display: flex;
+    gap: 12px;
+    margin-right: -10px;
+    margin-left: -10px;
+    padding: 2px 10px 14px;
+    overflow-x: auto;
+    scroll-snap-type: x mandatory;
+    scrollbar-width: none;
+  }
+
+  .collectionGrid::-webkit-scrollbar {
+    display: none;
+  }
+
+  .collectionGrid > * {
+    width: min(78vw, 300px);
+    flex: 0 0 min(78vw, 300px);
+    scroll-snap-align: start;
   }
 
   .processSection {


### PR DESCRIPTION
## Summary
- fix Safari mobile navigation positioning by removing persistent transform/filter effects from the root page-entry animation
- keep the storefront and dashboard bottom tabs fixed to the viewport with a higher, explicit overlay layer
- remove the duplicate floating festival widget that overlapped the footer and mobile tabs
- add mobile footer clearance so footer actions remain readable above the fixed navigation
- replace the awkward two-column category mosaic with a swipeable, snap-aligned category rail
- compact dashboard empty-state spacing and stop tab action links wrapping on narrow screens

## Root cause
The completed global page animation retained CSS transform/filter values on an ancestor of the fixed navigation. Mobile Safari therefore treated the navigation as fixed to that transformed document container instead of the viewport, making it appear only near the bottom of the page.

## Scope and performance
- no new package
- no new API call
- no JavaScript scroll listener
- category scrolling uses native CSS overflow and scroll snap
- desktop layouts retain their current grids and navigation

## Validation
- inspected the six-file diff against current `PROD`
- confirmed category carousel rules are inside the existing `max-width: 600px` media query
- confirmed fixed-navigation changes apply only to mobile components
- confirmed root animation still fades in, without creating a fixed-position containing block