### PR TITLE
Add real product reviews to the homepage

### DIFF
--- a/src/pageComponents/home/index.js
+++ b/src/pageComponents/home/index.js
@@ -17,6 +17,7 @@ import AquaLayout from "@/components/Layout/Layout";
 import AquaCategoryCard from "@/components/cards/categoryCard";
 import LazyImage from "@/components/image/LazyImage";
 import AquaHomeHero from "./homeHeroSection";
+import AquaHomeReviews from "./reviews";
 import styles from "@/styles/home.module.css";
 
 const AquaProducts = dynamic(() => import("./products"));
@@ -166,6 +167,8 @@ const AquaHomeComponent = ({
           </section>
 
           <AquaProducts initialProducts={initialProducts} />
+
+          <AquaHomeReviews products={initialProducts} />
 
           <section
             className={styles.collectionsSection}

--- a/src/pageComponents/home/reviews.js
+++ b/src/pageComponents/home/reviews.js
@@ -1,0 +1,161 @@
+import Link from "next/link";
+import {
+  ArrowRight,
+  MessageSquareQuote,
+  ShieldCheck,
+  Star,
+} from "lucide-react";
+
+import LazyImage from "@/components/image/LazyImage";
+import styles from "@/styles/home.module.css";
+
+const cleanText = (value = "") =>
+  String(value)
+    .replace(/<[^>]+>/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+
+const reviewerName = (review = {}) => {
+  const value = cleanText(
+    review.name || review.userName || "Aquakart customer",
+  );
+  return value.includes("@") ? value.split("@")[0] : value;
+};
+
+const productHref = (product = {}) =>
+  `/product/${product.slug || product.seoSlug || product._id || product.id}`;
+
+const productImage = (product = {}) => {
+  const photo = product.photos?.[0];
+  return photo?.delivery_url || photo?.secure_url || product.image || "";
+};
+
+const buildReviewFeed = (products = []) =>
+  products
+    .flatMap((product) =>
+      (Array.isArray(product?.reviews) ? product.reviews : []).map(
+        (review) => ({
+          ...review,
+          product,
+          rating: Number(review?.rating),
+          comment: cleanText(review?.comment),
+        }),
+      ),
+    )
+    .filter(
+      (review) =>
+        Number.isFinite(review.rating) &&
+        review.rating >= 1 &&
+        review.rating <= 5 &&
+        review.comment.length >= 12,
+    )
+    .sort((left, right) => {
+      const dateDifference =
+        new Date(right.createdAt || 0) - new Date(left.createdAt || 0);
+      return dateDifference || right.rating - left.rating;
+    });
+
+const Stars = ({ rating }) => (
+  <span className={styles.reviewStars} aria-label={`${rating} out of 5 stars`}>
+    {[1, 2, 3, 4, 5].map((star) => (
+      <Star
+        key={star}
+        size={15}
+        fill={star <= rating ? "currentColor" : "none"}
+      />
+    ))}
+  </span>
+);
+
+const AquaHomeReviews = ({ products = [] }) => {
+  const allReviews = buildReviewFeed(products);
+  const visibleReviews = allReviews.slice(0, 6);
+  if (!visibleReviews.length) return null;
+
+  const average =
+    allReviews.reduce((total, review) => total + review.rating, 0) /
+    allReviews.length;
+
+  return (
+    <section className={styles.reviewsSection} aria-labelledby="reviews-title">
+      <div className={styles.reviewIntro}>
+        <span className={styles.sectionEyebrow}>Real product experiences</span>
+        <h2 id="reviews-title">Trusted at home, reviewed by customers.</h2>
+        <p>
+          See what Aquakart customers say after choosing products for their
+          everyday water needs.
+        </p>
+
+        <div className={styles.reviewScore}>
+          <strong>{average.toFixed(1)}</strong>
+          <div>
+            <Stars rating={Math.round(average)} />
+            <span>
+              Based on {allReviews.length} product review
+              {allReviews.length === 1 ? "" : "s"}
+            </span>
+          </div>
+        </div>
+
+        <div className={styles.reviewTrustNote}>
+          <ShieldCheck size={18} />
+          <span>Reviews are submitted through Aquakart product pages.</span>
+        </div>
+
+        <Link href="/shop" className={styles.reviewShopLink}>
+          Explore reviewed products <ArrowRight size={16} />
+        </Link>
+      </div>
+
+      <div className={styles.reviewGrid}>
+        {visibleReviews.map((review, index) => {
+          const image = productImage(review.product);
+          return (
+            <article
+              key={review._id || `${review.product?._id}-${index}`}
+              className={styles.reviewCard}
+            >
+              <div className={styles.reviewCardTop}>
+                <Stars rating={Math.round(review.rating)} />
+                <MessageSquareQuote size={19} />
+              </div>
+              <blockquote>“{review.comment}”</blockquote>
+              <div className={styles.reviewerMeta}>
+                <span className={styles.reviewerAvatar}>
+                  {reviewerName(review).slice(0, 1).toUpperCase()}
+                </span>
+                <div>
+                  <strong>{reviewerName(review)}</strong>
+                  <span>Aquakart customer</span>
+                </div>
+              </div>
+              <Link
+                href={productHref(review.product)}
+                className={styles.reviewProduct}
+              >
+                {image ? (
+                  <span className={styles.reviewProductImage}>
+                    <LazyImage
+                      src={image}
+                      alt=""
+                      fill
+                      sizes="48px"
+                      imgClassName={styles.reviewProductImageAsset}
+                    />
+                  </span>
+                ) : null}
+                <span>
+                  <small>Reviewed product</small>
+                  <strong>{review.product?.title || "Aquakart product"}</strong>
+                </span>
+                <ArrowRight size={15} />
+              </Link>
+            </article>
+          );
+        })}
+      </div>
+    </section>
+  );
+};
+
+export default AquaHomeReviews;

--- a/src/styles/home.module.css
+++ b/src/styles/home.module.css
@@ -422,6 +422,7 @@
 
 .needsSection,
 .productsSection,
+.reviewsSection,
 .collectionsSection,
 .processSection,
 .editorialSection {
@@ -600,6 +601,234 @@
   display: none;
 }
 
+.reviewsSection {
+  display: grid;
+  grid-template-columns: minmax(260px, 0.72fr) minmax(0, 1.6fr);
+  gap: 48px;
+  padding: 48px;
+  border: 1px solid var(--home-line);
+  border-radius: 28px;
+  background:
+    radial-gradient(
+      circle at 8% 12%,
+      rgba(16, 191, 164, 0.12),
+      transparent 30%
+    ),
+    #f7fbfa;
+}
+
+.reviewIntro {
+  align-self: center;
+}
+
+.reviewIntro h2 {
+  margin: 11px 0 0;
+  font-size: clamp(30px, 3.4vw, 48px);
+  font-weight: 750;
+  letter-spacing: -0.045em;
+  line-height: 1.08;
+}
+
+.reviewIntro > p {
+  margin: 15px 0 0;
+  color: var(--home-muted);
+  font-size: 14px;
+  line-height: 1.75;
+}
+
+.reviewScore {
+  display: flex;
+  align-items: center;
+  gap: 15px;
+  margin-top: 28px;
+}
+
+.reviewScore > strong {
+  font-size: 42px;
+  letter-spacing: -0.05em;
+  line-height: 1;
+}
+
+.reviewScore > div {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.reviewScore > div > span {
+  color: var(--home-muted);
+  font-size: 10px;
+  font-weight: 700;
+}
+
+.reviewStars {
+  display: inline-flex;
+  gap: 2px;
+  color: #f4a51c;
+}
+
+.reviewTrustNote {
+  display: flex;
+  align-items: flex-start;
+  gap: 9px;
+  margin-top: 23px;
+  color: #50646b;
+  font-size: 11px;
+  line-height: 1.5;
+}
+
+.reviewTrustNote svg {
+  flex: 0 0 auto;
+  color: var(--home-green);
+}
+
+.reviewShopLink {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  margin-top: 25px;
+  color: var(--home-green);
+  font-size: 12px;
+  font-weight: 800;
+}
+
+.reviewGrid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 13px;
+}
+
+.reviewCard {
+  display: flex;
+  min-width: 0;
+  min-height: 275px;
+  flex-direction: column;
+  padding: 22px;
+  border: 1px solid #dce9e6;
+  border-radius: 19px;
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: 0 13px 35px rgba(31, 69, 66, 0.06);
+}
+
+.reviewCardTop {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.reviewCardTop > svg {
+  color: #9fb4b5;
+}
+
+.reviewCard blockquote {
+  display: -webkit-box;
+  margin: 18px 0;
+  overflow: hidden;
+  color: #23383f;
+  font-size: 13px;
+  line-height: 1.7;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 4;
+}
+
+.reviewerMeta {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: auto;
+}
+
+.reviewerAvatar {
+  display: flex;
+  width: 35px;
+  height: 35px;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  border-radius: 50%;
+  background: var(--home-mint);
+  color: var(--home-green);
+  font-size: 12px;
+  font-weight: 850;
+}
+
+.reviewerMeta > div {
+  min-width: 0;
+}
+
+.reviewerMeta strong,
+.reviewerMeta span {
+  display: block;
+}
+
+.reviewerMeta strong {
+  overflow: hidden;
+  font-size: 11px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.reviewerMeta span {
+  margin-top: 2px;
+  color: var(--home-muted);
+  font-size: 9px;
+}
+
+.reviewProduct {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 9px;
+  margin-top: 17px;
+  padding-top: 14px;
+  border-top: 1px solid #e4edeb;
+}
+
+.reviewProductImage {
+  position: relative;
+  width: 38px;
+  height: 38px;
+  overflow: hidden;
+  flex: 0 0 auto;
+  border-radius: 9px;
+  background: var(--home-soft);
+}
+
+.reviewProductImageAsset {
+  object-fit: contain;
+}
+
+.reviewProduct > span:nth-child(2) {
+  min-width: 0;
+  flex: 1;
+}
+
+.reviewProduct small,
+.reviewProduct strong {
+  display: block;
+}
+
+.reviewProduct small {
+  color: var(--home-green);
+  font-size: 8px;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.reviewProduct strong {
+  margin-top: 3px;
+  overflow: hidden;
+  font-size: 10px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.reviewProduct > svg {
+  flex: 0 0 auto;
+  color: #819498;
+}
+
 .collectionGrid {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
@@ -739,6 +968,10 @@
   .processSection {
     grid-template-columns: 1fr;
     gap: 42px;
+  }
+
+  .reviewsSection {
+    grid-template-columns: 1fr;
   }
 }
 
@@ -909,6 +1142,7 @@
 
   .needsSection,
   .productsSection,
+  .reviewsSection,
   .collectionsSection,
   .processSection,
   .editorialSection {
@@ -928,6 +1162,34 @@
 
   .sectionHeading > .textLink {
     display: none;
+  }
+
+  .reviewsSection {
+    gap: 30px;
+    padding: 30px 18px;
+    border-radius: 22px;
+  }
+
+  .reviewGrid {
+    display: flex;
+    margin-right: -18px;
+    margin-left: -18px;
+    padding: 2px 18px 14px;
+    overflow-x: auto;
+    gap: 12px;
+    scroll-snap-type: x mandatory;
+    scrollbar-width: none;
+  }
+
+  .reviewGrid::-webkit-scrollbar {
+    display: none;
+  }
+
+  .reviewCard {
+    width: min(82vw, 310px);
+    min-height: 280px;
+    flex: 0 0 min(82vw, 310px);
+    scroll-snap-align: start;
   }
 
   .needCard {


### PR DESCRIPTION
## What changed

- adds a polished customer-review section after the featured products on the homepage
- builds the feed from real reviews already returned with the product catalogue
- shows aggregate rating and total written-review count
- displays up to six recent reviews with customer name, star rating and reviewed product
- links every review card back to its product page
- uses a responsive two-column layout on desktop and a swipeable carousel-style row on mobile
- hides the entire section when no valid written reviews exist

## Trust and accuracy

The section only includes reviews with a valid 1–5 rating and a meaningful written comment. It does not claim “verified purchase,” because purchase verification is not currently stored in the review model. Reviews are ordered by recency rather than cherry-picking the highest ratings.

## Performance

No additional browser request is introduced. The homepage reuses review data from the existing server-rendered product response.

## Validation

- files formatted with the repository-compatible Prettier version
- `git diff --check` passes
- full Next.js build was not run because this checkout does not contain the e-commerce dependencies