### PR TITLE
Polish product rails and homepage cards

### DIFF
--- a/src/components/cards/RelatedProductCard.js
+++ b/src/components/cards/RelatedProductCard.js
@@ -86,7 +86,7 @@ const AquaRelatedProductCard = ({ product }) => {
   };
 
   return (
-    <article className="group flex h-full min-h-[30rem] w-full flex-col overflow-hidden rounded-[2rem] border border-white/85 bg-white/88 shadow-[0_22px_65px_rgba(15,23,42,0.1)] backdrop-blur-xl transition hover:-translate-y-1 hover:shadow-[0_28px_75px_rgba(15,23,42,0.14)] focus-within:ring-2 focus-within:ring-emerald-400 focus-within:ring-offset-2">
+    <article className="group flex h-full min-h-[30rem] w-full flex-col overflow-hidden rounded-[2rem] border border-slate-200 bg-white shadow-none transition-colors hover:border-emerald-300 focus-within:border-emerald-400 focus-within:ring-2 focus-within:ring-emerald-300 focus-within:ring-offset-2">
       <div className="relative aspect-[4/3] overflow-hidden bg-[radial-gradient(circle_at_50%_35%,#ffffff_0%,#ecfeff_48%,#d1fae5_100%)]">
         {/* Embla Carousel */}
         <div className="h-full overflow-hidden" ref={emblaRef}>
@@ -125,7 +125,7 @@ const AquaRelatedProductCard = ({ product }) => {
         >
           <button
             type="button"
-            className={`rounded-full p-2.5 shadow-lg ring-1 ring-white/80 backdrop-blur-xl transition-all duration-300 ${
+            className={`rounded-full border border-slate-200 p-2.5 shadow-none backdrop-blur-xl transition-all duration-300 ${
               isFavorite ? "bg-rose-100/95" : "bg-white/80"
             } hover:bg-white`}
           >
@@ -145,14 +145,14 @@ const AquaRelatedProductCard = ({ product }) => {
         </motion.div>
 
         {priceDetails.discountPercent ? (
-          <div className="absolute left-4 top-4 inline-flex items-center rounded-full bg-emerald-500/95 px-3 py-1.5 text-[10px] font-black uppercase tracking-[0.12em] text-white shadow-lg shadow-emerald-500/20">
+          <div className="absolute left-4 top-4 inline-flex items-center rounded-full bg-emerald-500/95 px-3 py-1.5 text-[10px] font-black uppercase tracking-[0.12em] text-white">
             Save {priceDetails.discountPercent}%
           </div>
         ) : null}
 
         {/* Timeline Indicators */}
         {displayPhotos.length > 1 && (
-          <div className="absolute bottom-3 left-1/2 flex -translate-x-1/2 space-x-1.5 rounded-full bg-white/70 px-2.5 py-2 shadow-sm backdrop-blur-xl">
+          <div className="absolute bottom-3 left-1/2 flex -translate-x-1/2 space-x-1.5 rounded-full border border-slate-200 bg-white/85 px-2.5 py-2 backdrop-blur-xl">
             {displayPhotos.slice(0, 5).map((_, index) => (
               <button
                 type="button"
@@ -211,7 +211,7 @@ const AquaRelatedProductCard = ({ product }) => {
 
           <motion.button
             type="button"
-            className={`relative inline-flex items-center justify-center rounded-full px-4 py-2 text-xs font-semibold text-white shadow transition-all duration-300 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-1 ${
+            className={`relative inline-flex items-center justify-center rounded-full px-4 py-2 text-xs font-semibold text-white transition-all duration-300 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-1 ${
               isInCart ? "bg-emerald-600" : "bg-slate-900 hover:bg-slate-800"
             }`}
             whileTap={{ scale: 0.95 }}

--- a/src/components/cards/categoryCard.js
+++ b/src/components/cards/categoryCard.js
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import React, { useMemo } from "react";
+import { ArrowUpRight } from "lucide-react";
 
 const FALLBACK_CATEGORY_IMAGE =
   "https://res.cloudinary.com/aquakartproducts/image/upload/v1695408027/android-chrome-512x512_kfw439.png";
@@ -38,25 +39,39 @@ const AquaCategoryCard = ({ category, variant = "catalog" }) => {
     return (
       <Link
         href={href}
-        className={`${baseCardClass} aspect-[16/10] min-h-[142px] rounded-2xl border-white/70 shadow-[0_16px_36px_rgba(15,23,42,0.08)] hover:-translate-y-1 hover:border-emerald-200 hover:shadow-[0_22px_54px_rgba(15,23,42,0.12)]`}
+        className={`${baseCardClass} min-h-[22rem] rounded-[1.75rem] border-slate-200/80 p-2 shadow-[0_18px_48px_rgba(15,23,42,0.09)] hover:-translate-y-1 hover:border-emerald-300 hover:shadow-[0_26px_64px_rgba(15,23,42,0.14)]`}
       >
-        <img
-          src={imageUrl}
-          alt={title}
-          className="absolute inset-0 h-full w-full object-cover object-center transition duration-500 group-hover:scale-105"
-          loading="lazy"
-        />
-        <div className="absolute inset-0 bg-gradient-to-t from-slate-950/80 via-slate-950/15 to-white/5 transition duration-300 group-hover:from-slate-950/70" />
-        <div className="absolute inset-x-0 bottom-0 p-4 text-white">
-          <h3
-            className="min-h-[40px] text-sm font-extrabold leading-5 drop-shadow-md sm:text-[15px]"
-            style={clampTwoLines}
-            title={title}
+        <div className="relative h-[15rem] overflow-hidden rounded-[1.35rem] bg-gradient-to-br from-cyan-50 via-white to-emerald-50">
+          <img
+            src={imageUrl}
+            alt={title}
+            className="absolute inset-0 h-full w-full object-cover object-center transition duration-700 group-hover:scale-[1.06]"
+            loading="lazy"
+          />
+          <div className="absolute inset-0 bg-gradient-to-t from-slate-950/30 via-transparent to-white/10" />
+          <span className="absolute left-3 top-3 rounded-full border border-white/70 bg-white/85 px-3 py-1.5 text-[9px] font-black uppercase tracking-[0.16em] text-emerald-700 shadow-sm backdrop-blur-xl">
+            Aquakart collection
+          </span>
+        </div>
+
+        <div className="flex min-h-[6rem] items-center justify-between gap-3 px-3 py-3">
+          <div className="min-w-0">
+            <span className="text-[9px] font-black uppercase tracking-[0.17em] text-slate-400">
+              Better water starts here
+            </span>
+            <h3
+              className="mt-1 text-lg font-black leading-tight tracking-tight text-slate-950 transition group-hover:text-emerald-700"
+              style={clampTwoLines}
+              title={title}
+            >
+              {title}
+            </h3>
+          </div>
+          <span
+            className="flex h-11 w-11 flex-none items-center justify-center rounded-full bg-slate-950 text-white shadow-lg transition duration-300 group-hover:rotate-6 group-hover:bg-emerald-600"
+            aria-hidden="true"
           >
-            {title}
-          </h3>
-          <span className="mt-1 inline-flex translate-y-2 items-center gap-1 text-[10px] font-bold uppercase tracking-wide text-emerald-200 opacity-0 transition-all duration-300 group-hover:translate-y-0 group-hover:opacity-100">
-            View Collection
+            <ArrowUpRight size={19} />
           </span>
         </div>
       </Link>

--- a/src/pageComponents/products/AquaProductRevamp.js
+++ b/src/pageComponents/products/AquaProductRevamp.js
@@ -1436,7 +1436,7 @@ function AquaProductRevamp({
                   className="overflow-hidden px-1 pb-3"
                   ref={relatedProductRef}
                 >
-                  <div className="flex items-stretch gap-3 sm:gap-5">
+                  <div className="flex items-stretch">
                     <Suspense
                       fallback={
                         <div className="h-96 min-w-[280px] animate-pulse rounded-[2rem] bg-white/60" />
@@ -1445,7 +1445,7 @@ function AquaProductRevamp({
                       {relatedProducts.map((item) => (
                         <div
                           key={item._id}
-                          className="min-w-0 flex-[0_0_88%] sm:flex-[0_0_48%] lg:flex-[0_0_31%]"
+                          className="box-border min-w-0 flex-[0_0_88%] pr-3 sm:flex-[0_0_48%] sm:pr-5 lg:flex-[0_0_31%]"
                         >
                           <AquaRelatedProductCard product={item} />
                         </div>

--- a/src/pageComponents/products/AquaProductRevamp.js
+++ b/src/pageComponents/products/AquaProductRevamp.js
@@ -914,6 +914,7 @@ function AquaProductRevamp({
   stockCount = 0,
   fallbackImage = DEFAULT_FALLBACK_IMAGE,
 }) {
+  const shouldReduceCarouselMotion = useReducedMotion();
   const [isLoading, setIsLoading] = useState(true);
   const [reviews, setReviews] = useState([]);
   const [reviewsLoading, setReviewsLoading] = useState(true);
@@ -1018,6 +1019,20 @@ function AquaProductRevamp({
       relatedProductApi.off("reInit", updateRelatedIndex);
     };
   }, [relatedProductApi]);
+
+  useEffect(() => {
+    if (
+      !relatedProductApi ||
+      shouldReduceCarouselMotion ||
+      relatedProducts.length < 2
+    )
+      return undefined;
+    const timer = window.setInterval(
+      () => relatedProductApi.scrollNext(),
+      4500,
+    );
+    return () => window.clearInterval(timer);
+  }, [relatedProductApi, relatedProducts.length, shouldReduceCarouselMotion]);
 
   const scrollPrev = () => relatedProductApi?.scrollPrev();
   const scrollNext = () => relatedProductApi?.scrollNext();
@@ -1433,7 +1448,7 @@ function AquaProductRevamp({
                 </div>
 
                 <div
-                  className="overflow-hidden px-1 pb-3"
+                  className="overflow-hidden px-2 py-2"
                   ref={relatedProductRef}
                 >
                   <div className="flex items-stretch">


### PR DESCRIPTION
## What changed

### Product rail
- keeps the Similar products rail looping infinitely
- automatically advances every 4.5 seconds while respecting reduced-motion preferences
- uses measured per-slide spacing for consistent scroll gaps at every breakpoint
- adds internal viewport padding so borders and focus rings are not clipped

### Product-card clarity
- removes the large card, badge and action shadows that were visually cutting across card edges
- replaces shadow separation with crisp slate borders and emerald hover/focus borders
- removes hover translation so cards remain aligned in the rail
- preserves clear image, price, review, favourite and cart actions

### Homepage categories
- redesigns collection cards as premium commerce cards
- adds a framed image, collection badge, persistent category title and Explore action
- keeps equal heights and responsive swipe/grid behavior

## Validation

- Prettier completed
- `git diff --check` passes

## Scope

Only the product rail, related-product card and shared category-card components are included. Unrelated invoice-review work is excluded.