### PR TITLE
Clean up shop cards and dashboard scrolling

### DIFF
--- a/src/components/cards/ProductCardTwo.js
+++ b/src/components/cards/ProductCardTwo.js
@@ -156,11 +156,11 @@ const ReusableProductCard = ({
   const renderRatingBadge = (variant = "overlay") => {
     if (!reviewStats.ratingValue && !reviewStats.ratingCount) return null;
     const base =
-      "absolute z-20 inline-flex items-center gap-1 rounded-full font-semibold shadow";
+      "absolute z-20 inline-flex items-center gap-1 rounded-full border font-semibold";
     const styles =
       variant === "light"
-        ? "bottom-3 left-3 bg-white/95 px-2 py-1 text-[11px] text-slate-800"
-        : "left-4 top-14 bg-black/35 px-2.5 py-1.5 text-xs text-white backdrop-blur";
+        ? "bottom-3 left-3 border-slate-200 bg-white px-2 py-1 text-[11px] text-slate-800"
+        : "left-4 top-14 border-white/30 bg-black/45 px-2.5 py-1.5 text-xs text-white";
     return (
       <div className={`${base} ${styles}`}>
         <FaStar className="text-amber-400" size={12} />
@@ -232,7 +232,7 @@ const ReusableProductCard = ({
     const label = fav && cart ? "Saved + In cart" : fav ? "Saved" : "In cart";
     return (
       <span
-        className={`absolute right-4 top-[4.6rem] z-20 inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-[10px] font-black shadow-lg backdrop-blur-md ${
+        className={`absolute right-4 top-[4.6rem] z-20 inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-[10px] font-black ${
           fav && cart
             ? "border-violet-200 bg-violet-600/95 text-white"
             : fav
@@ -299,7 +299,7 @@ const ReusableProductCard = ({
         tabIndex={0}
         onClick={handleNavigate}
         onKeyDown={handleKeyPress}
-        className={`group relative flex cursor-pointer gap-6 rounded-2xl glass-card p-4 transition-all duration-300 hover:shadow-[0_16px_48px_rgba(0,0,0,0.1)] focus:outline-none focus:ring-2 focus:ring-emerald-400 focus:ring-offset-2 ${
+        className={`group relative flex cursor-pointer gap-6 rounded-2xl border border-slate-200 bg-white p-4 transition-colors duration-200 hover:border-emerald-300 hover:bg-emerald-50/20 focus:outline-none focus:ring-2 focus:ring-emerald-400 focus:ring-offset-2 ${
           fav ? "border-rose-200" : ""
         } ${cart ? "ring-1 ring-emerald-300" : ""}`}
         aria-label={`View details for ${title}`}
@@ -346,7 +346,7 @@ const ReusableProductCard = ({
             type="button"
             onClick={handleFavToggle}
             aria-label={fav ? "Remove from wishlist" : "Add to wishlist"}
-            className={`absolute top-2 right-2 z-10 rounded-full border p-2 shadow-lg transition-all duration-300 ${
+            className={`absolute top-2 right-2 z-10 rounded-full border p-2 transition-colors duration-200 ${
               fav
                 ? "border-rose-500 bg-white/90 text-rose-600 hover:bg-rose-500 hover:text-white"
                 : "border-white/70 bg-white/80 text-slate-500 hover:border-rose-300 hover:text-rose-500"
@@ -401,7 +401,7 @@ const ReusableProductCard = ({
               onClick={handleCartToggle}
               type="button"
               aria-label={cart ? "Remove from cart" : "Add to cart"}
-              className={`flex-1 rounded-full py-3 text-sm font-semibold shadow-md transition-all duration-300 ${
+              className={`flex-1 rounded-full py-3 text-sm font-semibold transition-colors duration-200 ${
                 cart
                   ? "bg-emerald-500 text-white hover:bg-emerald-600"
                   : "bg-slate-900 text-white hover:bg-slate-800"
@@ -429,7 +429,7 @@ const ReusableProductCard = ({
       {isGlass ? (
         <div
           className={[
-            "group relative h-[460px] w-full cursor-pointer overflow-hidden rounded-[30px] border border-white/50 bg-white/20 shadow-[0_10px_34px_rgba(15,23,42,0.12)] backdrop-blur-sm transition-shadow duration-300 hover:shadow-[0_18px_48px_rgba(15,23,42,0.18)]",
+            "group relative h-[460px] w-full cursor-pointer overflow-hidden rounded-[30px] border border-slate-200 bg-white transition-colors duration-200 hover:border-emerald-300",
             fav ? "ring-2 ring-rose-500 ring-offset-2" : "",
             cart
               ? "outline outline-2 outline-emerald-500 outline-offset-[-2px]"
@@ -488,8 +488,10 @@ const ReusableProductCard = ({
           <button
             onClick={handleFavToggle}
             aria-label={fav ? "Remove from wishlist" : "Add to wishlist"}
-            className={`absolute right-4 top-4 z-20 rounded-full p-3 shadow ${
-              fav ? "bg-rose-500 text-white" : "bg-white/90 text-slate-600"
+            className={`absolute right-4 top-4 z-20 rounded-full border p-3 transition-colors ${
+              fav
+                ? "border-rose-500 bg-rose-500 text-white"
+                : "border-slate-200 bg-white text-slate-600 hover:border-rose-300 hover:text-rose-500"
             }`}
           >
             <FaHeart size={18} />
@@ -512,7 +514,7 @@ const ReusableProductCard = ({
                 <p className="text-[11px] font-bold uppercase tracking-[0.14em] text-white/70">
                   {product?.brand || "Aquakart"}
                 </p>
-                <h3 className="line-clamp-2 text-xl font-black leading-snug drop-shadow-sm">
+                <h3 className="line-clamp-2 text-xl font-black leading-snug">
                   {title}
                 </h3>
                 {description && (
@@ -573,10 +575,10 @@ const ReusableProductCard = ({
               <button
                 onClick={handleCartToggle}
                 type="button"
-                className={`flex w-full items-center justify-center gap-2 rounded-full px-5 py-3.5 text-sm font-black shadow-lg transition-colors ${
+                className={`flex w-full items-center justify-center gap-2 rounded-full border px-5 py-3.5 text-sm font-black transition-colors ${
                   cart
-                    ? "bg-emerald-500 text-white hover:bg-emerald-600"
-                    : "bg-white text-slate-950 hover:bg-slate-100"
+                    ? "border-emerald-500 bg-emerald-500 text-white hover:bg-emerald-600"
+                    : "border-white bg-white text-slate-950 hover:bg-slate-100"
                 }`}
                 aria-label={cart ? "Remove from cart" : "Add to cart"}
               >
@@ -592,7 +594,7 @@ const ReusableProductCard = ({
           tabIndex={0}
           onClick={handleNavigate}
           onKeyDown={handleKeyPress}
-          className={`group relative flex h-full cursor-pointer flex-col overflow-hidden rounded-[30px] border bg-white p-3 shadow-[0_10px_32px_rgba(15,23,42,0.07)] transition-shadow duration-300 hover:shadow-[0_16px_42px_rgba(15,23,42,0.12)] focus:outline-none focus:ring-2 focus:ring-emerald-400 focus:ring-offset-2 ${
+          className={`group relative flex h-full cursor-pointer flex-col overflow-hidden rounded-[26px] border bg-white p-3 transition-colors duration-200 hover:border-emerald-400 hover:bg-emerald-50/20 focus:outline-none focus:ring-2 focus:ring-emerald-400 focus:ring-offset-2 ${
             fav ? "border-rose-200" : "border-slate-200/80"
           } ${cart ? "ring-1 ring-emerald-300" : ""}`}
           aria-label={`View details for ${title}`}
@@ -644,7 +646,7 @@ const ReusableProductCard = ({
               type="button"
               onClick={handleFavToggle}
               aria-label={fav ? "Remove from wishlist" : "Add to wishlist"}
-              className={`absolute top-4 right-4 z-10 rounded-full border p-3 transition-all duration-300 shadow-lg ${
+              className={`absolute top-4 right-4 z-10 rounded-full border p-3 transition-colors duration-200 ${
                 fav
                   ? "border-rose-500 bg-white/90 text-rose-600 hover:bg-rose-500 hover:text-white"
                   : "border-white/70 bg-white/80 text-slate-500 hover:border-rose-300 hover:text-rose-500"
@@ -731,10 +733,10 @@ const ReusableProductCard = ({
               <button
                 onClick={handleCartToggle}
                 type="button"
-                className={`flex w-full items-center justify-center gap-2 rounded-full px-5 py-3 text-sm font-black shadow-sm transition-colors ${
+                className={`flex w-full items-center justify-center gap-2 rounded-full border px-5 py-3 text-sm font-black transition-colors ${
                   cart
-                    ? "bg-emerald-500 text-white hover:bg-emerald-600"
-                    : "bg-slate-950 text-white hover:bg-emerald-700"
+                    ? "border-emerald-500 bg-emerald-500 text-white hover:bg-emerald-600"
+                    : "border-slate-950 bg-slate-950 text-white hover:border-emerald-700 hover:bg-emerald-700"
                 }`}
                 aria-label={cart ? "Remove from cart" : "Add to cart"}
               >

--- a/src/pageComponents/shop/index.js
+++ b/src/pageComponents/shop/index.js
@@ -161,7 +161,7 @@ const FilterChip = ({ label, onRemove }) => (
     initial={{ opacity: 0, scale: 0.9 }}
     animate={{ opacity: 1, scale: 1 }}
     exit={{ opacity: 0, scale: 0.9 }}
-    className="inline-flex min-h-9 items-center gap-2 rounded-full border border-emerald-200/80 bg-emerald-50/85 px-3 text-[11px] font-bold text-emerald-800 shadow-sm"
+    className="inline-flex min-h-9 items-center gap-2 rounded-full border border-emerald-200 bg-emerald-50 px-3 text-[11px] font-bold text-emerald-800"
   >
     {label}
     <button
@@ -438,7 +438,7 @@ const AquaShopPageComponent = ({
       <button
         type="button"
         onClick={() => setShowFilters(false)}
-        className="inline-flex min-h-12 items-center justify-center gap-2 rounded-2xl bg-slate-950 px-4 text-xs font-black text-white shadow-[0_14px_28px_rgba(15,23,42,0.2)] transition hover:bg-emerald-700"
+        className="inline-flex min-h-12 items-center justify-center gap-2 rounded-2xl border border-slate-950 bg-slate-950 px-4 text-xs font-black text-white transition hover:border-emerald-700 hover:bg-emerald-700"
       >
         View {filteredAndSortedProducts.length} products{" "}
         <ArrowRight size={15} />
@@ -460,7 +460,7 @@ const AquaShopPageComponent = ({
           subtext="Matching products, prices and availability for you."
         />
       ) : error ? (
-        <section className="mx-auto my-12 flex min-h-[58vh] w-[calc(100%-2rem)] max-w-3xl flex-col items-center justify-center overflow-hidden rounded-[2.5rem] border border-white/80 bg-white/75 p-8 text-center shadow-[0_30px_80px_rgba(15,23,42,0.1)] backdrop-blur-2xl">
+        <section className="mx-auto my-12 flex min-h-[58vh] w-[calc(100%-2rem)] max-w-3xl flex-col items-center justify-center overflow-hidden rounded-[2.5rem] border border-slate-200 bg-white p-8 text-center">
           <div className="grid h-16 w-16 place-items-center rounded-2xl bg-rose-50 text-rose-500">
             <Droplets size={28} />
           </div>
@@ -476,7 +476,7 @@ const AquaShopPageComponent = ({
           <button
             type="button"
             onClick={fetchProducts}
-            className="mt-7 inline-flex min-h-12 items-center gap-2 rounded-full bg-slate-950 px-6 text-xs font-black text-white shadow-lg transition hover:bg-emerald-700"
+            className="mt-7 inline-flex min-h-12 items-center gap-2 rounded-full border border-slate-950 bg-slate-950 px-6 text-xs font-black text-white transition hover:border-emerald-700 hover:bg-emerald-700"
           >
             Refresh catalogue <RotateCcw size={15} />
           </button>
@@ -493,7 +493,7 @@ const AquaShopPageComponent = ({
             <section id="shop-products" className="scroll-mt-28">
               <div className="grid items-start gap-6 lg:grid-cols-[280px_minmax(0,1fr)] xl:grid-cols-[310px_minmax(0,1fr)]">
                 <aside className="hidden lg:block">
-                  <div className="sticky top-[92px] max-h-[calc(100vh-108px)] overflow-y-auto rounded-[1.75rem] border border-white/80 bg-white/78 p-4 shadow-[0_18px_55px_rgba(15,23,42,0.08)] backdrop-blur-2xl">
+                  <div className="sticky top-[92px] max-h-[calc(100vh-108px)] overflow-y-auto rounded-[1.75rem] border border-slate-200 bg-white p-4">
                     <div className="mb-4 flex items-center justify-between border-b border-slate-200/70 pb-4">
                       <div>
                         <span className="text-[9px] font-black uppercase tracking-[0.18em] text-emerald-700">
@@ -529,12 +529,12 @@ const AquaShopPageComponent = ({
                 </aside>
 
                 <div className="min-w-0">
-                  <div className="sticky top-[76px] z-30 mb-4 rounded-[1.65rem] border border-white/80 bg-[rgba(248,252,251,0.96)] p-2.5 shadow-[0_18px_55px_rgba(15,23,42,0.09)] backdrop-blur-2xl sm:top-[92px] sm:p-3">
+                  <div className="sticky top-[76px] z-30 mb-4 rounded-[1.65rem] border border-slate-200 bg-white p-2.5 sm:top-[92px] sm:p-3">
                     <div className="flex items-center gap-2.5">
                       <button
                         type="button"
                         onClick={() => setShowFilters(true)}
-                        className="relative inline-flex h-12 shrink-0 items-center gap-2 rounded-2xl bg-slate-950 px-4 text-xs font-black text-white shadow-lg transition hover:bg-emerald-700 lg:hidden"
+                        className="relative inline-flex h-12 shrink-0 items-center gap-2 rounded-2xl border border-slate-950 bg-slate-950 px-4 text-xs font-black text-white transition hover:border-emerald-700 hover:bg-emerald-700 lg:hidden"
                       >
                         <SlidersHorizontal size={17} />
                         <span className="hidden sm:inline">Tune filters</span>

--- a/src/pageComponents/shop/productGrid.js
+++ b/src/pageComponents/shop/productGrid.js
@@ -49,7 +49,7 @@ const ProductGrid = ({ products = [], viewMode = "grid" }) => {
           <ReusableProductCard
             product={product}
             viewMode={viewMode}
-            variant="glass"
+            variant="standard"
             imagePriority={index < 4}
           />
         </motion.div>

--- a/src/pageComponents/shop/shopFilter.jsx
+++ b/src/pageComponents/shop/shopFilter.jsx
@@ -28,7 +28,7 @@ const FilterSection = ({
   onToggle,
   children,
 }) => (
-  <section className="overflow-hidden rounded-2xl border border-slate-200/75 bg-white/70 shadow-[0_10px_30px_rgba(15,23,42,0.035)]">
+  <section className="overflow-hidden rounded-2xl border border-slate-200 bg-white">
     <button
       type="button"
       onClick={onToggle}
@@ -78,7 +78,7 @@ const ChoiceButton = ({ selected, label, onClick, count }) => (
     onClick={onClick}
     className={`group flex w-full items-center gap-2 rounded-xl border px-3 py-2.5 text-left text-xs font-bold transition ${
       selected
-        ? "border-emerald-200 bg-emerald-50 text-emerald-800 shadow-sm"
+        ? "border-emerald-300 bg-emerald-50 text-emerald-800"
         : "border-transparent bg-slate-50/80 text-slate-600 hover:border-slate-200 hover:bg-white hover:text-slate-950"
     }`}
   >
@@ -131,7 +131,7 @@ const ToggleRow = ({ checked, onChange, icon: Icon, title, description }) => (
       }`}
     >
       <span
-        className={`absolute top-1 h-4 w-4 rounded-full bg-white shadow transition-transform ${
+        className={`absolute top-1 h-4 w-4 rounded-full border border-slate-200 bg-white transition-transform ${
           checked ? "translate-x-6" : "translate-x-1"
         }`}
       />
@@ -301,7 +301,7 @@ const ShopFiltersPanel = ({
               onChange={(event) =>
                 onFilterChange("price", Number(event.target.value))
               }
-              className="relative z-10 h-7 w-full cursor-pointer appearance-none bg-transparent accent-emerald-500 [&::-moz-range-thumb]:h-5 [&::-moz-range-thumb]:w-5 [&::-moz-range-thumb]:rounded-full [&::-moz-range-thumb]:border-2 [&::-moz-range-thumb]:border-white [&::-moz-range-thumb]:bg-emerald-500 [&::-webkit-slider-thumb]:h-5 [&::-webkit-slider-thumb]:w-5 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:border-2 [&::-webkit-slider-thumb]:border-white [&::-webkit-slider-thumb]:bg-emerald-500 [&::-webkit-slider-thumb]:shadow-lg"
+              className="relative z-10 h-7 w-full cursor-pointer appearance-none bg-transparent accent-emerald-500 [&::-moz-range-thumb]:h-5 [&::-moz-range-thumb]:w-5 [&::-moz-range-thumb]:rounded-full [&::-moz-range-thumb]:border-2 [&::-moz-range-thumb]:border-white [&::-moz-range-thumb]:bg-emerald-500 [&::-webkit-slider-thumb]:h-5 [&::-webkit-slider-thumb]:w-5 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:border-2 [&::-webkit-slider-thumb]:border-white [&::-webkit-slider-thumb]:bg-emerald-500"
             />
           </div>
         </div>

--- a/src/pageComponents/userDasboard/layout/header.js
+++ b/src/pageComponents/userDasboard/layout/header.js
@@ -12,9 +12,19 @@ import {
 
 const navItems = [
   { id: "dashboard", label: "Dashboard", href: "/dashboard", icon: Home },
-  { id: "orders", label: "Orders", href: "/dashboard/orders", icon: ShoppingBag },
+  {
+    id: "orders",
+    label: "Orders",
+    href: "/dashboard/orders",
+    icon: ShoppingBag,
+  },
   { id: "cart", label: "Cart", href: "/dashboard/cart", icon: ShoppingCart },
-  { id: "favourites", label: "Favourites", href: "/dashboard/fav", icon: Heart },
+  {
+    id: "favourites",
+    label: "Favourites",
+    href: "/dashboard/fav",
+    icon: Heart,
+  },
   { id: "profile", label: "Profile", href: "/dashboard/profile", icon: User },
 ];
 
@@ -32,9 +42,9 @@ const NavigationItem = ({ item, pathname, mobile = false }) => {
       scroll={false}
       aria-label={item.label}
       aria-current={active ? "page" : undefined}
-      className={`group relative grid h-11 w-11 place-items-center rounded-[14px] transition-[background-color,color,box-shadow,transform] duration-200 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950 ${
+      className={`group relative grid h-11 w-11 place-items-center rounded-[14px] transition-[background-color,color,transform] duration-200 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950 ${
         active
-          ? "bg-emerald-500 text-slate-950 shadow-[0_8px_22px_rgba(16,185,129,0.3)]"
+          ? "bg-emerald-500 text-slate-950"
           : "text-slate-400 hover:-translate-y-0.5 hover:bg-white/10 hover:text-emerald-300"
       }`}
     >
@@ -56,7 +66,7 @@ const AquaUserDashboardHeader = () => {
 
   return (
     <>
-      <aside className="sticky top-4 hidden h-[calc(100vh-2rem)] w-[72px] shrink-0 flex-col items-center rounded-[26px] border border-white/10 bg-slate-950 px-3 py-3 shadow-[0_20px_55px_rgba(15,23,42,0.2)] lg:flex">
+      <aside className="sticky top-4 hidden h-[calc(100vh-2rem)] w-[72px] shrink-0 flex-col items-center rounded-[26px] border border-slate-800 bg-slate-950 px-3 py-3 lg:flex">
         <Link
           href="/"
           aria-label="Open Aquakart shop"
@@ -72,7 +82,10 @@ const AquaUserDashboardHeader = () => {
           />
         </Link>
 
-        <nav className="my-auto flex flex-col items-center gap-2" aria-label="User dashboard tabs">
+        <nav
+          className="my-auto flex flex-col items-center gap-2"
+          aria-label="User dashboard tabs"
+        >
           {navItems.map((item) => (
             <NavigationItem key={item.id} item={item} pathname={pathname} />
           ))}
@@ -90,9 +103,17 @@ const AquaUserDashboardHeader = () => {
         </Link>
       </aside>
 
-      <nav className="fixed bottom-3 left-1/2 z-50 flex -translate-x-1/2 items-center gap-1 rounded-[20px] border border-white/10 bg-slate-950/95 px-2 py-2 shadow-[0_18px_50px_rgba(15,23,42,0.28)] backdrop-blur lg:hidden" aria-label="User dashboard tabs">
+      <nav
+        className="fixed bottom-3 left-1/2 z-50 flex -translate-x-1/2 items-center gap-1 rounded-[20px] border border-white/10 bg-slate-950/95 px-2 py-2 shadow-[0_18px_50px_rgba(15,23,42,0.28)] backdrop-blur lg:hidden"
+        aria-label="User dashboard tabs"
+      >
         {navItems.map((item) => (
-          <NavigationItem key={item.id} item={item} pathname={pathname} mobile />
+          <NavigationItem
+            key={item.id}
+            item={item}
+            pathname={pathname}
+            mobile
+          />
         ))}
         <span
           className="mx-0.5 h-7 w-px shrink-0 bg-white/15"

--- a/src/pageComponents/userDasboard/layout/layout.js
+++ b/src/pageComponents/userDasboard/layout/layout.js
@@ -5,12 +5,30 @@ import { useSelector } from "react-redux";
 import { useRouter } from "next/router";
 
 const ROUTE_COPY = {
-  "/dashboard": { title: "Dashboard", subtitle: "Your Aquakart snapshot at a glance." },
-  "/dashboard/profile": { title: "Profile", subtitle: "Review and update your personal details." },
-  "/dashboard/settings": { title: "Settings", subtitle: "Fine-tune how you experience Aquakart." },
-  "/dashboard/orders": { title: "Orders", subtitle: "Track every purchase and its delivery status." },
-  "/dashboard/cart": { title: "Cart", subtitle: "Quick access to items waiting for checkout." },
-  "/dashboard/fav": { title: "Favourites", subtitle: "All the products you've saved for later." },
+  "/dashboard": {
+    title: "Dashboard",
+    subtitle: "Your Aquakart snapshot at a glance.",
+  },
+  "/dashboard/profile": {
+    title: "Profile",
+    subtitle: "Review and update your personal details.",
+  },
+  "/dashboard/settings": {
+    title: "Settings",
+    subtitle: "Fine-tune how you experience Aquakart.",
+  },
+  "/dashboard/orders": {
+    title: "Orders",
+    subtitle: "Track every purchase and its delivery status.",
+  },
+  "/dashboard/cart": {
+    title: "Cart",
+    subtitle: "Quick access to items waiting for checkout.",
+  },
+  "/dashboard/fav": {
+    title: "Favourites",
+    subtitle: "All the products you've saved for later.",
+  },
 };
 
 const AquaUserDashbordLayout = ({ children, title, subtitle }) => {
@@ -28,23 +46,31 @@ const AquaUserDashbordLayout = ({ children, title, subtitle }) => {
   return (
     <div className="relative min-h-screen bg-slate-50">
       <AquaCartAddressDialog />
-      <div className="mx-auto flex w-full max-w-[1320px] items-start gap-4 px-3 py-4 sm:px-5 lg:h-screen lg:items-stretch lg:gap-5 lg:overflow-hidden">
+      <div className="mx-auto flex w-full max-w-[1320px] items-start gap-4 px-3 py-4 sm:px-5 lg:gap-5">
         <AquaUserDashboardHeader />
 
-        <main className="min-h-[calc(100vh-2rem)] min-w-0 flex-1 pb-24 lg:flex lg:h-[calc(100vh-2rem)] lg:min-h-0 lg:flex-col lg:overflow-hidden lg:pb-0">
-          <AquaUserGreet userName={getFirstLettersFromEmail(userData?.user?.email)} />
+        <main className="min-h-[calc(100vh-2rem)] min-w-0 flex-1 pb-24 lg:pb-0">
+          <AquaUserGreet
+            userName={getFirstLettersFromEmail(userData?.user?.email)}
+          />
 
-          <section className="mx-auto mt-4 w-full max-w-5xl lg:min-h-0 lg:flex-1">
-            <div className="min-h-[calc(100vh-14rem)] w-full rounded-[28px] border border-slate-200/80 bg-white p-4 shadow-[0_16px_45px_rgba(15,23,42,0.05)] sm:p-6 lg:flex lg:h-full lg:min-h-0 lg:flex-col lg:overflow-hidden lg:p-7">
+          <section className="mx-auto mt-4 w-full max-w-5xl">
+            <div className="min-h-[calc(100vh-14rem)] w-full rounded-[28px] border border-slate-200 bg-white p-4 sm:p-6 lg:p-7">
               <header className="mb-6 flex shrink-0 items-end justify-between gap-4 border-b border-slate-100 pb-4">
                 <div>
-                  <h1 className="text-xl font-black text-slate-950 sm:text-2xl">{resolvedTitle}</h1>
-                  {resolvedSubtitle && <p className="mt-1 text-sm text-slate-500">{resolvedSubtitle}</p>}
+                  <h1 className="text-xl font-black text-slate-950 sm:text-2xl">
+                    {resolvedTitle}
+                  </h1>
+                  {resolvedSubtitle && (
+                    <p className="mt-1 text-sm text-slate-500">
+                      {resolvedSubtitle}
+                    </p>
+                  )}
                 </div>
               </header>
               <div
                 key={router.pathname}
-                className="animate-[dashboard-tab-in_180ms_cubic-bezier(0.22,1,0.36,1)] lg:min-h-0 lg:flex-1 lg:overflow-y-auto lg:overscroll-contain lg:pr-2"
+                className="animate-[dashboard-tab-in_180ms_cubic-bezier(0.22,1,0.36,1)]"
               >
                 {children}
               </div>
@@ -54,11 +80,19 @@ const AquaUserDashbordLayout = ({ children, title, subtitle }) => {
       </div>
       <style jsx global>{`
         @keyframes dashboard-tab-in {
-          from { opacity: 0; transform: translateY(5px); }
-          to { opacity: 1; transform: translateY(0); }
+          from {
+            opacity: 0;
+            transform: translateY(5px);
+          }
+          to {
+            opacity: 1;
+            transform: translateY(0);
+          }
         }
         @media (prefers-reduced-motion: reduce) {
-          [class*="dashboard-tab-in"] { animation: none !important; }
+          [class*="dashboard-tab-in"] {
+            animation: none !important;
+          }
         }
       `}</style>
     </div>

--- a/src/styles/profile.module.css
+++ b/src/styles/profile.module.css
@@ -153,6 +153,7 @@
   transition:
     background-color 180ms ease,
     transform 180ms ease;
+  cursor: pointer;
 }
 
 .editProfileButton:hover,
@@ -219,6 +220,7 @@
   background: #ffffff;
   text-align: left;
   transition: background-color 160ms ease;
+  cursor: pointer;
 }
 
 .detailRow:nth-child(2n) {
@@ -231,6 +233,16 @@
 
 .detailRow:hover {
   background: #f9fcfb;
+}
+
+.detailRow:focus-visible,
+.editProfileButton:focus-visible,
+.addAddressButton:focus-visible,
+.accountPanel > button:focus-visible,
+.addressActions button:focus-visible,
+.emptyAddress button:focus-visible {
+  outline: 2px solid #20bea3;
+  outline-offset: 3px;
 }
 
 .detailIcon {
@@ -406,6 +418,7 @@
   color: #70e3ca;
   font-size: 10px;
   font-weight: 800;
+  cursor: pointer;
 }
 
 .addressSection {
@@ -435,6 +448,14 @@
   border: 1px solid var(--profile-line);
   border-radius: 17px;
   background: #ffffff;
+  transition:
+    border-color 160ms ease,
+    background-color 160ms ease;
+}
+
+.addressCard:hover {
+  border-color: #9ed5c8;
+  background: #fbfefd;
 }
 
 .defaultAddressCard {
@@ -515,6 +536,17 @@
   color: var(--profile-ink);
   font-size: 9px;
   font-weight: 800;
+  cursor: pointer;
+  transition:
+    border-color 160ms ease,
+    background-color 160ms ease,
+    color 160ms ease;
+}
+
+.addressActions button:hover {
+  border-color: #9ed5c8;
+  background: var(--profile-mint);
+  color: var(--profile-green);
 }
 
 .addressActions button:first-child {
@@ -558,6 +590,7 @@
   color: var(--profile-green);
   font-size: 10px;
   font-weight: 850;
+  cursor: pointer;
 }
 
 @media (max-width: 850px) {


### PR DESCRIPTION
## What changed

### Shop clarity
- switches the shop grid from dark full-image overlays to clean retail cards with separate image and content areas
- removes card, filter, toolbar, badge and action shadows
- uses crisp borders and emerald hover/focus states for visual separation
- preserves interactive image galleries, ratings, wishlist feedback, cart feedback, search, sorting, filters and grid/list switching

### Dashboard scrolling
- removes fixed desktop viewport heights and internal content scrolling
- Orders and Profile now use one natural browser/page scrollbar
- keeps the desktop navigation rail sticky while long content expands normally

### Profile experience
- removes the dashboard shell and navigation elevation shadows
- adds visible keyboard focus states and clearer hover feedback
- improves affordances for personal detail and address actions

## Validation
- Prettier check passes for all changed files
- `git diff --check` passes
- frontend unit tests could not run because frontend dependencies are not installed in the workspace