### PR TITLE
Add customer reminder confirmation page

### DIFF
--- a/src/pages/service-reminder/confirm/[token].js
+++ b/src/pages/service-reminder/confirm/[token].js
@@ -1,0 +1,85 @@
+import Head from "next/head";
+import Link from "next/link";
+import { useRouter } from "next/router";
+import { useEffect, useState } from "react";
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL || "https://api.aquakart.co.in/v1";
+
+const labels = {
+  regeneration: "Regeneration reminder",
+  "annual-service": "Annual service reminder",
+  "warranty-expiry": "Warranty expiry reminder",
+};
+
+export default function ServiceReminderConfirmation() {
+  const router = useRouter();
+  const { token } = router.query;
+  const [reminder, setReminder] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState("");
+  const [notes, setNotes] = useState("");
+
+  useEffect(() => {
+    if (!token) return;
+    fetch(`${API_BASE}/service-reminders/confirm/${encodeURIComponent(token)}`)
+      .then(async response => {
+        const body = await response.json();
+        if (!response.ok) throw new Error(body.message || "This reminder link is invalid.");
+        setReminder(body.data);
+      })
+      .catch(err => setError(err.message))
+      .finally(() => setLoading(false));
+  }, [token]);
+
+  const confirm = async status => {
+    setSaving(true);
+    setError("");
+    try {
+      const response = await fetch(`${API_BASE}/service-reminders/confirm/${encodeURIComponent(token)}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ status, notes }),
+      });
+      const body = await response.json();
+      if (!response.ok) throw new Error(body.message || "Could not save your response.");
+      setReminder(current => ({ ...current, confirmationStatus: body.data.confirmationStatus }));
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <>
+      <Head><title>Confirm service reminder | Aquakart</title></Head>
+      <main className="min-h-screen bg-slate-50 px-4 py-12 text-slate-900">
+        <div className="mx-auto max-w-xl rounded-3xl border border-slate-200 bg-white p-6 shadow-sm sm:p-9">
+          <img src="/aqua-logo.png" alt="Aquakart" className="mb-7 h-12 w-auto" onError={event => { event.currentTarget.style.display = "none"; }} />
+          {loading ? <p>Loading your reminder…</p> : error && !reminder ? <><h1 className="text-2xl font-bold">Reminder unavailable</h1><p className="mt-3 text-red-600">{error}</p></> : reminder && (
+            <>
+              <p className="text-sm font-semibold uppercase tracking-wide text-blue-700">{labels[reminder.reminderType] || "Service reminder"}</p>
+              <h1 className="mt-2 text-3xl font-bold">Please confirm your requirement</h1>
+              <div className="mt-6 rounded-2xl bg-slate-50 p-5">
+                <div className="font-semibold">{reminder.productName}</div>
+                <div className="mt-1 text-sm text-slate-600">Invoice {reminder.invoiceNo || "Aquakart invoice"}</div>
+                <div className="mt-1 text-sm text-slate-600">Due: {new Intl.DateTimeFormat("en-IN", { dateStyle: "long" }).format(new Date(reminder.dueDate))}</div>
+              </div>
+              {reminder.confirmationStatus !== "unconfirmed" && <div className="mt-5 rounded-xl bg-green-50 p-4 text-green-800">Your current response: <strong>{reminder.confirmationStatus.replaceAll("-", " ")}</strong>. You can update it below.</div>}
+              <label className="mt-6 block text-sm font-medium" htmlFor="notes">Message for our service team (optional)</label>
+              <textarea id="notes" value={notes} maxLength={1000} onChange={event => setNotes(event.target.value)} rows={3} className="mt-2 w-full rounded-xl border border-slate-300 p-3 outline-none focus:border-blue-600" placeholder="Preferred call time or service details" />
+              {error && <p className="mt-3 text-sm text-red-600">{error}</p>}
+              <div className="mt-6 grid gap-3 sm:grid-cols-3">
+                <button disabled={saving} onClick={() => confirm("confirmed")} className="rounded-xl bg-blue-700 px-4 py-3 font-semibold text-white disabled:opacity-50">Confirm</button>
+                <button disabled={saving} onClick={() => confirm("service-required")} className="rounded-xl bg-amber-500 px-4 py-3 font-semibold text-white disabled:opacity-50">Need service</button>
+                <button disabled={saving} onClick={() => confirm("not-required")} className="rounded-xl border border-slate-300 px-4 py-3 font-semibold disabled:opacity-50">Not required</button>
+              </div>
+              <Link href={`/invoice/${reminder.invoiceId}`} className="mt-6 inline-block text-sm font-semibold text-blue-700">View invoice →</Link>
+            </>
+          )}
+        </div>
+      </main>
+    </>
+  );
+}


### PR DESCRIPTION


Latest update:
- Invoice correction request now supports customer email, WhatsApp/mobile number, and address after secure invoice login.
- CRM approval applies the corrected invoice details.
- On approval, backend emails the invoice again and sends WhatsApp/SMS fallback only when the phone number changed.
- Invoice page now shows clearer Gmail account guidance, correction fields, reminder consent, and product review controls.
- CRM request queue now shows current vs requested email, phone, and address.